### PR TITLE
deps: bump Spanner to 6.23.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,6 +23,8 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
     <excludedTests>com.google.cloud.spanner.pgadapter.IntegrationTest,com.google.cloud.spanner.pgadapter.golang.GolangTest</excludedTests>
+
+    <spanner.version>6.23.3</spanner.version>
   </properties>
 
   <modelVersion>4.0.0</modelVersion>
@@ -67,7 +69,7 @@
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-spanner</artifactId>
-      <version>6.23.3</version>
+      <version>${spanner.version}</version>
     </dependency>
     <dependency>
       <groupId>org.postgresql</groupId>
@@ -93,7 +95,7 @@
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-spanner</artifactId>
-      <version>6.23.3</version>
+      <version>${spanner.version}</version>
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-spanner</artifactId>
-      <version>6.23.1</version>
+      <version>6.23.3</version>
     </dependency>
     <dependency>
       <groupId>org.postgresql</groupId>
@@ -93,14 +93,14 @@
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-spanner</artifactId>
-      <version>6.23.1</version>
+      <version>6.23.3</version>
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.google.api</groupId>
       <artifactId>gax-grpc</artifactId>
-      <version>2.13.0</version>
+      <version>2.16.0</version>
       <classifier>testlib</classifier>
       <scope>test</scope>
     </dependency>


### PR DESCRIPTION
Bumps the Spanner client library to version 6.23.3.