### PR TITLE
fix: command should determine result type

### DIFF
--- a/src/main/java/com/google/cloud/spanner/pgadapter/statements/IntermediatePreparedStatement.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/statements/IntermediatePreparedStatement.java
@@ -37,7 +37,7 @@ public class IntermediatePreparedStatement extends IntermediateStatement {
   protected List<Integer> parameterDataTypes;
 
   public IntermediatePreparedStatement(String sql, Connection connection) throws SQLException {
-    super();
+    super(sql);
     SQLMetadata parsedSQL = Converter.toJDBCParams(sql);
     this.parameterCount = parsedSQL.getParameterCount();
     this.sql = parsedSQL.getSqlString();
@@ -54,7 +54,7 @@ public class IntermediatePreparedStatement extends IntermediateStatement {
       int totalParameters,
       SetMultimap<Integer, Integer> parameterIndexToPositions,
       Connection connection) {
-    super();
+    super(sql);
     this.sql = sql;
     this.command = parseCommand(sql);
     this.parameterCount = totalParameters;

--- a/src/main/java/com/google/cloud/spanner/pgadapter/statements/IntermediateStatement.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/statements/IntermediateStatement.java
@@ -16,7 +16,6 @@ package com.google.cloud.spanner.pgadapter.statements;
 
 import com.google.cloud.spanner.Dialect;
 import com.google.cloud.spanner.connection.AbstractStatementParser;
-import com.google.cloud.spanner.jdbc.JdbcConstants;
 import com.google.cloud.spanner.pgadapter.metadata.DescribeMetadata;
 import com.google.common.base.Preconditions;
 import java.sql.Connection;
@@ -69,11 +68,11 @@ public class IntermediateStatement {
   }
 
   /**
-   * Determines the result type based on the given sql string. The sql string has already been
-   * stripped of
+   * Determines the result type based on the given sql string. The sql string must already been
+   * stripped of any comments that might precede the actual sql string.
    *
-   * @param sql
-   * @return
+   * @param sql The sql string to determine the type of result for
+   * @return The {@link ResultType} that the given sql string will produce
    */
   protected static ResultType determineResultType(String sql) {
     if (PARSER.isUpdateStatement(sql)) {
@@ -82,25 +81,6 @@ public class IntermediateStatement {
       return ResultType.RESULT_SET;
     } else {
       return ResultType.NO_RESULT;
-    }
-  }
-  /**
-   * Extracts what type of result exists within the statement. In JDBC a statement update count is
-   * positive if it is an update statement, 0 if there is no result, or negative if there are
-   * results (i.e.: select statement)
-   *
-   * @param statement The resulting statement from an execution.
-   * @return The statement result type.
-   * @throws SQLException If getUpdateCount fails.
-   */
-  private static ResultType extractResultType(Statement statement) throws SQLException {
-    switch (statement.getUpdateCount()) {
-      case JdbcConstants.STATEMENT_NO_RESULT:
-        return ResultType.NO_RESULT;
-      case JdbcConstants.STATEMENT_RESULT_SET:
-        return ResultType.RESULT_SET;
-      default:
-        return ResultType.UPDATE_COUNT;
     }
   }
 

--- a/src/main/java/com/google/cloud/spanner/pgadapter/statements/IntermediateStatement.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/statements/IntermediateStatement.java
@@ -14,6 +14,8 @@
 
 package com.google.cloud.spanner.pgadapter.statements;
 
+import com.google.cloud.spanner.Dialect;
+import com.google.cloud.spanner.connection.AbstractStatementParser;
 import com.google.cloud.spanner.jdbc.JdbcConstants;
 import com.google.cloud.spanner.pgadapter.metadata.DescribeMetadata;
 import com.google.common.base.Preconditions;
@@ -30,9 +32,11 @@ import java.util.List;
  * statements which does not belong directly to Postgres, Spanner, etc.
  */
 public class IntermediateStatement {
+  private static final AbstractStatementParser PARSER =
+      AbstractStatementParser.getInstance(Dialect.POSTGRESQL);
 
   protected Statement statement;
-  protected ResultType resultType;
+  private final ResultType resultType;
   protected ResultSet statementResult;
   protected boolean hasMoreData;
   protected Exception exception;
@@ -47,23 +51,39 @@ public class IntermediateStatement {
   private static final char SINGLE_QUOTE = '\'';
 
   public IntermediateStatement(String sql, Connection connection) throws SQLException {
-    this();
     this.sql = sql;
     this.statements = parseStatements(sql);
     this.command = parseCommand(sql);
     this.connection = connection;
     this.statement = connection.createStatement();
+    // Note: This determines the result type based on the first statement in the SQL statement. That
+    // means that it assumes that if this is a batch of statements, all the statements in the batch
+    // will have the same type of result (that is; they are all DML statements, all DDL statements,
+    // all queries, etc.). That is a safe assumption for now, as PgAdapter currently only supports
+    // all-DML and all-DDL batches.
+    this.resultType = determineResultType(sql);
   }
 
-  protected IntermediateStatement() {
-    this.executed = false;
-    this.exception = null;
-    this.resultType = null;
-    this.hasMoreData = false;
-    this.statementResult = null;
-    this.updateCount = null;
+  protected IntermediateStatement(String sql) {
+    this.resultType = determineResultType(sql);
   }
 
+  /**
+   * Determines the result type based on the given sql string. The sql string has already been
+   * stripped of
+   *
+   * @param sql
+   * @return
+   */
+  protected static ResultType determineResultType(String sql) {
+    if (PARSER.isUpdateStatement(sql)) {
+      return ResultType.UPDATE_COUNT;
+    } else if (PARSER.isQuery(sql)) {
+      return ResultType.RESULT_SET;
+    } else {
+      return ResultType.NO_RESULT;
+    }
+  }
   /**
    * Extracts what type of result exists within the statement. In JDBC a statement update count is
    * positive if it is an update statement, 0 if there is no result, or negative if there are
@@ -209,7 +229,6 @@ public class IntermediateStatement {
    * @throws SQLException If an issue occurred in extracting result metadata.
    */
   protected void updateResultCount() throws SQLException {
-    this.resultType = IntermediateStatement.extractResultType(this.statement);
     if (this.containsResultSet()) {
       this.statementResult = this.statement.getResultSet();
       this.hasMoreData = this.statementResult.next();
@@ -221,7 +240,6 @@ public class IntermediateStatement {
   }
 
   protected void updateBatchResultCount(int[] updateCounts) throws SQLException {
-    this.resultType = IntermediateStatement.extractResultType(this.statement);
     this.updateCount = 0;
     for (int i = 0; i < updateCounts.length; ++i) {
       this.updateCount += updateCounts[i];
@@ -239,7 +257,6 @@ public class IntermediateStatement {
     this.exception = e;
     this.hasMoreData = false;
     this.statementResult = null;
-    this.resultType = ResultType.NO_RESULT;
   }
 
   /** Execute the SQL statement, storing metadata. */

--- a/src/main/java/com/google/cloud/spanner/pgadapter/statements/MatcherStatement.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/statements/MatcherStatement.java
@@ -30,7 +30,7 @@ public class MatcherStatement extends IntermediateStatement {
   private JSONObject commandMetadataJSON;
 
   public MatcherStatement(String sql, ConnectionHandler connectionHandler) throws SQLException {
-    super();
+    super(sql);
     this.connection = connectionHandler.getJdbcConnection();
     this.statement = this.connection.createStatement();
     this.commandMetadataJSON = connectionHandler.getServer().getOptions().getCommandMetadataJSON();

--- a/src/main/java/com/google/cloud/spanner/pgadapter/statements/PSQLStatement.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/statements/PSQLStatement.java
@@ -29,7 +29,7 @@ public class PSQLStatement extends IntermediateStatement {
   private JSONObject commandMetadataJSON;
 
   public PSQLStatement(String sql, ConnectionHandler connectionHandler) throws SQLException {
-    super();
+    super(sql);
     this.connection = connectionHandler.getJdbcConnection();
     this.statement = this.connection.createStatement();
     this.commandMetadataJSON = connectionHandler.getServer().getOptions().getCommandMetadataJSON();

--- a/src/main/java/com/google/cloud/spanner/pgadapter/wireprotocol/DescribeMessage.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/wireprotocol/DescribeMessage.java
@@ -87,13 +87,21 @@ public class DescribeMessage extends ControlMessage {
     if (this.statement.hasException()) {
       this.handleError(this.statement.getException());
     } else {
-      new RowDescriptionResponse(
-              this.outputStream,
-              this.statement,
-              ((DescribePortalMetadata) this.statement.describe()).getMetadata(),
-              this.connection.getServer().getOptions(),
-              QueryMode.EXTENDED)
-          .send();
+      switch (this.statement.getResultType()) {
+        case UPDATE_COUNT:
+        case NO_RESULT:
+          new NoDataResponse(this.outputStream).send();
+          break;
+        case RESULT_SET:
+          new RowDescriptionResponse(
+                  this.outputStream,
+                  this.statement,
+                  ((DescribePortalMetadata) this.statement.describe()).getMetadata(),
+                  this.connection.getServer().getOptions(),
+                  QueryMode.EXTENDED)
+              .send();
+          break;
+      }
     }
   }
 


### PR DESCRIPTION
The result type was determined by looking at the update count returned
by the JDBC statement that was executed on Cloud Spanner. This is
however wrong, as:
1. An update count of 0 does not mean 'no result'. It means that zero
   rows were updated/deleted.
2. The result type is determined by the type of statement. A DML
   statement will always return an update count. A DDL statement will
   always return no result. A query will always return a result set.