### PR TITLE
test: use simple DatabaseAdminServiceImpl for tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-spanner</artifactId>
-      <version>6.21.0</version>
+      <version>6.23.1</version>
     </dependency>
     <dependency>
       <groupId>org.postgresql</groupId>
@@ -93,14 +93,14 @@
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-spanner</artifactId>
-      <version>6.21.0</version>
+      <version>6.23.1</version>
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.google.api</groupId>
       <artifactId>gax-grpc</artifactId>
-      <version>2.12.2</version>
+      <version>2.13.0</version>
       <classifier>testlib</classifier>
       <scope>test</scope>
     </dependency>

--- a/src/test/java/com/google/cloud/spanner/pgadapter/AbstractMockServerTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/AbstractMockServerTest.java
@@ -214,7 +214,6 @@ public abstract class AbstractMockServerTest {
         NettyServerBuilder.forAddress(address)
             .addService(mockSpanner)
             .addService(mockDatabaseAdmin)
-            //            .addService(mockOperationsService)
             .intercept(
                 new ServerInterceptor() {
                   @Override
@@ -239,10 +238,6 @@ public abstract class AbstractMockServerTest {
                 })
             .build()
             .start();
-
-    // Create the test database on the mock server. This should be replaced by a simple feature in
-    // the mock server to just add a database instead of having to simulate the creation of it.
-    //    createDatabase();
 
     ImmutableList.Builder<String> argsListBuilder =
         ImmutableList.<String>builder()

--- a/src/test/java/com/google/cloud/spanner/pgadapter/CopyInMockServerTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/CopyInMockServerTest.java
@@ -197,7 +197,9 @@ public class CopyInMockServerTest extends AbstractMockServerTest {
 
     try (Connection connection = DriverManager.getConnection(createUrl())) {
       System.setProperty("copy_in_commit_limit", "10");
-      connection.createStatement().execute("set autocommit_dml_mode='partitioned_non_atomic'");
+      connection
+          .createStatement()
+          .execute("set spanner.autocommit_dml_mode='partitioned_non_atomic'");
       CopyManager copyManager = new CopyManager(connection.unwrap(BaseConnection.class));
       copyManager.copyIn("COPY users FROM STDIN;", new StringReader("5\t5\t5\n6\t6\t6\n7\t7\t7\n"));
     } finally {
@@ -222,7 +224,9 @@ public class CopyInMockServerTest extends AbstractMockServerTest {
 
     try (Connection connection = DriverManager.getConnection(createUrl())) {
       System.setProperty("copy_in_commit_limit", "10");
-      connection.createStatement().execute("set autocommit_dml_mode='partitioned_non_atomic'");
+      connection
+          .createStatement()
+          .execute("set spanner.autocommit_dml_mode='partitioned_non_atomic'");
       CopyManager copyManager = new CopyManager(connection.unwrap(BaseConnection.class));
       SQLException exception =
           assertThrows(


### PR DESCRIPTION
Use a simple `DatabaseAdminServiceImpl` instance for tests to allow easy adding of exceptions for invalid DDL statements.