### PR TITLE
fix: lower case single statement commands were not recognized

### DIFF
--- a/src/main/java/com/google/cloud/spanner/pgadapter/statements/IntermediateStatement.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/statements/IntermediateStatement.java
@@ -519,7 +519,7 @@ public class IntermediateStatement {
     // Before executing the statement, handle specific statements that change the transaction status
     String command = getCommand(index);
     String statement = getStatement(index);
-    if ("BEGIN".equals(command)) {
+    if ("BEGIN".equals(command) || "START".equals(command)) {
       // Executing a BEGIN statement when a transaction is already active will set the execution
       // mode to EXPLICIT_TRANSACTION. The current transaction is not committed.
       executionStatus = ExecutionStatus.EXPLICIT_TRANSACTION;

--- a/src/main/java/com/google/cloud/spanner/pgadapter/utils/StatementParser.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/utils/StatementParser.java
@@ -53,7 +53,7 @@ public class StatementParser {
         return sql.substring(0, i).toUpperCase();
       }
     }
-    return sql;
+    return sql.toUpperCase();
   }
 
   /** Returns true if the given sql string is the given command. */


### PR DESCRIPTION
Lower case single word commands were not recognized, as they were not
automatically converted to upper case by PGAdapter. This could cause
PGAdapter to skip starting or committing a transaction.