### PR TITLE
build: simplify Docker build

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -2,12 +2,7 @@
 #                                     BUILD                                    #
 ################################################################################
 
-FROM gcr.io/cloud-marketplace/google/ubuntu1804:latest AS build
-
-ENV CLOUD_SDK_VERSION=340.0.0
-
-RUN apt-get update                                                          && \
-    apt-get -qq -y install git maven python
+FROM maven:3.8.4-eclipse-temurin-17-alpine AS build
 
 # Copy over build files to docker image.
 COPY LICENSE ./
@@ -19,29 +14,19 @@ COPY src src/
 COPY pom.xml ./
 COPY license-checks.xml ./
 COPY java.header ./
-
-# Install google-cloud-sdk to get gcloud.
-RUN mkdir -p /usr/local/gcloud                                              && \
-    cd /usr/local/gcloud                                                    && \
-    curl -s -O https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-${CLOUD_SDK_VERSION}-linux-x86_64.tar.gz && \
-    tar -xf google-cloud-sdk-${CLOUD_SDK_VERSION}-linux-x86_64.tar.gz       && \
-    /usr/local/gcloud/google-cloud-sdk/install.sh                           && \
-    ln -s /usr/local/gcloud/google-cloud-sdk/bin/gcloud /usr/bin/gcloud     && \
-    rm google-cloud-sdk-${CLOUD_SDK_VERSION}-linux-x86_64.tar.gz
+# Download dependencies
+RUN mvn dependency:go-offline
 
 # Build from source.
-RUN mvn clean package -P shade -DskipTests
+RUN mvn package -Passembly -DskipTests
 
 ################################################################################
 #                                   RELEASE                                    #
 ################################################################################
 
-FROM gcr.io/cloud-marketplace/google/ubuntu1804:latest
+FROM eclipse-temurin:17-jre
 
-RUN apt-get update                                                          && \
-    apt-get -qq -y install default-jre
-
-COPY --from=build target/pgadapter.jar /home/pgadapter/pgadapter.jar
+COPY --from=build target/pgadapter /home/pgadapter
 COPY --from=build LICENSE /home/pgadapter/
 COPY --from=build CONTRIBUTING.md /home/pgadapter/
 COPY --from=build README.md /home/pgadapter/

--- a/build/startup.sh
+++ b/build/startup.sh
@@ -13,6 +13,6 @@ do
 done
 
 cd /home/pgadapter
-COMMAND="java -jar ${JAVA_ARGUMENTS} /home/pgadapter/pgadapter.jar ${ARGUMENTS}"
+COMMAND="java ${JAVA_ARGUMENTS} -cp \"pgadapter.jar:lib/*\" com.google.cloud.spanner.pgadapter.Server ${ARGUMENTS}"
 echo $COMMAND
 eval " $COMMAND"

--- a/pom.xml
+++ b/pom.xml
@@ -204,6 +204,62 @@
         <excludedTests>com.google.cloud.spanner.pgadapter.IntegrationTest</excludedTests>
       </properties>
     </profile>
+
+    <profile>
+      <id>assembly</id>
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-resources-plugin</artifactId>
+            <version>3.2.0</version>
+            <executions>
+              <execution>
+                <id>copy-resources</id>
+                <phase>validate</phase>
+                <goals>
+                  <goal>copy-resources</goal>
+                </goals>
+                <configuration>
+                  <outputDirectory>${basedir}/target/PGAdapter</outputDirectory>
+                  <resources>
+                    <resource>
+                      <directory>resources</directory>
+                      <filtering>true</filtering>
+                    </resource>
+                  </resources>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-dependency-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>copy-dependencies</id>
+                <phase>prepare-package</phase>
+                <goals>
+                  <goal>copy-dependencies</goal>
+                </goals>
+                <configuration>
+                  <outputDirectory>${project.build.directory}/pgadapter/lib</outputDirectory>
+                  <overWriteReleases>false</overWriteReleases>
+                  <overWriteSnapshots>false</overWriteSnapshots>
+                  <overWriteIfNewer>true</overWriteIfNewer>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-jar-plugin</artifactId>
+            <configuration>
+              <finalName>pgadapter/pgadapter</finalName>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
   </profiles>
 
   <build>


### PR DESCRIPTION
Simplifies the Docker build and image by:
1. Using pre-built images that already contain Maven and a JRE.
2. Downloading and caching Maven dependencies for quicker rebuilds.
3. Building a thin jar + dependencies folder instead of a fat jar.

This also reduces the size of the Docker container from more than 800MB to 330MB.