### PR TITLE
build: restore the distribution management tags in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,21 @@
     <version>1.2.7</version>
   </parent>
 
+  <distributionManagement>
+    <snapshotRepository>
+      <id>artifact-registry</id>
+      <url>
+        artifactregistry://us-west1-maven.pkg.dev/span-cloud-testing/spangres-artifacts
+      </url>
+    </snapshotRepository>
+    <repository>
+      <id>artifact-registry</id>
+      <url>
+        artifactregistry://us-west1-maven.pkg.dev/span-cloud-testing/spangres-artifacts
+      </url>
+    </repository>
+  </distributionManagement>
+
   <dependencies>
     <dependency>
       <groupId>com.googlecode.json-simple</groupId>


### PR DESCRIPTION
The specific distribution management setup for PGAdapter was accidentally removed when switching to the public Java client. This causes the publishing of the jars in the artifact registry to fail.