### PR TITLE
docs: update README with instructions for running

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,9 @@ information regarding project id, instance id, database name, credentials file
 path; All other items map directly to previously mentioned CLI options.
 
 ### Options
+
+#### Required
+
 The following options are required to run the proxy:
 
 ```    
@@ -135,7 +138,10 @@ The following options are required to run the proxy:
   * Do remember to grant the service account sufficient credentials to access the database.
 ```
 
+#### Optional
+
 The following options are optional:
+
 ```    
 -s <port>
   * The inbound port for the proxy. Defaults to 5432. Choose a different port if you already have

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ See [Options](#Options) for an explanation of all further options.
 
 ### Standalone with pre-built jar
 
-A pre-built jar containing all dependencies can be downloaded from https://storage.googleapis.com/pgadapter-jar-releases/pgadapter-<VERSION>.jar
+A pre-built jar containing all dependencies can be downloaded from https://storage.googleapis.com/pgadapter-jar-releases/pgadapter-&lt;VERSION&gt;.jar
 
 Example (replace `v0.2.1` with the version you want to download):
 

--- a/README.md
+++ b/README.md
@@ -37,11 +37,11 @@ See [Options](#Options) for an explanation of all further options.
 
 ### Standalone with pre-built jar
 
-A pre-built jar containing all dependencies can be downloaded from https://storage.googleapis.com/pgadapter-jar-releases/pgadapter-latest.jar
+A pre-built jar containing all dependencies can be downloaded from https://storage.googleapis.com/pgadapter-jar-releases/pgadapter.jar
 
 ```shell
-wget https://storage.googleapis.com/pgadapter-jar-releases/pgadapter-latest.jar
-java -jar pgadapter-latest.jar -p my-project -i my-instance -d my-database
+wget https://storage.googleapis.com/pgadapter-jar-releases/pgadapter.jar
+java -jar pgadapter.jar -p my-project -i my-instance -d my-database
 ```
 
 Use the `-s` option to specify a different local port than the default 5432 if you already have
@@ -260,7 +260,7 @@ not supported:
 * COPY <table_name> TO ...
 * COPY <table_name> FROM <filename | PROGRAM program>
 
-COPY <table_name> FROM STDIN __is supported__.
+See [COPY <table-name> FROM STDIN](#copy-support) for more information on COPY.
 
 Only the following `psql` meta-commands are supported:
   * `\d <table>` 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ docker run \
   -d -p 5432:5432 \
   -v ${GOOGLE_APPLICATION_CREDENTIALS}:${GOOGLE_APPLICATION_CREDENTIALS}:ro \
   -e GOOGLE_APPLICATION_CREDENTIALS \
-  us-west1-docker.pkg.dev/cloud-spanner-pg-adapter/pgadapter/pgadapter \
+  us-west1-docker.pkg.dev/cloud-spanner-pg-adapter/pgadapter-docker-images/pgadapter \
   -p my-project -i my-instance -d my-database \
   -x
 ```

--- a/README.md
+++ b/README.md
@@ -49,13 +49,14 @@ See [Options](#Options) for an explanation of all further options.
 
 ### Standalone with pre-built jar
 
-A pre-built jar containing all dependencies can be downloaded from https://storage.googleapis.com/pgadapter-jar-releases/pgadapter-&lt;VERSION&gt;.jar
+A pre-built jar containing all dependencies can be downloaded from https://storage.googleapis.com/pgadapter-jar-releases/pgadapter-VERSION.jar
 
 Example (replace `v0.2.1` with the version you want to download):
 
 ```shell
-wget https://storage.googleapis.com/pgadapter-jar-releases/pgadapter-v0.2.1.jar
-java -jar pgadapter-v0.2.1.jar -p my-project -i my-instance -d my-database
+VERSION=v0.2.1
+wget https://storage.googleapis.com/pgadapter-jar-releases/pgadapter-${VERSION}.jar
+java -jar pgadapter-${VERSION}.jar -p my-project -i my-instance -d my-database
 ```
 
 Use the `-s` option to specify a different local port than the default 5432 if you already have

--- a/README.md
+++ b/README.md
@@ -5,10 +5,13 @@ Cloud Spanner equivalent for Cloud Spanner databases [that use the PostgreSQL di
 
 PGAdapter has been tested and can be used with the following clients:
 1. `psql`: Versions 11, 12, 13 and 14 are supported. See [psql support](docs/psql.md) for more details.
-2. `JDBC`: Versions 42.x and higher are partly supported. See [JDBC support](docs/jdbc.md) for more details.
-3. `pgx`: Version 4.15 and higher have limited support. See [pgx support](docs/pgx.md) for more details.
+2. `JDBC`: Versions 42.x and higher have __limited support__. See [JDBC support](docs/jdbc.md) for more details.
+3. `pgx`: Version 4.15 and higher have __limited support__. See [pgx support](docs/pgx.md) for more details.
 
-Other drivers and tools have not been specifically tested and are not known to work with PGAdapter.
+Other drivers and tools have __not been specifically tested__ and are not known to work with PGAdapter
+and are therefore __not supported__. Drivers and tools that use [simple query protocol](https://www.postgresql.org/docs/current/protocol-flow.html#id-1.10.5.7.4)
+are likely to work with PGAdapter. Drivers and tools that use the [extended query protocol](https://www.postgresql.org/docs/current/protocol-flow.html#PROTOCOL-FLOW-EXT-QUERY)
+are more likely to at least have some issues when used with PGAdapter.
 
 ## Usage
 The PostgreSQL adapter can be started both as a Docker container, a standalone process as well as an
@@ -38,6 +41,8 @@ The `-x` option tells PGAdapter to accept connections other hosts than `localhos
 when running PGAdapter in a Docker container, as requests will not be seen as coming from `localhost`
 in the container. Choose a different host port than 5432 if you already have PostgreSQL running on
 your local system.
+
+See [running PGAdapter using Docker](docs/docker.md) for more examples for running PGAdapter in Docker.
 
 See [Options](#Options) for an explanation of all further options.
 

--- a/README.md
+++ b/README.md
@@ -19,30 +19,31 @@ in-process server (the latter is only supported for Java applications).
 
 ### Docker
 
+See [running PGAdapter using Docker](docs/docker.md) for more examples for running PGAdapter in Docker.
+
 Replace the project, instance and database names and the credentials file in the example below to
 run PGAdapter from a pre-built Docker image.
 
 ```shell
+export GOOGLE_APPLICATION_CREDENTIALS=/path/to/credentials.json
 docker pull us-west1-docker.pkg.dev/cloud-spanner-pg-adapter/pgadapter-docker-images/pgadapter
 docker run \
   -d -p 5432:5432 \
-  -v /local/path/to/credentials.json:/tmp/keys/key.json:ro \
-  -e GOOGLE_APPLICATION_CREDENTIALS=/tmp/keys/key.json \
+  -v ${GOOGLE_APPLICATION_CREDENTIALS}:${GOOGLE_APPLICATION_CREDENTIALS}:ro \
+  -e GOOGLE_APPLICATION_CREDENTIALS \
   us-west1-docker.pkg.dev/cloud-spanner-pg-adapter/pgadapter/pgadapter \
   -p my-project -i my-instance -d my-database \
   -x
 ```
 
-The option `-v /local/path/to/credentials.json:/tmp/keys/key.json:ro` mounts the credentials file on
-your local system to a file in the Docker container. The `-e GOOGLE_APPLICATION_CREDENTIALS=/tmp/keys/key.json`
-sets the file as the default credentials to use inside the container.
+The option `-v ${GOOGLE_APPLICATION_CREDENTIALS}:${GOOGLE_APPLICATION_CREDENTIALS}:ro` mounts the
+default credentials file on your local system to a virtual file with the same name in the Docker container.
+The `-e GOOGLE_APPLICATION_CREDENTIALS` sets the file as the default credentials to use inside the container.
 
 The `-x` option tells PGAdapter to accept connections other hosts than `localhost`. This is required
 when running PGAdapter in a Docker container, as requests will not be seen as coming from `localhost`
 in the container. Choose a different host port than 5432 if you already have PostgreSQL running on
 your local system.
-
-See [running PGAdapter using Docker](docs/docker.md) for more examples for running PGAdapter in Docker.
 
 See [Options](#Options) for an explanation of all further options.
 

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -6,11 +6,12 @@ Each version of PGAdapter is published as a pre-built Docker image. You can pull
 image without the need to build it yourself:
 
 ```shell
+export GOOGLE_APPLICATION_CREDENTIALS=/path/to/credentials.json
 docker pull us-west1-docker.pkg.dev/cloud-spanner-pg-adapter/pgadapter-docker-images/pgadapter
 docker run \
   -d -p 5432:5432 \
-  -v /local/path/to/credentials.json:/tmp/keys/key.json:ro \
-  -e GOOGLE_APPLICATION_CREDENTIALS=/tmp/keys/key.json \
+  -v ${GOOGLE_APPLICATION_CREDENTIALS}:${GOOGLE_APPLICATION_CREDENTIALS}:ro \
+  -e GOOGLE_APPLICATION_CREDENTIALS \
   us-west1-docker.pkg.dev/cloud-spanner-pg-adapter/pgadapter/pgadapter \
   -p my-project -i my-instance -d my-database \
   -x
@@ -20,11 +21,11 @@ The Docker options in the `docker run` command that are used in the above exampl
 * `-d`: Start the Docker container in [detached mode](https://docs.docker.com/engine/reference/run/#detached--d).
 * `-p 5432:5432`: Map local port 5432 to port 5432 on the container. This will forward traffic to port
   5432 on localhost to port 5432 in the container where PGAdapter is running.
-* `-v`: Map the local file `/local/path/to/credentials.json` to the virtual file `/tmp/keys/key.json` in the container.
+* `-v`: Map the local file `/path/to/credentials.json` to the virtual file `/path/to/credentials.json` in the container.
   The `:ro` suffix indicates that the file should be read-only, preventing the container from ever modifying the file.
   The local file should contain the credentials that should be used by PGAdapter.
-* `-e`: Assign the environment variable `GOOGLE_APPLICATION_CREDENTIALS` the value `/tmp/keys/key.json`.
-  This will make the virtual file `/tmp/keys/key.json` the default credentials in the container.
+* `-e`: Copy the value of the environment variable `GOOGLE_APPLICATION_CREDENTIALS` to the container.
+  This will make the virtual file `/path/to/credentials.json` the default credentials in the container.
 
 The PGAdapter options in the `docker run` command that are used in the above example are:
 * `-p`: The Google Cloud project name where the Cloud Spanner database is located.
@@ -42,8 +43,8 @@ different host port to forward to the Docker container:
 ```shell
 docker run \
   -d -p 5433:5432 \
-  -v /local/path/to/credentials.json:/tmp/keys/key.json:ro \
-  -e GOOGLE_APPLICATION_CREDENTIALS=/tmp/keys/key.json \
+  -v ${GOOGLE_APPLICATION_CREDENTIALS}:${GOOGLE_APPLICATION_CREDENTIALS}:ro \
+  -e GOOGLE_APPLICATION_CREDENTIALS \
   us-west1-docker.pkg.dev/cloud-spanner-pg-adapter/pgadapter/pgadapter \
   -p my-project -i my-instance -d my-database \
   -x

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -1,0 +1,55 @@
+# Google Cloud Spanner PostgreSQL Adapter - Docker
+
+## Basic Usage
+
+Each version of PGAdapter is published as a pre-built Docker image. You can pull and run this Docker
+image without the need to build it yourself:
+
+```shell
+docker pull us-west1-docker.pkg.dev/cloud-spanner-pg-adapter/pgadapter-docker-images/pgadapter
+docker run \
+  -d -p 5432:5432 \
+  -v /local/path/to/credentials.json:/tmp/keys/key.json:ro \
+  -e GOOGLE_APPLICATION_CREDENTIALS=/tmp/keys/key.json \
+  us-west1-docker.pkg.dev/cloud-spanner-pg-adapter/pgadapter/pgadapter \
+  -p my-project -i my-instance -d my-database \
+  -x
+```
+
+The Docker options in the `docker run` command that are used in the above example are:
+* `-d`: Start the Docker container in [detached mode](https://docs.docker.com/engine/reference/run/#detached--d).
+* `-p 5432:5432`: Map local port 5432 to port 5432 on the container. This will forward traffic to port
+  5432 on localhost to port 5432 in the container where PGAdapter is running.
+* `-v`: Map the local file `/local/path/to/credentials.json` to the virtual file `/tmp/keys/key.json` in the container.
+  The `:ro` suffix indicates that the file should be read-only, preventing the container from ever modifying the file.
+  The local file should contain the credentials that should be used by PGAdapter.
+* `-e`: Assign the environment variable `GOOGLE_APPLICATION_CREDENTIALS` the value `/tmp/keys/key.json`.
+  This will make the virtual file `/tmp/keys/key.json` the default credentials in the container.
+
+The PGAdapter options in the `docker run` command that are used in the above example are:
+* `-p`: The Google Cloud project name where the Cloud Spanner database is located.
+* `-i`: The name of the Cloud Spanner instance where the databsae is located.
+* `-d`: The name of the Cloud Spanner database that PGAdapter should connect to.
+* `-x`: Allow PGAdapter to accept connections from other hosts than localhost. This is required as
+  PGAdapter is running in a Docker container. This means that connections from the host machine will
+  not be seen as coming from localhost in PGAdapter.
+
+## Running on a different port
+
+If you already have PostgreSQL running on your local system on port 5432, you need to assign a
+different host port to forward to the Docker container:
+
+```shell
+docker run \
+  -d -p 5433:5432 \
+  -v /local/path/to/credentials.json:/tmp/keys/key.json:ro \
+  -e GOOGLE_APPLICATION_CREDENTIALS=/tmp/keys/key.json \
+  us-west1-docker.pkg.dev/cloud-spanner-pg-adapter/pgadapter/pgadapter \
+  -p my-project -i my-instance -d my-database \
+  -x
+psql -h localhost -p 5433
+```
+
+The above example starts PGAdapter in a Docker container on the default port 5432. That port is
+mapped to port 5433 on the host machine. When connecting to PGAdapter in the Docker container, you
+must specify port 5433 for the connection.

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -12,7 +12,7 @@ docker run \
   -d -p 5432:5432 \
   -v ${GOOGLE_APPLICATION_CREDENTIALS}:${GOOGLE_APPLICATION_CREDENTIALS}:ro \
   -e GOOGLE_APPLICATION_CREDENTIALS \
-  us-west1-docker.pkg.dev/cloud-spanner-pg-adapter/pgadapter/pgadapter \
+  us-west1-docker.pkg.dev/cloud-spanner-pg-adapter/pgadapter-docker-images/pgadapter \
   -p my-project -i my-instance -d my-database \
   -x
 ```
@@ -45,7 +45,7 @@ docker run \
   -d -p 5433:5432 \
   -v ${GOOGLE_APPLICATION_CREDENTIALS}:${GOOGLE_APPLICATION_CREDENTIALS}:ro \
   -e GOOGLE_APPLICATION_CREDENTIALS \
-  us-west1-docker.pkg.dev/cloud-spanner-pg-adapter/pgadapter/pgadapter \
+  us-west1-docker.pkg.dev/cloud-spanner-pg-adapter/pgadapter-docker-images/pgadapter \
   -p my-project -i my-instance -d my-database \
   -x
 psql -h localhost -p 5433

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -1,4 +1,4 @@
-# Google Cloud Spanner PostgreSQL Adapter - Docker
+# Google Cloud Spanner PGAdapter - Docker
 
 ## Basic Usage
 
@@ -7,12 +7,12 @@ image without the need to build it yourself:
 
 ```shell
 export GOOGLE_APPLICATION_CREDENTIALS=/path/to/credentials.json
-docker pull us-west1-docker.pkg.dev/cloud-spanner-pg-adapter/pgadapter-docker-images/pgadapter
+docker pull gcr.io/cloud-spanner-pg-adapter/pgadapter
 docker run \
   -d -p 5432:5432 \
   -v ${GOOGLE_APPLICATION_CREDENTIALS}:${GOOGLE_APPLICATION_CREDENTIALS}:ro \
   -e GOOGLE_APPLICATION_CREDENTIALS \
-  us-west1-docker.pkg.dev/cloud-spanner-pg-adapter/pgadapter-docker-images/pgadapter \
+  gcr.io/cloud-spanner-pg-adapter/pgadapter \
   -p my-project -i my-instance -d my-database \
   -x
 ```
@@ -45,7 +45,7 @@ docker run \
   -d -p 5433:5432 \
   -v ${GOOGLE_APPLICATION_CREDENTIALS}:${GOOGLE_APPLICATION_CREDENTIALS}:ro \
   -e GOOGLE_APPLICATION_CREDENTIALS \
-  us-west1-docker.pkg.dev/cloud-spanner-pg-adapter/pgadapter-docker-images/pgadapter \
+  gcr.io/cloud-spanner-pg-adapter/pgadapter \
   -p my-project -i my-instance -d my-database \
   -x
 psql -h localhost -p 5433

--- a/docs/jdbc.md
+++ b/docs/jdbc.md
@@ -1,6 +1,6 @@
 # Google Cloud Spanner PostgreSQL Adapter - JDBC Support
 
-PGAdapter has partly support for the [PostgreSQL JDBC driver](https://github.com/pgjdbc/pgjdbc)
+PGAdapter has __limited support__ for the [PostgreSQL JDBC driver](https://github.com/pgjdbc/pgjdbc)
 version 42.0.0 and higher.
 
 ## Usage

--- a/docs/jdbc.md
+++ b/docs/jdbc.md
@@ -1,0 +1,31 @@
+# Google Cloud Spanner PostgreSQL Adapter - JDBC Support
+
+PGAdapter has partly support for the [PostgreSQL JDBC driver](https://github.com/pgjdbc/pgjdbc)
+version 42.0.0 and higher.
+
+## Usage
+
+First start PGAdapter in JDBC mode (see [README](../README.md) for more possibilities on how to run
+PGAdapter):
+
+```shell
+wget https://storage.googleapis.com/pgadapter-jar-releases/pgadapter-v0.2.1.jar
+java -jar pgadapter-v0.2.1.jar -p my-project -i my-instance -d my-database -jdbc
+```
+
+Connect to PGAdapter like this:
+
+```java
+// Make sure the PG JDBC driver is loaded.
+Class.forName("org.postgresql.Driver");
+
+// Replace localhost and 5432 with the host and port number where PGAdapter is running.
+// prepareThreshold=0 disables the use of server-side prepared statements in JDBC.
+try (Connection connection = DriverManager.getConnection("jdbc:postgresql://localhost:5432/?prepareThreshold=0")) {
+  try (ResultSet resultSet = connection.createStatement().executeQuery("select 'Hello world!' as hello")) {
+    while (resultSet.next()) {
+      System.out.printf("Greeting from Cloud Spanner PostgreSQL: %s\n", resultSet.getString(1));
+    }
+  }
+}
+```

--- a/docs/jdbc.md
+++ b/docs/jdbc.md
@@ -1,17 +1,15 @@
-# Google Cloud Spanner PostgreSQL Adapter - JDBC Support
+# Google Cloud Spanner PGAdapter - JDBC Support
 
 PGAdapter has __limited support__ for the [PostgreSQL JDBC driver](https://github.com/pgjdbc/pgjdbc)
 version 42.0.0 and higher.
 
 ## Usage
 
-First start PGAdapter in JDBC mode. This example uses the pre-built jar with dependencies to run
-PGAdapter as a standalone process. See [README](../README.md) for more possibilities on how to run
-PGAdapter:
+First start PGAdapter in JDBC mode by adding `-jdbc` to the command line parameters:
 
 ```shell
-wget https://storage.googleapis.com/pgadapter-jar-releases/pgadapter-v0.2.1.jar
-java -jar pgadapter-v0.2.1.jar -p my-project -i my-instance -d my-database -jdbc
+wget https://storage.googleapis.com/pgadapter-jar-releases/pgadapter-latest.jar
+java -jar pgadapter-latest.jar -p my-project -i my-instance -d my-database -jdbc
 ```
 
 Connect to PGAdapter like this:
@@ -30,3 +28,8 @@ try (Connection connection = DriverManager.getConnection("jdbc:postgresql://loca
   }
 }
 ```
+
+## Running PGAdapter
+
+This example uses the pre-built jar with dependencies to run PGAdapter as a standalone process.
+See [README](../README.md) for more possibilities on how to run PGAdapter.

--- a/docs/jdbc.md
+++ b/docs/jdbc.md
@@ -5,8 +5,9 @@ version 42.0.0 and higher.
 
 ## Usage
 
-First start PGAdapter in JDBC mode (see [README](../README.md) for more possibilities on how to run
-PGAdapter):
+First start PGAdapter in JDBC mode. This example uses the pre-built jar with dependencies to run
+PGAdapter as a standalone process. See [README](../README.md) for more possibilities on how to run
+PGAdapter:
 
 ```shell
 wget https://storage.googleapis.com/pgadapter-jar-releases/pgadapter-v0.2.1.jar

--- a/docs/jdbc.md
+++ b/docs/jdbc.md
@@ -8,8 +8,8 @@ version 42.0.0 and higher.
 First start PGAdapter in JDBC mode by adding `-jdbc` to the command line parameters:
 
 ```shell
-wget https://storage.googleapis.com/pgadapter-jar-releases/pgadapter-latest.jar
-java -jar pgadapter-latest.jar -p my-project -i my-instance -d my-database -jdbc
+wget https://storage.googleapis.com/pgadapter-jar-releases/pgadapter.jar
+java -jar pgadapter.jar -p my-project -i my-instance -d my-database -jdbc
 ```
 
 Connect to PGAdapter like this:

--- a/docs/pgx.md
+++ b/docs/pgx.md
@@ -1,4 +1,4 @@
-# Google Cloud Spanner PostgreSQL Adapter - pgx Support
+# Google Cloud Spanner PGAdapter - pgx Support
 
 PGAdapter has limited support for the [Go pgx driver](https://github.com/jackc/pgx) version 4.15.0
 and higher. 
@@ -9,12 +9,12 @@ First start PGAdapter:
 
 ```shell
 export GOOGLE_APPLICATION_CREDENTIALS=/path/to/credentials.json
-docker pull us-west1-docker.pkg.dev/cloud-spanner-pg-adapter/pgadapter-docker-images/pgadapter
+docker pull gcr.io/cloud-spanner-pg-adapter/pgadapter
 docker run \
   -d -p 5432:5432 \
   -v ${GOOGLE_APPLICATION_CREDENTIALS}:${GOOGLE_APPLICATION_CREDENTIALS}:ro \
   -e GOOGLE_APPLICATION_CREDENTIALS \
-  us-west1-docker.pkg.dev/cloud-spanner-pg-adapter/pgadapter-docker-images/pgadapter \
+  gcr.io/cloud-spanner-pg-adapter/pgadapter \
   -p my-project -i my-instance -d my-database \
   -x
 ```
@@ -42,3 +42,8 @@ if err != nil {
 }
 fmt.Printf("Greeting from Cloud Spanner PostgreSQL: %v\n", greeting)
 ```
+
+## Running PGAdapter
+
+This example uses the pre-built Docker image to run PGAdapter.
+See [README](../README.md) for more possibilities on how to run PGAdapter.

--- a/docs/pgx.md
+++ b/docs/pgx.md
@@ -25,7 +25,9 @@ Then connect to PGAdapter like this:
 // pwd:uid is not used by PGAdapter, but it is required in the connection string.
 // Replace localhost and 5432 with the host and port number where PGAdapter is running.
 // statement_cache_capacity=0 disables the use of prepared statements in pgx.
-connString := "postgres://uid:pwd@localhost:5432/?statement_cache_capacity=0"
+// sslmode=disable instructs pgx to try plain text mode directly. Otherwise, pgx will try two times
+// with SSL enabled before trying plain text.
+connString := "postgres://uid:pwd@localhost:5432/?statement_cache_capacity=0&sslmode=disable"
 ctx := context.Background()
 conn, err := pgx.Connect(ctx, connString)
 if err != nil {

--- a/docs/pgx.md
+++ b/docs/pgx.md
@@ -5,7 +5,21 @@ and higher.
 
 ## Usage
 
-First start PGAdapter and then connect to PGAdapter like this:
+First start PGAdapter:
+
+```shell
+export GOOGLE_APPLICATION_CREDENTIALS=/path/to/credentials.json
+docker pull us-west1-docker.pkg.dev/cloud-spanner-pg-adapter/pgadapter-docker-images/pgadapter
+docker run \
+  -d -p 5432:5432 \
+  -v ${GOOGLE_APPLICATION_CREDENTIALS}:${GOOGLE_APPLICATION_CREDENTIALS}:ro \
+  -e GOOGLE_APPLICATION_CREDENTIALS \
+  us-west1-docker.pkg.dev/cloud-spanner-pg-adapter/pgadapter/pgadapter \
+  -p my-project -i my-instance -d my-database \
+  -x
+```
+
+Then connect to PGAdapter like this:
 
 ```go
 // pwd:uid is not used by PGAdapter, but it is required in the connection string.

--- a/docs/pgx.md
+++ b/docs/pgx.md
@@ -14,7 +14,7 @@ docker run \
   -d -p 5432:5432 \
   -v ${GOOGLE_APPLICATION_CREDENTIALS}:${GOOGLE_APPLICATION_CREDENTIALS}:ro \
   -e GOOGLE_APPLICATION_CREDENTIALS \
-  us-west1-docker.pkg.dev/cloud-spanner-pg-adapter/pgadapter/pgadapter \
+  us-west1-docker.pkg.dev/cloud-spanner-pg-adapter/pgadapter-docker-images/pgadapter \
   -p my-project -i my-instance -d my-database \
   -x
 ```

--- a/docs/pgx.md
+++ b/docs/pgx.md
@@ -1,0 +1,28 @@
+# Google Cloud Spanner PostgreSQL Adapter - pgx Support
+
+PGAdapter has limited support for the [Go pgx driver](https://github.com/jackc/pgx) version 4.15.0
+and higher. 
+
+## Usage
+
+First start PGAdapter and then connect to PGAdapter like this:
+
+```go
+// pwd:uid is not used by PGAdapter, but it is required in the connection string.
+// Replace localhost and 5432 with the host and port number where PGAdapter is running.
+// statement_cache_capacity=0 disables the use of prepared statements in pgx.
+connString := "postgres://uid:pwd@localhost:5432/?statement_cache_capacity=0"
+ctx := context.Background()
+conn, err := pgx.Connect(ctx, connString)
+if err != nil {
+    return err
+}
+defer conn.Close(ctx)
+
+var greeting string
+err = conn.QueryRow(ctx, "select 'Hello world!' as hello").Scan(&greeting)
+if err != nil {
+    return err
+}
+fmt.Printf("Greeting from Cloud Spanner PostgreSQL: %v\n", greeting)
+```

--- a/docs/psql.md
+++ b/docs/psql.md
@@ -14,7 +14,7 @@ docker run \
   -d -p 5432:5432 \
   -v ${GOOGLE_APPLICATION_CREDENTIALS}:${GOOGLE_APPLICATION_CREDENTIALS}:ro \
   -e GOOGLE_APPLICATION_CREDENTIALS \
-  us-west1-docker.pkg.dev/cloud-spanner-pg-adapter/pgadapter/pgadapter \
+  us-west1-docker.pkg.dev/cloud-spanner-pg-adapter/pgadapter-docker-images/pgadapter \
   -p my-project -i my-instance -d my-database \
   -x -q
 ```
@@ -45,7 +45,7 @@ docker run \
   -d -p 5433:5432 \
   -v ${GOOGLE_APPLICATION_CREDENTIALS}:${GOOGLE_APPLICATION_CREDENTIALS}:ro \
   -e GOOGLE_APPLICATION_CREDENTIALS \
-  us-west1-docker.pkg.dev/cloud-spanner-pg-adapter/pgadapter/pgadapter \
+  us-west1-docker.pkg.dev/cloud-spanner-pg-adapter/pgadapter-docker-images/pgadapter \
   -p my-project -i my-instance -d my-database \
   -x -q
 psql -h localhost -p 5433

--- a/docs/psql.md
+++ b/docs/psql.md
@@ -1,30 +1,29 @@
-# Google Cloud Spanner PostgreSQL Adapter - PSQL Support
+# Google Cloud Spanner PGAdapter - PSQL Support
 
 PGAdapter supports [psql](https://www.postgresql.org/docs/current/app-psql.html) versions 11, 12, 13 and 14.
 
 ## Usage
 
-First start PGAdapter in `psql` mode (see [README](../README.md) for more possibilities on how to run
-PGAdapter).
+First start PGAdapter in `psql` mode by adding `-q` to the command line parameters.
 
 ```shell
 export GOOGLE_APPLICATION_CREDENTIALS=/path/to/credentials.json
-docker pull us-west1-docker.pkg.dev/cloud-spanner-pg-adapter/pgadapter-docker-images/pgadapter
+docker pull gcr.io/cloud-spanner-pg-adapter/pgadapter
 docker run \
   -d -p 5432:5432 \
   -v ${GOOGLE_APPLICATION_CREDENTIALS}:${GOOGLE_APPLICATION_CREDENTIALS}:ro \
   -e GOOGLE_APPLICATION_CREDENTIALS \
-  us-west1-docker.pkg.dev/cloud-spanner-pg-adapter/pgadapter-docker-images/pgadapter \
+  gcr.io/cloud-spanner-pg-adapter/pgadapter \
   -p my-project -i my-instance -d my-database \
-  -x -q
+  -x \
+  -q
 ```
 
-Note:
+- The `-q` option tells PGAdapter to translate queries from `psql` for meta commands like `\dt` into
+  queries that are supported by Cloud Spanner.
 - The `-x` option tells PGAdapter to accept incoming connections from other hosts than localhost.
   This is necessary when running PGAdapter in a Docker container, as you will be connecting to it
   from outside the container, which will be seen as a connection from a different host.
-- The `-q` option tells PGAdapter to translate queries from `psql` for meta commands like `\dt` into
-  queries that are supported by Cloud Spanner.
 
 Then connect to PGAdapter using `psql`:
 
@@ -34,19 +33,25 @@ psql -h localhost
 
 ## Running alongside a local PostgreSQL server
 
-If you have PostgreSQL installed locally on your machine, it is highly likely that PostgreSQL is
+If you have PostgreSQL installed locally on your machine, it is likely that PostgreSQL is
 already using port 5432. You then need to run PGAdapter on a different port, and specify this port
 when starting `psql` to connect to PGAdapter instead of the local PostgreSQL server:
 
 ```shell
 export GOOGLE_APPLICATION_CREDENTIALS=/path/to/credentials.json
-docker pull us-west1-docker.pkg.dev/cloud-spanner-pg-adapter/pgadapter-docker-images/pgadapter
+docker pull gcr.io/cloud-spanner-pg-adapter/pgadapter
 docker run \
   -d -p 5433:5432 \
   -v ${GOOGLE_APPLICATION_CREDENTIALS}:${GOOGLE_APPLICATION_CREDENTIALS}:ro \
   -e GOOGLE_APPLICATION_CREDENTIALS \
-  us-west1-docker.pkg.dev/cloud-spanner-pg-adapter/pgadapter-docker-images/pgadapter \
+  gcr.io/cloud-spanner-pg-adapter/pgadapter \
   -p my-project -i my-instance -d my-database \
-  -x -q
+  -x \
+  -q
 psql -h localhost -p 5433
 ```
+
+## Running PGAdapter
+
+This example uses the pre-built Docker image to run PGAdapter.
+See [README](../README.md) for more possibilities on how to run PGAdapter.

--- a/docs/psql.md
+++ b/docs/psql.md
@@ -1,0 +1,50 @@
+# Google Cloud Spanner PostgreSQL Adapter - JDBC Support
+
+PGAdapter supports [psql](https://www.postgresql.org/docs/current/app-psql.html) versions 11, 12, 13 and 14.
+
+## Usage
+
+First start PGAdapter in `psql` mode (see [README](../README.md) for more possibilities on how to run
+PGAdapter).
+
+```shell
+docker pull us-west1-docker.pkg.dev/cloud-spanner-pg-adapter/pgadapter-docker-images/pgadapter
+docker run \
+  -d -p 5432:5432 \
+  -v /local/path/to/credentials.json:/tmp/keys/key.json:ro \
+  -e GOOGLE_APPLICATION_CREDENTIALS=/tmp/keys/key.json \
+  us-west1-docker.pkg.dev/cloud-spanner-pg-adapter/pgadapter/pgadapter \
+  -p my-project -i my-instance -d my-database \
+  -x -q
+```
+
+Note:
+- The `-x` option tells PGAdapter to accept incoming connections from other hosts than localhost.
+  This is necessary when running PGAdapter in a Docker container, as you will be connecting to it
+  from outside the container, which will be seen as a connection from a different host.
+- The `-q` option tells PGAdapter to translate queries from `psql` for meta commands like `\dt` into
+  queries that are supported by Cloud Spanner.
+
+Then connect to PGAdapter using `psql`:
+
+```shell
+psql -h localhost
+```
+
+## Running alongside a local PostgreSQL server
+
+If you have PostgreSQL installed locally on your machine, it is highly likely that PostgreSQL is
+already using port 5432. You then need to run PGAdapter on a different port, and specify this port
+when starting `psql` to connect to PGAdapter instead of the local PostgreSQL server:
+
+```shell
+docker pull us-west1-docker.pkg.dev/cloud-spanner-pg-adapter/pgadapter-docker-images/pgadapter
+docker run \
+  -d -p 5433:5432 \
+  -v /local/path/to/credentials.json:/tmp/keys/key.json:ro \
+  -e GOOGLE_APPLICATION_CREDENTIALS=/tmp/keys/key.json \
+  us-west1-docker.pkg.dev/cloud-spanner-pg-adapter/pgadapter/pgadapter \
+  -p my-project -i my-instance -d my-database \
+  -x -q
+psql -h localhost -p 5433
+```

--- a/docs/psql.md
+++ b/docs/psql.md
@@ -1,4 +1,4 @@
-# Google Cloud Spanner PostgreSQL Adapter - JDBC Support
+# Google Cloud Spanner PostgreSQL Adapter - PSQL Support
 
 PGAdapter supports [psql](https://www.postgresql.org/docs/current/app-psql.html) versions 11, 12, 13 and 14.
 
@@ -8,11 +8,12 @@ First start PGAdapter in `psql` mode (see [README](../README.md) for more possib
 PGAdapter).
 
 ```shell
+export GOOGLE_APPLICATION_CREDENTIALS=/path/to/credentials.json
 docker pull us-west1-docker.pkg.dev/cloud-spanner-pg-adapter/pgadapter-docker-images/pgadapter
 docker run \
   -d -p 5432:5432 \
-  -v /local/path/to/credentials.json:/tmp/keys/key.json:ro \
-  -e GOOGLE_APPLICATION_CREDENTIALS=/tmp/keys/key.json \
+  -v ${GOOGLE_APPLICATION_CREDENTIALS}:${GOOGLE_APPLICATION_CREDENTIALS}:ro \
+  -e GOOGLE_APPLICATION_CREDENTIALS \
   us-west1-docker.pkg.dev/cloud-spanner-pg-adapter/pgadapter/pgadapter \
   -p my-project -i my-instance -d my-database \
   -x -q
@@ -38,11 +39,12 @@ already using port 5432. You then need to run PGAdapter on a different port, and
 when starting `psql` to connect to PGAdapter instead of the local PostgreSQL server:
 
 ```shell
+export GOOGLE_APPLICATION_CREDENTIALS=/path/to/credentials.json
 docker pull us-west1-docker.pkg.dev/cloud-spanner-pg-adapter/pgadapter-docker-images/pgadapter
 docker run \
   -d -p 5433:5432 \
-  -v /local/path/to/credentials.json:/tmp/keys/key.json:ro \
-  -e GOOGLE_APPLICATION_CREDENTIALS=/tmp/keys/key.json \
+  -v ${GOOGLE_APPLICATION_CREDENTIALS}:${GOOGLE_APPLICATION_CREDENTIALS}:ro \
+  -e GOOGLE_APPLICATION_CREDENTIALS \
   us-west1-docker.pkg.dev/cloud-spanner-pg-adapter/pgadapter/pgadapter \
   -p my-project -i my-instance -d my-database \
   -x -q


### PR DESCRIPTION
Updates README with additional instructions for how to run PGAdapter:
* Using a pre-built Docker image.
* Using a pre-built uber-jar.

Also adds separate documentation files for commonly used tools/drivers with specific instructions for those tools/drivers. The latter is to a certain degree a placeholder for more documentation to come.