### PR TITLE
cleanup: use ClientSideStatementType instead of string comparison

### DIFF
--- a/src/main/java/com/google/cloud/spanner/pgadapter/statements/IntermediateStatement.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/statements/IntermediateStatement.java
@@ -28,6 +28,7 @@ import com.google.cloud.spanner.connection.AbstractStatementParser.StatementType
 import com.google.cloud.spanner.connection.Connection;
 import com.google.cloud.spanner.connection.PostgreSQLStatementParser;
 import com.google.cloud.spanner.connection.StatementResult;
+import com.google.cloud.spanner.connection.StatementResult.ClientSideStatementType;
 import com.google.cloud.spanner.connection.TransactionMode;
 import com.google.cloud.spanner.pgadapter.ConnectionHandler;
 import com.google.cloud.spanner.pgadapter.ConnectionHandler.ConnectionStatus;
@@ -362,8 +363,8 @@ public class IntermediateStatement {
       maybeStartImplicitTransaction(executedCount);
 
       if (connectionHandler.getStatus() == ConnectionStatus.TRANSACTION_ABORTED
-          && !"ROLLBACK".equals(getCommand(executedCount))
-          && !"COMMIT".equals(getCommand(executedCount))) {
+          && !isRollback(executedCount)
+          && !isCommit(executedCount)) {
         handleExecutionException(
             executedCount,
             SpannerExceptionFactory.newSpannerException(
@@ -515,11 +516,28 @@ public class IntermediateStatement {
         .allMatch(type -> type == StatementType.UPDATE);
   }
 
+  private boolean isBegin(int index) {
+    return getStatements().get(index).getType() == StatementType.CLIENT_SIDE
+        && getStatements().get(index).getClientSideStatementType() == ClientSideStatementType.BEGIN;
+  }
+
+  private boolean isCommit(int index) {
+    return getStatements().get(index).getType() == StatementType.CLIENT_SIDE
+        && getStatements().get(index).getClientSideStatementType()
+            == ClientSideStatementType.COMMIT;
+  }
+
+  private boolean isRollback(int index) {
+    return getStatements().get(index).getType() == StatementType.CLIENT_SIDE
+        && getStatements().get(index).getClientSideStatementType()
+            == ClientSideStatementType.ROLLBACK;
+  }
+
   private void executeSingleStatement(int index) {
     // Before executing the statement, handle specific statements that change the transaction status
     String command = getCommand(index);
     String statement = getStatement(index);
-    if ("BEGIN".equals(command) || "START".equals(command)) {
+    if (isBegin(index)) {
       // Executing a BEGIN statement when a transaction is already active will set the execution
       // mode to EXPLICIT_TRANSACTION. The current transaction is not committed.
       executionStatus = ExecutionStatus.EXPLICIT_TRANSACTION;
@@ -528,7 +546,7 @@ public class IntermediateStatement {
       }
       return;
     }
-    if ("COMMIT".equals(command) || "ROLLBACK".equals(command)) {
+    if (isCommit(index) || isRollback(index)) {
       if (connectionHandler.getStatus() == ConnectionStatus.TRANSACTION_ABORTED) {
         connectionHandler.setStatus(ConnectionStatus.IDLE);
         // COMMIT rollbacks aborted transaction


### PR DESCRIPTION
Use `ClientSideStatementType` instead of string comparison to recognize specific transaction commands.