### PR TITLE
chore: disable logging during tests by default

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -226,6 +226,12 @@
         <configuration>
           <excludedGroups>com.google.cloud.spanner.pgadapter.IntegrationTest</excludedGroups>
           <reportNameSuffix>sponge_log</reportNameSuffix>
+          <systemProperties>
+            <property>
+              <name>java.util.logging.config.file</name>
+              <value>src/test/resources/logging.properties</value>
+            </property>
+          </systemProperties>
         </configuration>
       </plugin>
       <plugin>

--- a/src/test/resources/logging.properties
+++ b/src/test/resources/logging.properties
@@ -1,0 +1,3 @@
+.level=OFF
+handlers=java.util.logging.ConsoleHandler
+java.util.logging.ConsoleHandler.level=OFF


### PR DESCRIPTION
Reduce the noise during tests by turning off logging by default during unit tests.