### PR TITLE
chore: setup release-please

### DIFF
--- a/.github/release-please.yml
+++ b/.github/release-please.yml
@@ -1,0 +1,3 @@
+releaseType: java-yoshi
+bumpMinorPreMajor: true
+handleGHRelease: true

--- a/.github/release-trigger.yml
+++ b/.github/release-trigger.yml
@@ -1,0 +1,1 @@
+enabled: true

--- a/java.header
+++ b/java.header
@@ -1,0 +1,13 @@
+^// Copyright \d\d\d\d,? Google (Inc\.|LLC)$
+^//$
+^// Licensed under the Apache License, Version 2\.0 \(the "License"\);$
+^// you may not use this file except in compliance with the License\.$
+^// You may obtain a copy of the License at$
+^//$
+^//[ ]+https?://www.apache.org/licenses/LICENSE-2\.0$
+^//$
+^// Unless required by applicable law or agreed to in writing, software$
+^// distributed under the License is distributed on an "AS IS" BASIS,$
+^// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied\.$
+^// See the License for the specific language governing permissions and$
+^// limitations under the License\.$

--- a/license-checks.xml
+++ b/license-checks.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+  "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+  "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
+<module name="Checker">
+  <module name="RegexpHeader">
+    <property name="fileExtensions" value="java"/>
+    <property name="headerFile" value="${checkstyle.header.file}"/>
+  </module>
+  <module name="BeforeExecutionExclusionFileFilter">
+    <property name="fileNamePattern"
+      value=".*[\\/]src[\\/]main[\\/]javacc[\\/].*$"/>
+  </module>
+  <module name="BeforeExecutionExclusionFileFilter">
+    <property name="fileNamePattern"
+      value=".*[\\/]src[\\/]main[\\/]java[\\/]com[\\/]google[\\/]cloud[\\/]spanner[\\/]pgadapter[\\/]parsers[\\/]copy[\\/].*$"/>
+  </module>
+</module>

--- a/pom.xml
+++ b/pom.xml
@@ -72,11 +72,6 @@
       <artifactId>json</artifactId>
       <version>20210307</version>
     </dependency>
-    <dependency>
-      <groupId>com.google.api</groupId>
-      <artifactId>gax-grpc</artifactId>
-      <version>2.3.0</version>
-    </dependency>
     <!-- Test dependencies -->
     <dependency>
       <groupId>com.google.cloud</groupId>
@@ -88,7 +83,7 @@
     <dependency>
       <groupId>com.google.api</groupId>
       <artifactId>gax-grpc</artifactId>
-      <version>2.8.1</version>
+      <version>2.11.0</version>
       <classifier>testlib</classifier>
       <scope>test</scope>
     </dependency>
@@ -180,10 +175,9 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>3.0.0-M3</version>
+        <version>3.0.0-M5</version>
         <configuration>
-          <excludedGroups>com.google.cloud.spanner.pgadapter.IntegrationTest
-          </excludedGroups>
+          <excludedGroups>com.google.cloud.spanner.pgadapter.IntegrationTest</excludedGroups>
           <reportNameSuffix>sponge_log</reportNameSuffix>
         </configuration>
       </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -26,16 +26,20 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.google.cloud</groupId>
   <artifactId>google-cloud-spanner-pgadapter</artifactId>
-  <version>0.1.0-pg-SNAPSHOT</version>
-  <name>Google Cloud Spanner PostgreSQL Adaptor</name>
+  <version>0.1.0-SNAPSHOT</version>
+  <name>Google Cloud Spanner PostgreSQL Adapter</name>
   <packaging>jar</packaging>
   <description>
-    The Adapter server implements the PostgreSQL wire-protocol, but sends all
-    received statements
-    to a Spanner database instead of a PostgreSQL database. This makes it
-    possible to use tools
-    developed for PostgreSQL to be used with Spanner.
+    The PGAdapter server implements the PostgreSQL wire-protocol, but sends all received statements
+    to a Cloud Spanner database instead of a PostgreSQL database. The Cloud Spanner database must
+    have been created using the PostgreSQL dialect. See https://cloud.google.com/spanner/docs/quickstart-console#postgresql
+    for more information on how to create PostgreSQL dialect databases on Cloud Spanner.
   </description>
+  <parent>
+    <groupId>com.google.cloud</groupId>
+    <artifactId>google-cloud-shared-config</artifactId>
+    <version>1.2.7</version>
+  </parent>
 
   <dependencies>
     <dependency>

--- a/src/main/java/com/google/cloud/spanner/pgadapter/metadata/CommandMetadataParser.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/metadata/CommandMetadataParser.java
@@ -1,18 +1,16 @@
-/*
- * Copyright 2021 Google LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 package com.google.cloud.spanner.pgadapter.metadata;
 

--- a/src/test/java/com/google/cloud/spanner/pgadapter/ArraysMockServerTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/ArraysMockServerTest.java
@@ -1,3 +1,17 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package com.google.cloud.spanner.pgadapter;
 
 import static org.junit.Assert.assertArrayEquals;

--- a/src/test/java/com/google/cloud/spanner/pgadapter/IntegrationTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/IntegrationTest.java
@@ -1,18 +1,16 @@
-/*
- * Copyright 2017 Google LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 package com.google.cloud.spanner.pgadapter;
 

--- a/src/test/java/com/google/cloud/spanner/pgadapter/RowDescriptionTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/RowDescriptionTest.java
@@ -1,3 +1,17 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package com.google.cloud.spanner.pgadapter.wireoutput;
 
 import static org.hamcrest.CoreMatchers.equalTo;

--- a/src/test/java/com/google/cloud/spanner/pgadapter/StatementParserTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/StatementParserTest.java
@@ -1,3 +1,17 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package com.google.cloud.spanner.pgadapter;
 
 import com.google.cloud.spanner.pgadapter.utils.StatementParser;

--- a/src/test/java/com/google/cloud/spanner/pgadapter/metadata/CommandMetadataParserTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/metadata/CommandMetadataParserTest.java
@@ -1,3 +1,17 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package com.google.cloud.spanner.pgadapter.metadata;
 
 import static org.junit.Assert.assertEquals;


### PR DESCRIPTION
Sets up `release-please` automation for this repository.

Also fixes some license header issues with several files in the repository. Some files missed a license header, and some used a slightly different format. Now all (non-generated) files have the same license header.