### PR TITLE
build: remove artifact registry tags from Docker build

### DIFF
--- a/.github/workflows/docker-build-and-push.yaml
+++ b/.github/workflows/docker-build-and-push.yaml
@@ -12,7 +12,6 @@ env:
   GITHUB_SHA: ${{ github.sha }}
   GITHUB_REF: ${{ github.ref }}
   IMAGE: pgadapter
-  ARTIFACT_REGISTRY_HOSTNAME: us-west1-docker.pkg.dev/cloud-spanner-pg-adapter/pgadapter-docker-images
   GCR_HOSTNAME: gcr.io/cloud-spanner-pg-adapter
 
 jobs:
@@ -33,7 +32,7 @@ jobs:
         uses: 'google-github-actions/setup-gcloud@v0'
 
       # Configure docker to use the gcloud command-line tool as a credential helper
-      - run: gcloud auth configure-docker gcr.io,us-west1-docker.pkg.dev
+      - run: gcloud auth configure-docker gcr.io
 
       # Build the Docker image
       - name: Build
@@ -41,7 +40,6 @@ jobs:
           export TAG=`echo $GITHUB_REF | awk -F/ '{print $NF}'`
           echo $TAG
           docker build . -f build/Dockerfile \
-            -t "$ARTIFACT_REGISTRY_HOSTNAME"/"$IMAGE":"$TAG" \
             -t "$GCR_HOSTNAME"/"$IMAGE":"$TAG" \
             --build-arg GITHUB_SHA="$GITHUB_SHA" \
             --build-arg GITHUB_REF="$GITHUB_REF"
@@ -51,9 +49,6 @@ jobs:
         run: |
           export TAG=`echo $GITHUB_REF | awk -F/ '{print $NF}'`
           echo $TAG
-          docker push "$ARTIFACT_REGISTRY_HOSTNAME"/"$IMAGE":"$TAG"
-          docker tag "$ARTIFACT_REGISTRY_HOSTNAME"/"$IMAGE":"$TAG" "$ARTIFACT_REGISTRY_HOSTNAME"/"$IMAGE":latest
-          docker push "$ARTIFACT_REGISTRY_HOSTNAME"/"$IMAGE":latest
           docker push "$GCR_HOSTNAME"/"$IMAGE":"$TAG"
           docker tag "$GCR_HOSTNAME"/"$IMAGE":"$TAG" "$GCR_HOSTNAME"/"$IMAGE":latest
           docker push "$GCR_HOSTNAME"/"$IMAGE":latest


### PR DESCRIPTION
Removes the Artifact Registry tags from the Docker build. This will stop Docker images from being published to `us-west1-docker.pkg.dev/cloud-spanner-pg-adapter/pgadapter-docker-images/pgadapter`