### PR TITLE
build: exclude generated code from test coverage

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -314,6 +314,11 @@
             </goals>
           </execution>
         </executions>
+        <configuration>
+          <excludes>
+            <exclude>com/google/cloud/spanner/pgadapter/parsers/copy/**/*</exclude>
+          </excludes>
+        </configuration>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Excludes packages that contain only generated code from the test coverage reports.