### PR TITLE
fix: error handling for extended query protocol

### DIFF
--- a/src/main/java/com/google/cloud/spanner/pgadapter/statements/CopyStatement.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/statements/CopyStatement.java
@@ -294,9 +294,9 @@ public class CopyStatement extends IntermediateStatement {
   }
 
   @Override
-  public void handleExecutionException(int index, SpannerException e) {
+  public void handleExecutionException(int index, SpannerException exception) {
     executor.shutdownNow();
-    super.handleExecutionException(index, e);
+    super.handleExecutionException(index, exception);
   }
 
   @Override

--- a/src/main/java/com/google/cloud/spanner/pgadapter/statements/IntermediatePortalStatement.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/statements/IntermediatePortalStatement.java
@@ -25,7 +25,6 @@ import com.google.cloud.spanner.pgadapter.metadata.DescribePortalMetadata;
 import com.google.cloud.spanner.pgadapter.metadata.OptionsMetadata;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
@@ -94,9 +93,9 @@ public class IntermediatePortalStatement extends IntermediatePreparedStatement {
       ResultSet statementResult = connection.executeQuery(this.statement);
       setStatementResult(0, statementResult);
       return new DescribePortalMetadata(statementResult);
-    } catch (SpannerException e) {
-      logger.log(Level.SEVERE, e, e::getMessage);
-      throw e;
+    } catch (SpannerException exception) {
+      handleExecutionExceptionAndTransactionStatus(0, exception);
+      throw exception;
     }
   }
 }

--- a/src/main/java/com/google/cloud/spanner/pgadapter/statements/IntermediatePreparedStatement.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/statements/IntermediatePreparedStatement.java
@@ -15,9 +15,11 @@
 package com.google.cloud.spanner.pgadapter.statements;
 
 import com.google.api.core.InternalApi;
+import com.google.cloud.spanner.ErrorCode;
 import com.google.cloud.spanner.ReadContext.QueryAnalyzeMode;
 import com.google.cloud.spanner.ResultSet;
 import com.google.cloud.spanner.SpannerException;
+import com.google.cloud.spanner.SpannerExceptionFactory;
 import com.google.cloud.spanner.Statement;
 import com.google.cloud.spanner.connection.AbstractStatementParser.ParsedStatement;
 import com.google.cloud.spanner.connection.AbstractStatementParser.StatementType;
@@ -32,6 +34,7 @@ import com.google.cloud.spanner.pgadapter.parsers.Parser.FormatCode;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
+import java.util.logging.Logger;
 import org.postgresql.core.Oid;
 
 /**
@@ -39,7 +42,8 @@ import org.postgresql.core.Oid;
  */
 @InternalApi
 public class IntermediatePreparedStatement extends IntermediateStatement {
-
+  private static final Logger logger =
+      Logger.getLogger(IntermediatePreparedStatement.class.getName());
   protected int[] parameterDataTypes;
   protected Statement statement;
 
@@ -77,6 +81,12 @@ public class IntermediatePreparedStatement extends IntermediateStatement {
 
   @Override
   public void execute() {
+    // TODO(230579451): Refactor to use ClientSideStatement information.
+    if (connectionHandler.getStatus() == ConnectionStatus.TRANSACTION_ABORTED) {
+      handleTransactionAborted();
+      return;
+    }
+
     // If the portal has already been described, the statement has already been executed, and we
     // don't need to do that once more.
     if (getStatementResult(0) == null) {
@@ -94,9 +104,28 @@ public class IntermediatePreparedStatement extends IntermediateStatement {
           connectionHandler.setStatus(
               connection.isInTransaction() ? ConnectionStatus.TRANSACTION : ConnectionStatus.IDLE);
         }
-      } catch (SpannerException e) {
-        handleExecutionException(0, e);
+      } catch (SpannerException exception) {
+        handleExecutionExceptionAndTransactionStatus(0, exception);
       }
+    }
+  }
+
+  private void handleTransactionAborted() {
+    // TODO(230579451): Refactor to use ClientSideStatement information.
+    String command = getCommand(0);
+    if ("COMMIT".equals(command) || "ROLLBACK".equals(command)) {
+      connectionHandler.setStatus(ConnectionStatus.IDLE);
+      // COMMIT rollbacks aborted transaction
+      commandTags.set(0, "ROLLBACK");
+      if (connection.isInTransaction()) {
+        connection.rollback();
+      }
+    } else {
+      handleExecutionException(
+          executedCount,
+          SpannerExceptionFactory.newSpannerException(
+              ErrorCode.INVALID_ARGUMENT, TRANSACTION_ABORTED_ERROR));
+      executedCount++;
     }
   }
 
@@ -130,16 +159,21 @@ public class IntermediatePreparedStatement extends IntermediateStatement {
 
   @Override
   public DescribeMetadata describe() {
-    if (this.parsedStatement.isQuery()) {
-      Statement statement = Statement.of(this.parsedStatement.getSqlWithoutComments());
-      try (ResultSet resultSet = connection.analyzeQuery(statement, QueryAnalyzeMode.PLAN)) {
-        // TODO: Remove ResultSet.next() call once this is supported in the client library.
-        // See https://github.com/googleapis/java-spanner/pull/1691
-        resultSet.next();
-        return new DescribeStatementMetadata(getParameterTypes(), resultSet);
+    try {
+      if (this.parsedStatement.isQuery()) {
+        Statement statement = Statement.of(this.parsedStatement.getSqlWithoutComments());
+        try (ResultSet resultSet = connection.analyzeQuery(statement, QueryAnalyzeMode.PLAN)) {
+          // TODO: Remove ResultSet.next() call once this is supported in the client library.
+          // See https://github.com/googleapis/java-spanner/pull/1691
+          resultSet.next();
+          return new DescribeStatementMetadata(getParameterTypes(), resultSet);
+        }
       }
+      return new DescribeStatementMetadata(getParameterTypes(), null);
+    } catch (SpannerException exception) {
+      this.handleExecutionExceptionAndTransactionStatus(0, exception);
+      throw exception;
     }
-    return new DescribeStatementMetadata(getParameterTypes(), null);
   }
 
   /**

--- a/src/main/java/com/google/cloud/spanner/pgadapter/statements/IntermediateStatement.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/statements/IntermediateStatement.java
@@ -337,18 +337,19 @@ public class IntermediateStatement {
   /**
    * Clean up and save metadata when an exception occurs.
    *
-   * @param e The exception to store.
+   * @param exception The exception to store.
    */
-  protected void handleExecutionException(int index, SpannerException e) {
-    this.exceptions[index] = e;
+  protected void handleExecutionException(int index, SpannerException exception) {
+    this.exceptions[index] = exception;
     this.hasMoreData[index] = false;
   }
 
-  private void handleExecutionExceptionAndTransactionStatus(int index, SpannerException e) {
+  protected void handleExecutionExceptionAndTransactionStatus(
+      int index, SpannerException exception) {
     if (executionStatus == ExecutionStatus.EXPLICIT_TRANSACTION) {
       connectionHandler.setStatus(ConnectionStatus.TRANSACTION_ABORTED);
     }
-    handleExecutionException(index, e);
+    handleExecutionException(index, exception);
   }
 
   /** Execute the SQL statement, storing metadata. */

--- a/src/main/java/com/google/cloud/spanner/pgadapter/wireprotocol/ExecuteMessage.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/wireprotocol/ExecuteMessage.java
@@ -84,8 +84,8 @@ public class ExecuteMessage extends ControlMessage {
       try {
         this.sendSpannerResult(0, this.statement, QueryMode.EXTENDED, this.maxRows);
         this.outputStream.flush();
-      } catch (Exception e) {
-        handleError(e);
+      } catch (Exception exception) {
+        handleError(exception);
       }
     }
     this.connection.cleanUp(this.statement);

--- a/src/test/java/com/google/cloud/spanner/pgadapter/ErrorHandlingTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/ErrorHandlingTest.java
@@ -1,0 +1,125 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.cloud.spanner.pgadapter;
+
+import static com.google.cloud.spanner.pgadapter.statements.IntermediateStatement.TRANSACTION_ABORTED_ERROR;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+import com.google.cloud.spanner.MockSpannerServiceImpl.StatementResult;
+import com.google.cloud.spanner.Statement;
+import com.google.spanner.v1.CommitRequest;
+import com.google.spanner.v1.RollbackRequest;
+import io.grpc.Status;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+
+@RunWith(Parameterized.class)
+public class ErrorHandlingTest extends AbstractMockServerTest {
+  private static final String INVALID_SELECT = "SELECT * FROM unknown_table";
+
+  @Parameter public String preferQueryMode;
+
+  @Parameters(name = "preferQueryMode = {0}")
+  public static Object[] data() {
+    return new Object[] {"extended", "simple"};
+  }
+
+  @BeforeClass
+  public static void loadPgJdbcDriver() throws Exception {
+    // Make sure the PG JDBC driver is loaded.
+    Class.forName("org.postgresql.Driver");
+  }
+
+  @BeforeClass
+  public static void setupErrorResults() {
+    mockSpanner.putStatementResult(
+        StatementResult.exception(
+            Statement.of(INVALID_SELECT), Status.NOT_FOUND.asRuntimeException()));
+  }
+
+  private String createUrl() {
+    return String.format(
+        "jdbc:postgresql://localhost:%d/?preferQueryMode=%s",
+        pgServer.getLocalPort(), preferQueryMode);
+  }
+
+  @Test
+  public void testInvalidQueryNoTransaction() throws SQLException {
+    try (Connection connection = DriverManager.getConnection(createUrl())) {
+      SQLException exception =
+          assertThrows(
+              SQLException.class, () -> connection.createStatement().executeQuery(INVALID_SELECT));
+      assertTrue(exception.getMessage(), exception.getMessage().contains("NOT_FOUND"));
+
+      // The connection should be usable, as there was no transaction.
+      assertTrue(connection.createStatement().execute("SELECT 1"));
+    }
+  }
+
+  @Test
+  public void testInvalidQueryInTransaction() throws SQLException {
+    try (Connection connection = DriverManager.getConnection(createUrl())) {
+      connection.setAutoCommit(false);
+
+      SQLException exception =
+          assertThrows(
+              SQLException.class, () -> connection.createStatement().executeQuery(INVALID_SELECT));
+      assertTrue(exception.getMessage(), exception.getMessage().contains("NOT_FOUND"));
+
+      // The connection should be in the aborted state.
+      exception =
+          assertThrows(SQLException.class, () -> connection.createStatement().execute("SELECT 1"));
+      assertTrue(
+          exception.getMessage(), exception.getMessage().contains(TRANSACTION_ABORTED_ERROR));
+
+      // Rolling back the transaction should bring the connection back to a usable state.
+      connection.rollback();
+      assertTrue(connection.createStatement().execute("SELECT 1"));
+    }
+  }
+
+  @Test
+  public void testCommitAbortedTransaction() throws SQLException {
+    try (Connection connection = DriverManager.getConnection(createUrl())) {
+      connection.setAutoCommit(false);
+
+      SQLException exception =
+          assertThrows(
+              SQLException.class, () -> connection.createStatement().executeQuery(INVALID_SELECT));
+      assertTrue(exception.getMessage(), exception.getMessage().contains("NOT_FOUND"));
+
+      // The connection should be in the aborted state.
+      exception =
+          assertThrows(SQLException.class, () -> connection.createStatement().execute("SELECT 1"));
+      assertTrue(
+          exception.getMessage(), exception.getMessage().contains(TRANSACTION_ABORTED_ERROR));
+
+      // Committing the transaction will actually execute a rollback.
+      connection.commit();
+    }
+    // Check that we only received a rollback and no commit.
+    assertEquals(1, mockSpanner.countRequestsOfType(RollbackRequest.class));
+    assertEquals(0, mockSpanner.countRequestsOfType(CommitRequest.class));
+  }
+}

--- a/src/test/java/com/google/cloud/spanner/pgadapter/ProtocolTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/ProtocolTest.java
@@ -1130,8 +1130,8 @@ public class ProtocolTest {
 
     String expectedSQL = "INSERT INTO users (name) VALUES ('test')";
 
-    when(connection.isInTransaction()).thenReturn(true);
     when(connectionHandler.getSpannerConnection()).thenReturn(connection);
+    when(connectionHandler.getStatus()).thenReturn(ConnectionStatus.TRANSACTION);
     when(statementResult.getResultType()).thenReturn(ResultType.UPDATE_COUNT);
     when(statementResult.getUpdateCount()).thenReturn(1L);
     when(connection.execute(Statement.of(expectedSQL))).thenReturn(statementResult);


### PR DESCRIPTION
Fixes the error handling for the extended query protocol, so it correctly returns the `Transaction aborted` state after an error in a transaction.