### PR TITLE
test: ignore tests that can fail because of errors in Connection.close()

### DIFF
--- a/src/test/java/com/google/cloud/spanner/pgadapter/AbstractMockServerTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/AbstractMockServerTest.java
@@ -352,7 +352,6 @@ public abstract class AbstractMockServerTest {
    * instance for a test case. This method will ignore any errors and retry if closing fails.
    */
   protected void closeSpannerPool() {
-    SpannerException exception = null;
     for (int attempt = 0; attempt < 1000; attempt++) {
       try {
         SpannerPool.closeSpannerPool();
@@ -363,10 +362,8 @@ public abstract class AbstractMockServerTest {
         } catch (InterruptedException interruptedException) {
           throw SpannerExceptionFactory.propagateInterrupt(interruptedException);
         }
-        exception = e;
       }
     }
-    throw exception;
   }
 
   @Before

--- a/src/test/java/com/google/cloud/spanner/pgadapter/AbstractMockServerTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/AbstractMockServerTest.java
@@ -352,6 +352,7 @@ public abstract class AbstractMockServerTest {
    * instance for a test case. This method will ignore any errors and retry if closing fails.
    */
   protected void closeSpannerPool() {
+    SpannerException exception = null;
     for (int attempt = 0; attempt < 1000; attempt++) {
       try {
         SpannerPool.closeSpannerPool();
@@ -362,8 +363,10 @@ public abstract class AbstractMockServerTest {
         } catch (InterruptedException interruptedException) {
           throw SpannerExceptionFactory.propagateInterrupt(interruptedException);
         }
+        exception = e;
       }
     }
+    throw exception;
   }
 
   @Before

--- a/src/test/java/com/google/cloud/spanner/pgadapter/JdbcSimpleModeMockServerTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/JdbcSimpleModeMockServerTest.java
@@ -46,6 +46,7 @@ import java.util.List;
 import java.util.TimeZone;
 import java.util.stream.Collectors;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -126,6 +127,7 @@ public class JdbcSimpleModeMockServerTest extends AbstractMockServerTest {
   }
 
   @Test
+  @Ignore("Skip until https://github.com/googleapis/java-spanner/pull/1877 has been released")
   public void testWrongDialect() {
     // Let the mock server respond with the Google SQL dialect instead of PostgreSQL. The
     // connection should be gracefully rejected. Close all open pooled Spanner objects so we know

--- a/src/test/java/com/google/cloud/spanner/pgadapter/golang/PgxMockServerTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/golang/PgxMockServerTest.java
@@ -39,6 +39,7 @@ import com.google.spanner.v1.TypeCode;
 import java.io.IOException;
 import java.util.List;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -254,6 +255,7 @@ public class PgxMockServerTest extends AbstractMockServerTest {
   }
 
   @Test
+  @Ignore("Skip until https://github.com/googleapis/java-spanner/pull/1877 has been released")
   public void testWrongDialect() {
     // Let the mock server respond with the Google SQL dialect instead of PostgreSQL. The
     // connection should be gracefully rejected. Close all open pooled Spanner objects so we know

--- a/src/test/java/com/google/cloud/spanner/pgadapter/golang/PgxSimpleModeMockServerTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/golang/PgxSimpleModeMockServerTest.java
@@ -37,6 +37,7 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -208,6 +209,7 @@ public class PgxSimpleModeMockServerTest extends AbstractMockServerTest {
   }
 
   @Test
+  @Ignore("Skip until https://github.com/googleapis/java-spanner/pull/1877 has been released")
   public void testWrongDialect() {
     // Let the mock server respond with the Google SQL dialect instead of PostgreSQL. The
     // connection should be gracefully rejected. Close all open pooled Spanner objects so we know


### PR DESCRIPTION
Skip tests that can fail because of errors while closing the connection. These can be re-enabled when https://github.com/googleapis/java-spanner/pull/1877 has been merged.