### PR TITLE
chore(cleanup): cleanup small test classes

### DIFF
--- a/src/test/java/com/google/cloud/spanner/pgadapter/MetadataTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/MetadataTest.java
@@ -14,13 +14,14 @@
 
 package com.google.cloud.spanner.pgadapter;
 
+import static org.junit.Assert.assertEquals;
+
 import com.google.cloud.spanner.pgadapter.metadata.DynamicCommandMetadata;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
-import org.junit.Assert;
 import org.junit.Test;
 
 public class MetadataTest {
@@ -44,10 +45,10 @@ public class MetadataTest {
 
     List<DynamicCommandMetadata> result =
         DynamicCommandMetadata.fromJSON((JSONObject) parser.parse(inputJSON));
-    Assert.assertEquals(1, result.size());
-    Assert.assertEquals("this is the output SQL query", result.get(0).getOutputPattern());
-    Assert.assertEquals("this is the input SQL query", result.get(0).getInputPattern());
-    Assert.assertEquals(new ArrayList<>(), result.get(0).getMatcherOrder());
+    assertEquals(1, result.size());
+    assertEquals("this is the output SQL query", result.get(0).getOutputPattern());
+    assertEquals("this is the input SQL query", result.get(0).getInputPattern());
+    assertEquals(new ArrayList<>(), result.get(0).getMatcherOrder());
   }
 
   @Test
@@ -77,12 +78,12 @@ public class MetadataTest {
 
     List<DynamicCommandMetadata> result =
         DynamicCommandMetadata.fromJSON((JSONObject) parser.parse(inputJSON));
-    Assert.assertEquals(2, result.size());
-    Assert.assertEquals("this is the output SQL query", result.get(0).getOutputPattern());
-    Assert.assertEquals("this is the input SQL query", result.get(0).getInputPattern());
-    Assert.assertEquals(firstResult, result.get(0).getMatcherOrder());
-    Assert.assertEquals("this is another output SQL query", result.get(1).getOutputPattern());
-    Assert.assertEquals("this is another input SQL query", result.get(1).getInputPattern());
-    Assert.assertEquals(secondResult, result.get(1).getMatcherOrder());
+    assertEquals(2, result.size());
+    assertEquals("this is the output SQL query", result.get(0).getOutputPattern());
+    assertEquals("this is the input SQL query", result.get(0).getInputPattern());
+    assertEquals(firstResult, result.get(0).getMatcherOrder());
+    assertEquals("this is another output SQL query", result.get(1).getOutputPattern());
+    assertEquals("this is another input SQL query", result.get(1).getInputPattern());
+    assertEquals(secondResult, result.get(1).getMatcherOrder());
   }
 }

--- a/src/test/java/com/google/cloud/spanner/pgadapter/metadata/CommandMetadataParserTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/metadata/CommandMetadataParserTest.java
@@ -16,6 +16,7 @@ package com.google.cloud.spanner.pgadapter.metadata;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
 
 import com.google.common.base.Charsets;
 import com.google.common.collect.ImmutableMap;
@@ -94,9 +95,8 @@ public class CommandMetadataParserTest {
     parser.parse(tempFile.getAbsolutePath());
   }
 
-  @Test(expected = IllegalArgumentException.class)
-  public void testThrowsIllegalArgumentExceptionWhenJsonIsNull()
-      throws IOException, ParseException {
+  @Test
+  public void testThrowsIllegalArgumentExceptionWhenJsonIsNull() throws IOException {
     final File tempFile = File.createTempFile("pgadapter-", ".json");
     tempFile.deleteOnExit();
 
@@ -106,6 +106,6 @@ public class CommandMetadataParserTest {
       writer.write("null");
     }
 
-    parser.parse(tempFile.getAbsolutePath());
+    assertThrows(IllegalArgumentException.class, () -> parser.parse(tempFile.getAbsolutePath()));
   }
 }


### PR DESCRIPTION
Cleanup a couple of small test classes:
1. Use static imports.
2. Make sure expected is the first argument in assertions.
3. Remove warnings.