### PR TITLE
feat: support JDBC PreparedStatement

### DIFF
--- a/src/main/java/com/google/cloud/spanner/pgadapter/parsers/BinaryParser.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/parsers/BinaryParser.java
@@ -32,6 +32,10 @@ public class BinaryParser extends Parser<byte[]> {
     this.item = (byte[]) item;
   }
 
+  public BinaryParser(byte[] item, FormatCode formatCode) {
+    this.item = item;
+  }
+
   @Override
   protected String stringParse() {
     return PGbytea.toPGString(this.item);

--- a/src/main/java/com/google/cloud/spanner/pgadapter/parsers/BooleanParser.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/parsers/BooleanParser.java
@@ -16,6 +16,7 @@ package com.google.cloud.spanner.pgadapter.parsers;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import org.postgresql.util.ByteConverter;
 
 /**
  * Parse specified data to boolean. For most cases it is simply translating from chars 't'/'f' to
@@ -32,6 +33,24 @@ public class BooleanParser extends Parser<Boolean> {
 
   public BooleanParser(Object item) {
     this.item = (Boolean) item;
+  }
+
+  public BooleanParser(byte[] item, FormatCode formatCode) {
+    switch (formatCode) {
+      case TEXT:
+        String stringValue = new String(item, UTF8);
+        this.item = Boolean.valueOf(stringValue);
+        break;
+      case BINARY:
+        if (!(item instanceof byte[])) {
+          throw new IllegalArgumentException(
+              "Unsupported input value for binary encoding: " + item.getClass());
+        }
+        this.item = ByteConverter.bool((byte[]) item, 0);
+        break;
+      default:
+        throw new IllegalArgumentException("Unsupported format: " + formatCode);
+    }
   }
 
   @Override

--- a/src/main/java/com/google/cloud/spanner/pgadapter/parsers/DateParser.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/parsers/DateParser.java
@@ -34,10 +34,20 @@ public class DateParser extends Parser<java.sql.Date> {
     this.item = (java.sql.Date) item;
   }
 
-  public DateParser(byte[] item) {
-    long days = ByteConverter.int4(item, 0) + PG_EPOCH_DAYS;
-    this.validateRange(days);
-    this.item = java.sql.Date.valueOf(LocalDate.ofEpochDay(days));
+  public DateParser(byte[] item, FormatCode formatCode) {
+    switch (formatCode) {
+      case TEXT:
+        String stringValue = new String(item, UTF8);
+        this.item = java.sql.Date.valueOf(stringValue);
+        break;
+      case BINARY:
+        long days = ByteConverter.int4(item, 0) + PG_EPOCH_DAYS;
+        this.validateRange(days);
+        this.item = java.sql.Date.valueOf(LocalDate.ofEpochDay(days));
+        break;
+      default:
+        throw new IllegalArgumentException("Unsupported format: " + formatCode);
+    }
   }
 
   /**

--- a/src/main/java/com/google/cloud/spanner/pgadapter/parsers/DoubleParser.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/parsers/DoubleParser.java
@@ -17,6 +17,7 @@ package com.google.cloud.spanner.pgadapter.parsers;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Types;
+import org.postgresql.util.ByteConverter;
 
 /** Translate from wire protocol to double. */
 public class DoubleParser extends Parser<Double> {
@@ -29,8 +30,17 @@ public class DoubleParser extends Parser<Double> {
     this.item = (Double) item;
   }
 
-  public DoubleParser(byte[] item) {
-    this.item = Double.valueOf(new String(item));
+  public DoubleParser(byte[] item, FormatCode formatCode) {
+    switch (formatCode) {
+      case TEXT:
+        this.item = Double.valueOf(new String(item));
+        break;
+      case BINARY:
+        this.item = ByteConverter.float8(item, 0);
+        break;
+      default:
+        throw new IllegalArgumentException("Unsupported format: " + formatCode);
+    }
   }
 
   @Override

--- a/src/main/java/com/google/cloud/spanner/pgadapter/parsers/LongParser.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/parsers/LongParser.java
@@ -17,6 +17,7 @@ package com.google.cloud.spanner.pgadapter.parsers;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Types;
+import org.postgresql.util.ByteConverter;
 
 /** Translate from wire protocol to long. */
 public class LongParser extends Parser<Long> {
@@ -29,8 +30,17 @@ public class LongParser extends Parser<Long> {
     this.item = (Long) item;
   }
 
-  public LongParser(byte[] item) {
-    this.item = Long.valueOf(new String(item));
+  public LongParser(byte[] item, FormatCode formatCode) {
+    switch (formatCode) {
+      case TEXT:
+        this.item = Long.valueOf(new String(item));
+        break;
+      case BINARY:
+        this.item = ByteConverter.int8(item, 0);
+        break;
+      default:
+        throw new IllegalArgumentException("Unsupported format: " + formatCode);
+    }
   }
 
   @Override

--- a/src/main/java/com/google/cloud/spanner/pgadapter/parsers/NumericParser.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/parsers/NumericParser.java
@@ -1,4 +1,4 @@
-// Copyright 2021 Google LLC
+// Copyright 2022 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,29 +14,27 @@
 
 package com.google.cloud.spanner.pgadapter.parsers;
 
+import java.math.BigDecimal;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Types;
-import org.postgresql.util.ByteConverter;
 
-/** Translate from wire protocol to int. */
-public class IntegerParser extends Parser<Integer> {
+/** Translate from wire protocol to {@link BigDecimal}. */
+public class NumericParser extends Parser<BigDecimal> {
 
-  public IntegerParser(ResultSet item, int position) throws SQLException {
-    this.item = item.getInt(position);
+  public NumericParser(ResultSet item, int position) throws SQLException {
+    this.item = item.getBigDecimal(position);
   }
 
-  public IntegerParser(Object item) {
-    this.item = (Integer) item;
+  public NumericParser(Object item) {
+    this.item = (BigDecimal) item;
   }
 
-  public IntegerParser(byte[] item, FormatCode formatCode) {
+  public NumericParser(byte[] item, FormatCode formatCode) {
     switch (formatCode) {
       case TEXT:
-        this.item = Integer.valueOf(new String(item));
-        break;
       case BINARY:
-        this.item = ByteConverter.int4(item, 0);
+        this.item = new BigDecimal(new String(item));
         break;
       default:
         throw new IllegalArgumentException("Unsupported format: " + formatCode);
@@ -44,17 +42,17 @@ public class IntegerParser extends Parser<Integer> {
   }
 
   @Override
-  public Integer getItem() {
+  public BigDecimal getItem() {
     return this.item;
   }
 
   @Override
   protected String stringParse() {
-    return Integer.toString(this.item);
+    return this.item.toPlainString();
   }
 
   @Override
   protected byte[] binaryParse() {
-    return toBinary(this.item, Types.INTEGER);
+    return toBinary(this.item, Types.NUMERIC);
   }
 }

--- a/src/main/java/com/google/cloud/spanner/pgadapter/parsers/StringParser.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/parsers/StringParser.java
@@ -28,7 +28,7 @@ public class StringParser extends Parser<String> {
     this.item = (String) item;
   }
 
-  public StringParser(byte[] item) {
+  public StringParser(byte[] item, FormatCode formatCode) {
     this.item = new String(item, UTF8);
   }
 

--- a/src/main/java/com/google/cloud/spanner/pgadapter/statements/IntermediatePortalStatement.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/statements/IntermediatePortalStatement.java
@@ -42,7 +42,8 @@ public class IntermediatePortalStatement extends IntermediatePreparedStatement {
       String sql,
       int parameterCount,
       SetMultimap<Integer, Integer> parameterIndexToPositions,
-      Connection connection) {
+      Connection connection)
+      throws SQLException {
     super(statement, sql, parameterCount, parameterIndexToPositions, connection);
     this.parameterFormatCodes = new ArrayList<>();
     this.resultFormatCodes = new ArrayList<>();

--- a/src/main/java/com/google/cloud/spanner/pgadapter/statements/IntermediatePreparedStatement.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/statements/IntermediatePreparedStatement.java
@@ -38,7 +38,7 @@ public class IntermediatePreparedStatement extends IntermediateStatement {
   protected List<Integer> parameterDataTypes;
 
   public IntermediatePreparedStatement(String sql, Connection connection) throws SQLException {
-    super();
+    super(sql);
     SQLMetadata parsedSQL = Converter.toJDBCParams(sql);
     this.parameterCount = parsedSQL.getParameterCount();
     this.sql = parsedSQL.getSqlString();

--- a/src/main/java/com/google/cloud/spanner/pgadapter/statements/IntermediateStatement.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/statements/IntermediateStatement.java
@@ -57,16 +57,22 @@ public class IntermediateStatement {
     this.command = parseCommand(sqlWithoutComments);
     this.connection = connection;
     this.statement = connection.createStatement();
-    if (PARSER.isUpdateStatement(sql)) {
-      this.resultType = ResultType.UPDATE_COUNT;
-    } else if (PARSER.isQuery(sql)) {
-      this.resultType = ResultType.RESULT_SET;
-    } else {
-      this.resultType = ResultType.NO_RESULT;
-    }
+    this.resultType = determineResultType(sql);
   }
 
-  protected IntermediateStatement() {}
+  protected IntermediateStatement(String sql) {
+    this.resultType = determineResultType(sql);
+  }
+
+  protected static ResultType determineResultType(String sql) {
+    if (PARSER.isUpdateStatement(sql)) {
+      return ResultType.UPDATE_COUNT;
+    } else if (PARSER.isQuery(sql)) {
+      return ResultType.RESULT_SET;
+    } else {
+      return ResultType.NO_RESULT;
+    }
+  }
 
   // Split statements by ';' delimiter, but ignore anything that is nested with '' or "".
   private List<String> splitStatements(String sql) {

--- a/src/main/java/com/google/cloud/spanner/pgadapter/statements/IntermediateStatement.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/statements/IntermediateStatement.java
@@ -14,7 +14,8 @@
 
 package com.google.cloud.spanner.pgadapter.statements;
 
-import com.google.cloud.spanner.jdbc.JdbcConstants;
+import com.google.cloud.spanner.Dialect;
+import com.google.cloud.spanner.connection.AbstractStatementParser;
 import com.google.cloud.spanner.pgadapter.metadata.DescribeMetadata;
 import com.google.common.base.Preconditions;
 import java.sql.Connection;
@@ -30,6 +31,8 @@ import java.util.List;
  * statements which does not belong directly to Postgres, Spanner, etc.
  */
 public class IntermediateStatement {
+  private static final AbstractStatementParser PARSER =
+      AbstractStatementParser.getInstance(Dialect.POSTGRESQL);
 
   protected Statement statement;
   protected ResultType resultType;
@@ -37,6 +40,7 @@ public class IntermediateStatement {
   protected boolean hasMoreData;
   protected Exception exception;
   protected String sql;
+  protected String sqlWithoutComments;
   protected String command;
   protected boolean executed;
   protected Connection connection;
@@ -47,42 +51,22 @@ public class IntermediateStatement {
   private static final char SINGLE_QUOTE = '\'';
 
   public IntermediateStatement(String sql, Connection connection) throws SQLException {
-    this();
     this.sql = sql;
+    this.sqlWithoutComments = PARSER.removeCommentsAndTrim(sql);
     this.statements = parseStatements(sql);
-    this.command = parseCommand(sql);
+    this.command = parseCommand(sqlWithoutComments);
     this.connection = connection;
     this.statement = connection.createStatement();
-  }
-
-  protected IntermediateStatement() {
-    this.executed = false;
-    this.exception = null;
-    this.resultType = null;
-    this.hasMoreData = false;
-    this.statementResult = null;
-    this.updateCount = null;
-  }
-
-  /**
-   * Extracts what type of result exists within the statement. In JDBC a statement update count is
-   * positive if it is an update statement, 0 if there is no result, or negative if there are
-   * results (i.e.: select statement)
-   *
-   * @param statement The resulting statement from an execution.
-   * @return The statement result type.
-   * @throws SQLException If getUpdateCount fails.
-   */
-  private static ResultType extractResultType(Statement statement) throws SQLException {
-    switch (statement.getUpdateCount()) {
-      case JdbcConstants.STATEMENT_NO_RESULT:
-        return ResultType.NO_RESULT;
-      case JdbcConstants.STATEMENT_RESULT_SET:
-        return ResultType.RESULT_SET;
-      default:
-        return ResultType.UPDATE_COUNT;
+    if (PARSER.isUpdateStatement(sql)) {
+      this.resultType = ResultType.UPDATE_COUNT;
+    } else if (PARSER.isQuery(sql)) {
+      this.resultType = ResultType.RESULT_SET;
+    } else {
+      this.resultType = ResultType.NO_RESULT;
     }
   }
+
+  protected IntermediateStatement() {}
 
   // Split statements by ';' delimiter, but ignore anything that is nested with '' or "".
   private List<String> splitStatements(String sql) {
@@ -209,7 +193,6 @@ public class IntermediateStatement {
    * @throws SQLException If an issue occurred in extracting result metadata.
    */
   protected void updateResultCount() throws SQLException {
-    this.resultType = IntermediateStatement.extractResultType(this.statement);
     if (this.containsResultSet()) {
       this.statementResult = this.statement.getResultSet();
       this.hasMoreData = this.statementResult.next();
@@ -221,7 +204,6 @@ public class IntermediateStatement {
   }
 
   protected void updateBatchResultCount(int[] updateCounts) throws SQLException {
-    this.resultType = IntermediateStatement.extractResultType(this.statement);
     this.updateCount = 0;
     for (int i = 0; i < updateCounts.length; ++i) {
       this.updateCount += updateCounts[i];

--- a/src/main/java/com/google/cloud/spanner/pgadapter/statements/MatcherStatement.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/statements/MatcherStatement.java
@@ -30,7 +30,7 @@ public class MatcherStatement extends IntermediateStatement {
   private JSONObject commandMetadataJSON;
 
   public MatcherStatement(String sql, ConnectionHandler connectionHandler) throws SQLException {
-    super();
+    super(sql);
     this.connection = connectionHandler.getJdbcConnection();
     this.statement = this.connection.createStatement();
     this.commandMetadataJSON = connectionHandler.getServer().getOptions().getCommandMetadataJSON();

--- a/src/main/java/com/google/cloud/spanner/pgadapter/statements/PSQLStatement.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/statements/PSQLStatement.java
@@ -29,7 +29,7 @@ public class PSQLStatement extends IntermediateStatement {
   private JSONObject commandMetadataJSON;
 
   public PSQLStatement(String sql, ConnectionHandler connectionHandler) throws SQLException {
-    super();
+    super(sql);
     this.connection = connectionHandler.getJdbcConnection();
     this.statement = this.connection.createStatement();
     this.commandMetadataJSON = connectionHandler.getServer().getOptions().getCommandMetadataJSON();

--- a/src/main/java/com/google/cloud/spanner/pgadapter/wireprotocol/BootstrapMessage.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/wireprotocol/BootstrapMessage.java
@@ -102,7 +102,7 @@ public abstract class BootstrapMessage extends WireMessage {
     new ParameterStatusResponse(output, "client_encoding".getBytes(), "utf8".getBytes()).send();
     new ParameterStatusResponse(output, "DateStyle".getBytes(), "ISO".getBytes()).send();
     new ParameterStatusResponse(output, "IntervalStyle".getBytes(), "iso_8601".getBytes()).send();
-    new ParameterStatusResponse(output, "standard_conforming_strings".getBytes(), "true".getBytes())
+    new ParameterStatusResponse(output, "standard_conforming_strings".getBytes(), "on".getBytes())
         .send();
     new ParameterStatusResponse(
             output,

--- a/src/main/java/com/google/cloud/spanner/pgadapter/wireprotocol/DescribeMessage.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/wireprotocol/DescribeMessage.java
@@ -87,13 +87,21 @@ public class DescribeMessage extends ControlMessage {
     if (this.statement.hasException()) {
       this.handleError(this.statement.getException());
     } else {
-      new RowDescriptionResponse(
-              this.outputStream,
-              this.statement,
-              ((DescribePortalMetadata) this.statement.describe()).getMetadata(),
-              this.connection.getServer().getOptions(),
-              QueryMode.EXTENDED)
-          .send();
+      switch (this.statement.getResultType()) {
+        case UPDATE_COUNT:
+        case NO_RESULT:
+          new NoDataResponse(this.outputStream).send();
+          break;
+        case RESULT_SET:
+          new RowDescriptionResponse(
+                  this.outputStream,
+                  this.statement,
+                  ((DescribePortalMetadata) this.statement.describe()).getMetadata(),
+                  this.connection.getServer().getOptions(),
+                  QueryMode.EXTENDED)
+              .send();
+          break;
+      }
     }
   }
 

--- a/src/main/java/com/google/cloud/spanner/pgadapter/wireprotocol/ParseMessage.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/wireprotocol/ParseMessage.java
@@ -40,9 +40,6 @@ public class ParseMessage extends ControlMessage {
     short numberOfParameters = this.inputStream.readShort();
     for (int i = 0; i < numberOfParameters; i++) {
       int type = this.inputStream.readInt();
-      if (type == 0) {
-        throw new IllegalArgumentException("PgAdapter does not support untyped parameters.");
-      }
       this.parameterDataTypes.add(type);
     }
     this.statement = new IntermediatePreparedStatement(queryString, connection.getJdbcConnection());

--- a/src/test/java/com/google/cloud/spanner/pgadapter/ITJdbcTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/ITJdbcTest.java
@@ -1,0 +1,230 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.cloud.spanner.pgadapter;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import com.google.cloud.ByteArray;
+import com.google.cloud.Timestamp;
+import com.google.cloud.spanner.Database;
+import com.google.cloud.spanner.KeySet;
+import com.google.cloud.spanner.Mutation;
+import com.google.cloud.spanner.pgadapter.metadata.OptionsMetadata;
+import com.google.common.collect.ImmutableList;
+import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Arrays;
+import java.util.Collections;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@Category(IntegrationTest.class)
+@RunWith(JUnit4.class)
+public class ITJdbcTest implements IntegrationTest {
+  private static final PgAdapterTestEnv testEnv = new PgAdapterTestEnv();
+  private static ProxyServer server;
+  private static Database database;
+
+  @BeforeClass
+  public static void setup() throws Exception {
+    // Make sure the PG JDBC driver is loaded.
+    Class.forName("org.postgresql.Driver");
+
+    testEnv.setUp();
+    if (testEnv.isUseExistingDb()) {
+      database = testEnv.getExistingDatabase();
+    } else {
+      database = testEnv.createDatabase();
+      testEnv.updateDdl(
+          database.getId().getDatabase(),
+          Arrays.asList(
+              "create table numbers (num int not null primary key, name varchar(100))",
+              "create table all_types ("
+                  + "col_bigint bigint not null primary key, "
+                  + "col_bool bool, "
+                  + "col_bytea bytea, "
+                  + "col_float8 float8, "
+                  + "col_int int, "
+                  + "col_numeric numeric, "
+                  + "col_timestamptz timestamptz, "
+                  + "col_varchar varchar(100))"));
+    }
+    String credentials = testEnv.getCredentials();
+    ImmutableList.Builder<String> argsListBuilder =
+        ImmutableList.<String>builder()
+            .add(
+                "-p",
+                testEnv.getProjectId(),
+                "-i",
+                testEnv.getInstanceId(),
+                "-d",
+                database.getId().getDatabase(),
+                "-s",
+                String.valueOf(testEnv.getPort()),
+                "-e",
+                testEnv.getUrl().getHost());
+    if (credentials != null) {
+      argsListBuilder.add("-c", testEnv.getCredentials());
+    }
+    String[] args = argsListBuilder.build().toArray(new String[0]);
+    server = new ProxyServer(new OptionsMetadata(args));
+    server.startServer();
+  }
+
+  @AfterClass
+  public static void teardown() {
+    if (server != null) {
+      server.stopServer();
+    }
+    testEnv.cleanUp();
+  }
+
+  @Before
+  public void insertTestData() {
+    String databaseId = database.getId().getDatabase();
+    testEnv.write(databaseId, Collections.singleton(Mutation.delete("numbers", KeySet.all())));
+    testEnv.write(databaseId, Collections.singleton(Mutation.delete("all_types", KeySet.all())));
+    testEnv.write(
+        databaseId,
+        Arrays.asList(
+            Mutation.newInsertBuilder("numbers").set("num").to(1L).set("name").to("One").build(),
+            Mutation.newInsertBuilder("all_types")
+                .set("col_bigint")
+                .to(1L)
+                .set("col_bool")
+                .to(true)
+                .set("col_bytea")
+                .to(ByteArray.copyFrom("test"))
+                .set("col_float8")
+                .to(3.14d)
+                .set("col_int")
+                .to(1)
+                .set("col_numeric")
+                .to(new BigDecimal("3.14"))
+                .set("col_timestamptz")
+                .to(Timestamp.parseTimestamp("2022-01-27T17:51:30+01:00"))
+                .set("col_varchar")
+                .to("test")
+                .build()));
+  }
+
+  @Test
+  public void testSelectHelloWorld() throws SQLException {
+    try (Connection connection =
+        DriverManager.getConnection(
+            String.format("jdbc:postgresql://localhost:%d/", testEnv.getPort()))) {
+      try (ResultSet resultSet =
+          connection.createStatement().executeQuery("SELECT 'Hello World!'")) {
+        assertTrue(resultSet.next());
+        assertEquals("Hello World!", resultSet.getString(1));
+        assertFalse(resultSet.next());
+      }
+    }
+  }
+
+  @Test
+  public void testSelectWithParameters() throws SQLException {
+    try (Connection connection =
+        DriverManager.getConnection(
+            String.format("jdbc:postgresql://localhost:%d/", testEnv.getPort()))) {
+      try (PreparedStatement statement =
+          connection.prepareStatement(
+              "select col_bigint, col_bool, col_bytea, col_float8, col_int, col_numeric, col_timestamptz, col_varchar "
+                  + "from all_types "
+                  + "where col_bigint=? "
+                  + "and col_bool=? "
+                  + "and col_bytea=? "
+                  + "and col_float8=? "
+                  + "and col_int=? "
+                  + "and col_numeric=? "
+                  + "and col_timestamptz=? "
+                  + "and col_varchar=?")) {
+
+        statement.setInt(1, 1);
+        statement.setBoolean(2, true);
+        statement.setBytes(3, "test".getBytes(StandardCharsets.UTF_8));
+        statement.setDouble(4, 3.14d);
+        statement.setInt(5, 1);
+        statement.setBigDecimal(6, new BigDecimal("3.14"));
+        statement.setTimestamp(
+            7, Timestamp.parseTimestamp("2022-01-27T17:51:30+01:00").toSqlTimestamp());
+        statement.setString(8, "test");
+
+        try (ResultSet resultSet = statement.executeQuery()) {
+          assertTrue(resultSet.next());
+
+          assertEquals(1, resultSet.getLong(1));
+          assertTrue(resultSet.getBoolean(2));
+          assertArrayEquals("test".getBytes(StandardCharsets.UTF_8), resultSet.getBytes(3));
+          assertEquals(3.14d, resultSet.getDouble(4), 0.0d);
+          assertEquals(1, resultSet.getInt(5));
+          assertEquals(new BigDecimal("3.14"), resultSet.getBigDecimal(6));
+          assertEquals(
+              Timestamp.parseTimestamp("2022-01-27T17:51:30+01:00").toSqlTimestamp(),
+              resultSet.getTimestamp(7));
+          assertEquals("test", resultSet.getString(8));
+
+          assertFalse(resultSet.next());
+        }
+      }
+    }
+  }
+
+  @Test
+  public void testInsert() throws SQLException {
+    try (Connection connection =
+        DriverManager.getConnection(
+            String.format("jdbc:postgresql://localhost:%d/", testEnv.getPort()))) {
+      int updateCount =
+          connection
+              .createStatement()
+              .executeUpdate("insert into numbers (num, name) values (2, 'Two')");
+      assertEquals(1, updateCount);
+    }
+  }
+
+  @Test
+  public void testUpdate() throws SQLException {
+    try (Connection connection =
+        DriverManager.getConnection(
+            String.format("jdbc:postgresql://localhost:%d/", testEnv.getPort()))) {
+      int updateCount =
+          connection
+              .createStatement()
+              .executeUpdate("update numbers set name='One - updated' where num=1");
+      assertEquals(1, updateCount);
+
+      // This should return a zero update count, as there is no row 2.
+      int noUpdateCount =
+          connection
+              .createStatement()
+              .executeUpdate("update numbers set name='Two - updated' where num=2");
+      assertEquals(0, noUpdateCount);
+    }
+  }
+}

--- a/src/test/java/com/google/cloud/spanner/pgadapter/ParserTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/ParserTest.java
@@ -29,6 +29,7 @@ import com.google.cloud.spanner.pgadapter.parsers.DoubleParser;
 import com.google.cloud.spanner.pgadapter.parsers.IntegerParser;
 import com.google.cloud.spanner.pgadapter.parsers.LongParser;
 import com.google.cloud.spanner.pgadapter.parsers.Parser;
+import com.google.cloud.spanner.pgadapter.parsers.Parser.FormatCode;
 import com.google.cloud.spanner.pgadapter.parsers.StringParser;
 import com.google.cloud.spanner.pgadapter.parsers.TimestampParser;
 import java.sql.Array;
@@ -165,7 +166,7 @@ public class ParserTest {
   public void testDateParsingRejectsInvalidDateTooLong() {
     byte[] result = new byte[4];
     ByteConverter.int4(result, 0, Integer.MAX_VALUE);
-    new DateParser(result);
+    new DateParser(result, FormatCode.BINARY);
   }
 
   @Test

--- a/src/test/java/com/google/cloud/spanner/pgadapter/PgAdapterTestEnv.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/PgAdapterTestEnv.java
@@ -26,10 +26,11 @@ import com.google.cloud.spanner.DatabaseAdminClient;
 import com.google.cloud.spanner.DatabaseClient;
 import com.google.cloud.spanner.DatabaseId;
 import com.google.cloud.spanner.Dialect;
+import com.google.cloud.spanner.Mutation;
 import com.google.cloud.spanner.Spanner;
 import com.google.cloud.spanner.SpannerOptions;
 import com.google.cloud.spanner.Statement;
-import com.google.cloud.spanner.testing.RemoteSpannerHelper;
+import com.google.common.base.Strings;
 import com.google.common.primitives.Bytes;
 import com.google.spanner.admin.database.v1.CreateDatabaseMetadata;
 import com.google.spanner.admin.database.v1.UpdateDatabaseDdlMetadata;
@@ -40,6 +41,7 @@ import java.net.URL;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
@@ -70,6 +72,8 @@ public final class PgAdapterTestEnv {
 
   // PgAdapter port should be set through this system property.
   public static final String SERVICE_PORT = "PG_ADAPTER_PORT";
+
+  public static final String USE_EXISTING_DB = "PG_ADAPTER_USE_EXISTING_DB";
 
   // Default fallback project Id will be used if one isn't set via the system property.
   private static final String DEFAULT_PROJECT_ID = "span-cloud-testing";
@@ -105,14 +109,14 @@ public final class PgAdapterTestEnv {
   // Spanner options for creating a client.
   private SpannerOptions options;
 
+  // Shared Spanner instance that is automatically created and closed.
+  private Spanner spanner;
+
   // Spanner URL.
   private URL spannerURL;
 
   // Log stream for the test process.
   private static final Logger logger = Logger.getLogger(PgAdapterTestEnv.class.getName());
-
-  // Utility class for setting up test connection.
-  private RemoteSpannerHelper spannerHelper;
 
   private final List<Database> databases = new ArrayList<>();
 
@@ -121,14 +125,20 @@ public final class PgAdapterTestEnv {
     options = createSpannerOptions();
   }
 
-  public SpannerOptions spannerOptions() {
-    return options;
+  public Spanner getSpanner() {
+    if (spanner == null) {
+      spanner = options.getService();
+    }
+    return spanner;
   }
 
-  public String getCredentials() throws Exception {
+  public String getCredentials() {
+    if (System.getenv().get(GCP_CREDENTIALS) == null) {
+      return null;
+    }
+
     if (gcpCredentials == null) {
-      Map<String, String> env = System.getenv();
-      gcpCredentials = env.get(GCP_CREDENTIALS);
+      gcpCredentials = System.getenv().get(GCP_CREDENTIALS);
       if (gcpCredentials.isEmpty()) {
         throw new IllegalArgumentException("Invalid GCP credentials file.");
       }
@@ -178,27 +188,41 @@ public final class PgAdapterTestEnv {
     return spannerURL;
   }
 
+  public boolean isUseExistingDb() {
+    return Boolean.parseBoolean(System.getProperty(USE_EXISTING_DB, "false"));
+  }
+
+  public Database getExistingDatabase() {
+    if (databaseId == null) {
+      databaseId = System.getProperty(TEST_DATABASE_PROPERTY, DEFAULT_DATABASE_ID);
+    }
+    return getSpanner().getDatabaseAdminClient().getDatabase(instanceId, databaseId);
+  }
+
   // Create database.
   public Database createDatabase() throws Exception {
+    if (isUseExistingDb()) {
+      throw new IllegalStateException(
+          "Cannot create a new test database if " + USE_EXISTING_DB + " is true.");
+    }
     String databaseId = getDatabaseId();
-    Spanner spanner = options.getService();
+    Spanner spanner = getSpanner();
     DatabaseAdminClient client = spanner.getDatabaseAdminClient();
-    Database db = null;
     OperationFuture<Database, CreateDatabaseMetadata> op =
         client.createDatabase(
             client
                 .newDatabaseBuilder(DatabaseId.of(projectId, instanceId, databaseId))
                 .setDialect(Dialect.POSTGRESQL)
                 .build(),
-            Arrays.asList());
-    db = op.get();
+            Collections.emptyList());
+    Database db = op.get();
     databases.add(db);
     logger.log(Level.INFO, "Created database [" + db.getId() + "]");
     return db;
   }
 
   public void updateDdl(String databaseId, Iterable<String> statements) throws Exception {
-    Spanner spanner = options.getService();
+    Spanner spanner = getSpanner();
     DatabaseAdminClient client = spanner.getDatabaseAdminClient();
     OperationFuture<Void, UpdateDatabaseDdlMetadata> op =
         client.updateDatabaseDdl(instanceId, databaseId, statements, null);
@@ -207,8 +231,8 @@ public final class PgAdapterTestEnv {
   }
 
   // Update tables of the database.
-  public void updateTables(String databaseId, Iterable<String> statements) throws Exception {
-    Spanner spanner = options.getService();
+  public void updateTables(String databaseId, Iterable<String> statements) {
+    Spanner spanner = getSpanner();
     DatabaseId db = DatabaseId.of(projectId, instanceId, databaseId);
     DatabaseClient dbClient = spanner.getDatabaseClient(db);
     dbClient
@@ -228,6 +252,19 @@ public final class PgAdapterTestEnv {
             });
   }
 
+  /**
+   * Writes data to the given test database.
+   *
+   * @param databaseId The id of the database to write to
+   * @param mutations The mutations to write
+   */
+  public void write(String databaseId, Iterable<Mutation> mutations) {
+    Spanner spanner = getSpanner();
+    DatabaseId db = DatabaseId.of(projectId, instanceId, databaseId);
+    DatabaseClient dbClient = spanner.getDatabaseClient(db);
+    dbClient.write(mutations);
+  }
+
   // Setup spanner options.
   private SpannerOptions createSpannerOptions() throws Exception {
     projectId = getProjectId();
@@ -236,12 +273,15 @@ public final class PgAdapterTestEnv {
     Map<String, String> env = System.getenv();
     gcpCredentials = env.get(GCP_CREDENTIALS);
     GoogleCredentials credentials = null;
-    credentials = GoogleCredentials.fromStream(new FileInputStream(gcpCredentials));
-    return SpannerOptions.newBuilder()
-        .setProjectId(projectId)
-        .setHost(spannerURL.toString())
-        .setCredentials(credentials)
-        .build();
+    if (!Strings.isNullOrEmpty(gcpCredentials)) {
+      credentials = GoogleCredentials.fromStream(new FileInputStream(gcpCredentials));
+    }
+    SpannerOptions.Builder builder =
+        SpannerOptions.newBuilder().setProjectId(projectId).setHost(spannerURL.toString());
+    if (credentials != null) {
+      builder.setCredentials(credentials);
+    }
+    return builder.build();
   }
 
   public static class PGMessage {
@@ -365,12 +405,17 @@ public final class PgAdapterTestEnv {
 
   // Drop all the databases we created explicitly.
   public void cleanUp() {
-    for (Database db : databases) {
-      try {
-        db.drop();
-      } catch (Exception e) {
-        logger.log(Level.WARNING, "Failed to drop test database " + db.getId(), e);
+    if (!isUseExistingDb()) {
+      for (Database db : databases) {
+        try {
+          db.drop();
+        } catch (Exception e) {
+          logger.log(Level.WARNING, "Failed to drop test database " + db.getId(), e);
+        }
       }
+    }
+    if (spanner != null) {
+      spanner.close();
     }
   }
 }

--- a/src/test/java/com/google/cloud/spanner/pgadapter/ProtocolTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/ProtocolTest.java
@@ -166,6 +166,7 @@ public class ProtocolTest {
     String expectedSQL = "SELECT * FROM users";
 
     Mockito.when(connection.createStatement()).thenReturn(statement);
+    Mockito.when(statement.getResultSet()).thenReturn(mock(ResultSet.class));
     Mockito.when(connectionHandler.getServer()).thenReturn(server);
     Mockito.when(server.getOptions()).thenReturn(options);
     Mockito.when(options.requiresMatcher()).thenReturn(true);

--- a/src/test/java/com/google/cloud/spanner/pgadapter/StatementTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/StatementTest.java
@@ -14,6 +14,8 @@
 
 package com.google.cloud.spanner.pgadapter;
 
+import static org.mockito.Mockito.mock;
+
 import com.google.cloud.spanner.jdbc.JdbcConstants;
 import com.google.cloud.spanner.pgadapter.metadata.ConnectionMetadata;
 import com.google.cloud.spanner.pgadapter.metadata.OptionsMetadata;
@@ -191,6 +193,7 @@ public class StatementTest {
 
     Mockito.when(connection.prepareStatement(ArgumentMatchers.anyString()))
         .thenReturn(preparedStatement);
+    Mockito.when(preparedStatement.getResultSet()).thenReturn(mock(ResultSet.class));
 
     IntermediatePreparedStatement intermediateStatement =
         new IntermediatePreparedStatement(sqlStatement, connection);

--- a/src/test/java/com/google/cloud/spanner/pgadapter/StatementTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/StatementTest.java
@@ -130,9 +130,9 @@ public class StatementTest {
   }
 
   @Test
-  public void testBasicNoResultStatement() throws Exception {
+  public void testBasicZeroUpdateCountStatement() throws Exception {
     Mockito.when(connection.createStatement()).thenReturn(statement);
-    Mockito.when(statement.getUpdateCount()).thenReturn(JdbcConstants.STATEMENT_NO_RESULT);
+    Mockito.when(statement.getUpdateCount()).thenReturn(0);
 
     IntermediateStatement intermediateStatement =
         new IntermediateStatement("UPDATE users SET name = someName WHERE id = -1", connection);
@@ -145,9 +145,9 @@ public class StatementTest {
     Mockito.verify(statement, Mockito.times(1))
         .execute("UPDATE users SET name = someName WHERE id = -1");
     Assert.assertFalse(intermediateStatement.containsResultSet());
-    Assert.assertEquals((int) intermediateStatement.getUpdateCount(), -2);
+    Assert.assertEquals((int) intermediateStatement.getUpdateCount(), 0);
     Assert.assertTrue(intermediateStatement.isExecuted());
-    Assert.assertEquals(intermediateStatement.getResultType(), ResultType.NO_RESULT);
+    Assert.assertEquals(intermediateStatement.getResultType(), ResultType.UPDATE_COUNT);
     Assert.assertNull(intermediateStatement.getStatementResult());
     Assert.assertFalse(intermediateStatement.isHasMoreData());
     Assert.assertFalse(intermediateStatement.hasException());


### PR DESCRIPTION
Adds integration tests that use the native PostgreSQL driver to connect
to PGAdapter, and tweaks the protocol response from PGAdapter to be in
line with what real PostgreSQL does. Notable changes to protocol:

1. standard_conforming_strings should return 'on' instead of 'true'
2. Describe Portal should respond with NoData if the portal does not
   contain any columns (i.e. it is an update count)

Adds support for decoding parameters that have been given in binary
format.

This change also fixes a wrong assumption in IntermediateStatement that
a zero update count means NO_RESULT. Zero update count means that no
rows were updated/deleted by the UPDATE or DELETE statement.