### PR TITLE
chore: configure renovate to update deps for default branch

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,7 @@
 {
+  "baseBranches": [
+    "postgresql-dialect"
+  ],
   "extends": [
     ":separateMajorReleases",
     ":combinePatchMinorReleases",


### PR DESCRIPTION
Add `postgresql-dialect` branch to the base branches that should be watched by renovate-bot.