### PR TITLE
A quick fix to backslash

### DIFF
--- a/.ci/e2e-expected/backslash-d-param.txt
+++ b/.ci/e2e-expected/backslash-d-param.txt
@@ -1,7 +1,7 @@
-                       Table ".users"
+                       Table "public.users"
  Column |       Type        | Collation | Nullable | Default 
 --------+-------------------+-----------+----------+---------
- id     | bigint            | 1         | not null | 
- age    | bigint            | 1         |          | 
- name   | character varying | 1         |          | 
+ id     | bigint            |           | not null |
+ age    | bigint            |           |          |
+ name   | character varying |           |          |
 

--- a/src/main/java/com/google/cloud/spanner/pgadapter/statements/MatcherStatement.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/statements/MatcherStatement.java
@@ -55,10 +55,7 @@ public class MatcherStatement extends IntermediateStatement {
     for (Command currentCommand :
         Command.getCommands(sql, this.connection, this.commandMetadataJSON)) {
       if (currentCommand.is()) {
-        System.out.println("DEBUG: ");
-        String s = currentCommand.translate();
-        System.out.println(s);
-        return s;
+        return currentCommand.translate();
       }
     }
     return sql;

--- a/src/main/java/com/google/cloud/spanner/pgadapter/statements/MatcherStatement.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/statements/MatcherStatement.java
@@ -55,7 +55,10 @@ public class MatcherStatement extends IntermediateStatement {
     for (Command currentCommand :
         Command.getCommands(sql, this.connection, this.commandMetadataJSON)) {
       if (currentCommand.is()) {
-        return currentCommand.translate();
+        System.out.println("DEBUG: ");
+        String s = currentCommand.translate();
+        System.out.println(s);
+        return s;
       }
     }
     return sql;

--- a/src/main/resources/metadata/default_command_metadata.json
+++ b/src/main/resources/metadata/default_command_metadata.json
@@ -8,7 +8,7 @@
     },
     {
       "input_pattern": "^SELECT c\\.oid,[ \n]+n\\.nspname,[ \n]+c\\.relname\nFROM pg_catalog\\.pg_class c[ \n]+LEFT JOIN pg_catalog\\.pg_namespace n ON n\\.oid = c\\.relnamespace\nWHERE c\\.relname OPERATOR\\(pg_catalog\\.~\\) '\\^\\((?<tablename>.*)\\)\\$'[ \n]+AND pg_catalog\\.pg_table_is_visible\\(c\\.oid\\)\nORDER BY 2, 3;$",
-      "output_pattern": "SELECT sha256(t.table_name::BYTEA) as oid, '' as nspname, t.table_name as relname FROM information_schema.tables AS t WHERE t.table_schema='public' AND LOWER(t.table_name) = LOWER('%s');",
+      "output_pattern": "SELECT t.table_name as oid, 'public' as nspname, t.table_name as relname FROM information_schema.tables AS t WHERE t.table_schema='public' AND LOWER(t.table_name) = LOWER('%s');",
       "matcher_array": [
         "tablename"
       ],
@@ -22,7 +22,7 @@
     },
     {
       "input_pattern": "^SELECT a\\.attname,[ \n]+pg_catalog\\.format_type\\(a\\.atttypid, a\\.atttypmod\\),[ \n]+\\(SELECT (substring\\()?pg_catalog\\.pg_get_expr\\(d\\.adbin, d\\.adrelid(?:, true)?\\)( for 128\\))?[ \n]+FROM pg_catalog\\.pg_attrdef d[ \n]+WHERE d\\.adrelid = a\\.attrelid AND d\\.adnum = a\\.attnum AND a\\.atthasdef\\),[ \n]+a\\.attnotnull,(?: a\\.attnum,)?[ \n]+NULL AS attcollation,[ \n]+(?:''::pg_catalog\\.char AS attidentity,[ \n]+''::pg_catalog\\.char AS attgenerated\n|  NULL AS indexdef,[ \n]+NULL AS attfdwoptions\n)?([ ]*''::pg_catalog.char AS attidentity)?[ \n]*FROM pg_catalog\\.pg_attribute a\nWHERE a\\.attrelid = '(?<tablename>.*)' AND a\\.attnum > 0 AND NOT a\\.attisdropped\nORDER BY a\\.attnum;$",
-      "output_pattern": "SELECT t.column_name as attname, t.data_type as format_type, '' as substring, t.is_nullable = 'NO' as attnotnull, 1 as attnum, null::INTEGER as attcollation, null::INTEGER as indexdef, null::INTEGER as attfdwoptions FROM information_schema.columns AS t WHERE t.table_schema='public' AND sha256(t.table_name::BYTEA) = '%s';",
+      "output_pattern": "SELECT t.column_name as attname, t.data_type as format_type, '' as substring, t.is_nullable = 'NO' as attnotnull, null::INTEGER as attcollation, null::INTEGER as indexdef, null::INTEGER as attfdwoptions FROM information_schema.columns AS t WHERE t.table_schema='public' AND t.table_name = '%s';",
       "matcher_array": [
         "tablename"
       ],

--- a/src/test/java/com/google/cloud/spanner/pgadapter/PSQLTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/PSQLTest.java
@@ -107,8 +107,8 @@ public class PSQLTest {
             + "ORDER BY 2, 3;";
     String result =
         "SELECT"
-            + " sha256(t.table_name::BYTEA) as oid,"
-            + " '' as nspname,"
+            + " t.table_name as oid,"
+            + " 'public' as nspname,"
             + " t.table_name as relname"
             + " FROM"
             + " information_schema.tables AS t"
@@ -136,8 +136,8 @@ public class PSQLTest {
             + "ORDER BY 2, 3;";
     String result =
         "SELECT"
-            + " sha256(t.table_name::BYTEA) as oid,"
-            + " '' as nspname,"
+            + " t.table_name as oid,"
+            + " 'public' as nspname,"
             + " t.table_name as relname"
             + " FROM"
             + " information_schema.tables AS t"
@@ -198,7 +198,6 @@ public class PSQLTest {
             + " t.data_type as format_type,"
             + " '' as substring,"
             + " t.is_nullable = 'NO' as attnotnull,"
-            + " 1 as attnum,"
             + " null::INTEGER as attcollation,"
             + " null::INTEGER as indexdef,"
             + " null::INTEGER as attfdwoptions"
@@ -206,7 +205,7 @@ public class PSQLTest {
             + " information_schema.columns AS t"
             + " WHERE"
             + " t.table_schema='public'"
-            + " AND sha256(t.table_name::BYTEA) = '-1';";
+            + " AND t.table_name = '-1';";
 
     MatcherStatement matcherStatement = new MatcherStatement(sql, connectionHandler);
 
@@ -236,7 +235,6 @@ public class PSQLTest {
             + " t.data_type as format_type,"
             + " '' as substring,"
             + " t.is_nullable = 'NO' as attnotnull,"
-            + " 1 as attnum,"
             + " null::INTEGER as attcollation,"
             + " null::INTEGER as indexdef,"
             + " null::INTEGER as attfdwoptions"
@@ -244,7 +242,7 @@ public class PSQLTest {
             + " information_schema.columns AS t"
             + " WHERE"
             + " t.table_schema='public'"
-            + " AND sha256(t.table_name::BYTEA) = 'bobby\\'; DROP TABLE USERS; SELECT\\'';";
+            + " AND t.table_name = 'bobby\\'; DROP TABLE USERS; SELECT\\'';";
 
     MatcherStatement matcherStatement = new MatcherStatement(sql, connectionHandler);
 


### PR DESCRIPTION
Fix the following:

1.  ".table_name"
2. 1 at collation column
3. \d doesn't work for some tables