### PR TITLE
fix: use assembly instead of fat jar

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,10 +37,10 @@ See [Options](#Options) for an explanation of all further options.
 
 ### Standalone with pre-built jar
 
-A pre-built jar containing all dependencies can be downloaded from https://storage.googleapis.com/pgadapter-jar-releases/pgadapter.jar
+A pre-built jar and all dependencies can be downloaded from https://storage.googleapis.com/pgadapter-jar-releases/pgadapter.tar.gz
 
 ```shell
-wget https://storage.googleapis.com/pgadapter-jar-releases/pgadapter.jar
+wget https://storage.googleapis.com/pgadapter-jar-releases/pgadapter.tar.gz && tar -xzvf pgadapter.tar.gz
 java -jar pgadapter.jar -p my-project -i my-instance -d my-database
 ```
 
@@ -51,22 +51,23 @@ You can also download a specific version of the jar. Example (replace `v0.4.0` w
 
 ```shell
 VERSION=v0.4.0
-wget https://storage.googleapis.com/pgadapter-jar-releases/pgadapter-${VERSION}.jar
-java -jar pgadapter-${VERSION}.jar -p my-project -i my-instance -d my-database
+wget https://storage.googleapis.com/pgadapter-jar-releases/pgadapter-${VERSION}.tar.gz && tar -xzvf pgadapter-${VERSION}.tar.gz
+java -jar pgadapter.jar -p my-project -i my-instance -d my-database
 ```
 
 See [Options](#Options) for an explanation of all further options.
 
 ### Standalone with locally built jar
-1. Build a jar file containing all dependencies by running
+1. Build a jar file and assemble all dependencies by running
 
 ```shell
-mvn package -P shade
+mvn package -P assembly
 ```
 
-2. Execute
+2. Execute (the binaries are in the target/pgadapter folder)
 ```shell
-java -jar <jar-file> <options>
+cd target/pgadapter
+java -jar pgadapter.jar -p my-project -i my-instance -d my-database
 ```
 
 See [Options](#Options) for an explanation of all further options.
@@ -243,8 +244,9 @@ The following options are optional:
 An example of a simple run string:
 
 ```shell
-java -jar <jar-file> -p <project name> -i <instance id> -d <database name> -c
-<path to credentials file> -s 5432 
+java -jar pgadapter.jar \
+     -p <project-id> -i <instance-id> -d <database-id> \
+     -c <path to credentials file> -s 5432
 ```
 
 ## Details

--- a/build/startup.sh
+++ b/build/startup.sh
@@ -13,6 +13,6 @@ do
 done
 
 cd /home/pgadapter
-COMMAND="java ${JAVA_ARGUMENTS} -cp \"pgadapter.jar:lib/*\" com.google.cloud.spanner.pgadapter.Server ${ARGUMENTS}"
+COMMAND="java ${JAVA_ARGUMENTS} -jar pgadapter.jar ${ARGUMENTS}"
 echo $COMMAND
 eval " $COMMAND"

--- a/docs/jdbc.md
+++ b/docs/jdbc.md
@@ -8,7 +8,7 @@ version 42.0.0 and higher.
 First start PGAdapter in JDBC mode by adding `-jdbc` to the command line parameters:
 
 ```shell
-wget https://storage.googleapis.com/pgadapter-jar-releases/pgadapter.jar
+wget https://storage.googleapis.com/pgadapter-jar-releases/pgadapter.tar.gz && tar -xzvf pgadapter.tar.gz
 java -jar pgadapter.jar -p my-project -i my-instance -d my-database -jdbc
 ```
 
@@ -31,5 +31,5 @@ try (Connection connection = DriverManager.getConnection("jdbc:postgresql://loca
 
 ## Running PGAdapter
 
-This example uses the pre-built jar with dependencies to run PGAdapter as a standalone process.
+This example uses the pre-built jar to run PGAdapter as a standalone process.
 See [README](../README.md) for more possibilities on how to run PGAdapter.

--- a/pom.xml
+++ b/pom.xml
@@ -62,11 +62,6 @@
 
   <dependencies>
     <dependency>
-      <groupId>com.googlecode.json-simple</groupId>
-      <artifactId>json-simple</artifactId>
-      <version>1.1.1</version>
-    </dependency>
-    <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-spanner</artifactId>
       <version>${spanner.version}</version>
@@ -77,6 +72,11 @@
       <version>42.3.4</version>
     </dependency>
     <dependency>
+      <groupId>com.googlecode.json-simple</groupId>
+      <artifactId>json-simple</artifactId>
+      <version>1.1.1</version>
+    </dependency>
+    <dependency>
       <groupId>commons-cli</groupId>
       <artifactId>commons-cli</artifactId>
       <version>1.4</version>
@@ -85,11 +85,6 @@
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-csv</artifactId>
       <version>1.9.0</version>
-    </dependency>
-    <dependency>
-      <groupId>org.json</groupId>
-      <artifactId>json</artifactId>
-      <version>20210307</version>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
@@ -116,6 +111,7 @@
       <groupId>net.java.dev.jna</groupId>
       <artifactId>jna</artifactId>
       <version>5.10.0</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>junit</groupId>
@@ -213,7 +209,7 @@
                   <goal>copy-resources</goal>
                 </goals>
                 <configuration>
-                  <outputDirectory>${basedir}/target/PGAdapter</outputDirectory>
+                  <outputDirectory>${project.build.directory}/pgadapter</outputDirectory>
                   <resources>
                     <resource>
                       <directory>resources</directory>
@@ -248,6 +244,14 @@
             <artifactId>maven-jar-plugin</artifactId>
             <configuration>
               <finalName>pgadapter/pgadapter</finalName>
+              <archive>
+                <index>false</index>
+                <manifest>
+                  <mainClass>com.google.cloud.spanner.pgadapter.Server</mainClass>
+                  <addClasspath>true</addClasspath>
+                  <classpathPrefix>lib/</classpathPrefix>
+                </manifest>
+              </archive>
             </configuration>
           </plugin>
         </plugins>


### PR DESCRIPTION
Customers should use an assembly with all dependencies in a separate
folder instead of a fat jar, as fat jars are prone to break if any of
the underlying dependencies use dynamic service loading and other forms
of dynamic class loading. The current fat jar for example breaks if it
is executed on a Google Cloud Engine VM using the default service
account of that VM, as the gRPC library will in that case attempt to
use DirectPath. That again requires certain classes to be dynamically
loaded, which breaks as not all classes and configuration files are
exactly where they are expected, after having been assembled into one
big jar.

A pre-built assembly does not have this problem, as all dependencies are
kept as separate jars including all their configuration files in their
original location. The pre-built Docker image already uses this
assembly. The downside of using an assembly instead of a fat jar, is
that it consists of more than one simple file. Customers must therefore
first untar the assembly and can then execute the pre-built jar with the
same command as before.

The assembly was already used internally by the pre-built Docker image.

Note: The **fat-jar will still be available** on Google Cloud Storage both for existing versions and new versions, and for building from source, so this will **not break** any existing customers that are already using the fat-jar.