### PR TITLE
build: execute tests on windows

### DIFF
--- a/.github/workflows/units.yaml
+++ b/.github/workflows/units.yaml
@@ -1,0 +1,36 @@
+on:
+pull_request:
+name: units
+jobs:
+  ubuntu:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        java: [8, 11, 17]
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-java@v3
+        with:
+          distribution: zulu
+          java-version: ${{matrix.java}}
+      - run: java -version
+      - uses: actions/setup-go@v2
+        with:
+          go-version: '^1.17.7'
+      - run: go version
+      - run: mvn -B test -Ptest-all
+  windows:
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        java: [8, 11, 17]
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-java@v3
+        with:
+          distribution: zulu
+          java-version: ${{matrix.java}}
+      - run: java -version
+      - run: mvn -B test

--- a/.github/workflows/units.yaml
+++ b/.github/workflows/units.yaml
@@ -1,5 +1,5 @@
 on:
-pull_request:
+  pull_request:
 name: units
 jobs:
   ubuntu:


### PR DESCRIPTION
Adds a GitHub Actions workflow for unit testing on different versions of Java on Ubuntu and Windows.