### PR TITLE
build: re-enable clirr check

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -55,6 +55,15 @@ jobs:
         java-version: 11
     - run: java -version
     - run: .ci/run-with-credentials.sh lint
+  clirr:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-java@v1
+        with:
+          java-version: 8
+      - run: java -version
+      - run: .ci/run-with-credentials.sh clirr
   e2e-psql-v11:
     runs-on: ubuntu-latest
     steps:
@@ -151,7 +160,7 @@ jobs:
     runs-on: ubuntu-latest
     # Only releases on the postgresql-dialect branch
     if: github.head_ref == 'postgresql-dialect'
-    needs: [ units, lint, integration, e2e-psql-v11, e2e-psql-v12, e2e-psql-v13 ]
+    needs: [ units, lint, clirr, integration, e2e-psql-v11, e2e-psql-v12, e2e-psql-v13 ]
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-java@v1
@@ -171,7 +180,7 @@ jobs:
     runs-on: ubuntu-latest
     # Only releases on the postgresql-dialect branch
     if: github.head_ref == 'postgresql-dialect'
-    needs: [ units, lint, integration, e2e-psql-v11, e2e-psql-v12, e2e-psql-v13 ]
+    needs: [ units, lint, clirr, integration, e2e-psql-v11, e2e-psql-v12, e2e-psql-v13 ]
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-java@v1

--- a/clirr-ignored-differences.xml
+++ b/clirr-ignored-differences.xml
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- see http://www.mojohaus.org/clirr-maven-plugin/examples/ignored-differences.html -->
+<differences>
+  <!-- Removed ProxyServer.run() as the server is now modeled as an ApiService. -->
+  <difference>
+    <differenceType>7002</differenceType>
+    <className>com/google/cloud/spanner/pgadapter/ProxyServer</className>
+    <method>void run()</method>
+  </difference>
+
+  <!-- Add ignores for all sub packages, as these are considered internal. -->
+  <difference>
+    <differenceType>1001</differenceType>
+    <className>com/google/cloud/spanner/pgadapter/*/*</className>
+    <method>**</method>
+    <from>**</from>
+    <to>**</to>
+  </difference>
+  <difference>
+    <differenceType>6001</differenceType>
+    <className>com/google/cloud/spanner/pgadapter/*/*</className>
+    <field>**</field>
+    <from>**</from>
+    <to>**</to>
+  </difference>
+  <difference>
+    <differenceType>6003</differenceType>
+    <className>com/google/cloud/spanner/pgadapter/*/*</className>
+    <field>**</field>
+    <from>**</from>
+    <to>**</to>
+  </difference>
+  <difference>
+    <differenceType>6004</differenceType>
+    <className>com/google/cloud/spanner/pgadapter/*/*</className>
+    <field>**</field>
+    <from>**</from>
+    <to>**</to>
+  </difference>
+  <difference>
+    <differenceType>6006</differenceType>
+    <className>com/google/cloud/spanner/pgadapter/*/*</className>
+    <field>**</field>
+    <from>**</from>
+    <to>**</to>
+  </difference>
+  <difference>
+    <differenceType>7002</differenceType>
+    <className>com/google/cloud/spanner/pgadapter/*/*</className>
+    <method>**</method>
+    <from>**</from>
+    <to>**</to>
+  </difference>
+  <difference>
+    <differenceType>7004</differenceType>
+    <className>com/google/cloud/spanner/pgadapter/*/*</className>
+    <method>**</method>
+    <from>**</from>
+    <to>**</to>
+  </difference>
+  <difference>
+    <differenceType>7005</differenceType>
+    <className>com/google/cloud/spanner/pgadapter/*/*</className>
+    <method>**</method>
+    <from>**</from>
+    <to>**</to>
+  </difference>
+  <difference>
+    <differenceType>7006</differenceType>
+    <className>com/google/cloud/spanner/pgadapter/*/*</className>
+    <method>**</method>
+    <from>**</from>
+    <to>**</to>
+  </difference>
+  <difference>
+    <differenceType>7009</differenceType>
+    <className>com/google/cloud/spanner/pgadapter/*/*</className>
+    <method>**</method>
+    <from>**</from>
+    <to>**</to>
+  </difference>
+  <difference>
+    <differenceType>8001</differenceType>
+    <className>com/google/cloud/spanner/pgadapter/*/*</className>
+    <method>**</method>
+    <from>**</from>
+    <to>**</to>
+  </difference>
+
+</differences>


### PR DESCRIPTION
Re-enables the clirr check, as this is a required step for the Kokoro
jobs that do the Maven releases.