### PR TITLE
deps: upgrade jdbc dependency to 2.5.5-pg-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-spanner-jdbc</artifactId>
-      <version>2.4.4-pg-SNAPSHOT</version>
+      <version>2.5.5-pg-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>org.postgresql</groupId>


### PR DESCRIPTION
Upgrades to latest Cloud Spanner JDBC Dependency