### PR TITLE
fix: clear statement tag before auto rollback

### DIFF
--- a/src/main/java/com/google/cloud/spanner/pgadapter/wireprotocol/QueryMessage.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/wireprotocol/QueryMessage.java
@@ -140,6 +140,8 @@ public class QueryMessage extends ControlMessage {
       if (connection.getStatus() == ConnectionStatus.TRANSACTION_ABORTED) {
         transactionStatus = Status.FAILED;
         // Actively rollback the aborted transaction but still block clients
+        // Clear any statement tags, as these are not allowed for rollbacks.
+        connection.getSpannerConnection().setStatementTag(null);
         connection.getSpannerConnection().rollback();
       } else {
         transactionStatus = Status.TRANSACTION;


### PR DESCRIPTION
Clear any statement tag before executing an automatic rollback when a
transaction is aborted, as statement tags are not allowed for rollback
requests.

Fixes #146