### PR TITLE
build: execute integration tests on Github Actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -147,7 +147,7 @@ jobs:
     runs-on: ubuntu-latest
     # Only releases on the postgresql-dialect branch
     if: github.head_ref == 'postgresql-dialect'
-    needs: [ units, lint, clirr, integration, e2e-psql-v11, e2e-psql-v12, e2e-psql-v13 ]
+    needs: [ units, lint, clirr, e2e-psql-v11, e2e-psql-v12, e2e-psql-v13 ]
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-java@v1
@@ -167,7 +167,7 @@ jobs:
     runs-on: ubuntu-latest
     # Only releases on the postgresql-dialect branch
     if: github.head_ref == 'postgresql-dialect'
-    needs: [ units, lint, clirr, integration, e2e-psql-v11, e2e-psql-v12, e2e-psql-v13 ]
+    needs: [ units, lint, clirr, e2e-psql-v11, e2e-psql-v12, e2e-psql-v13 ]
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-java@v1

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,19 +33,6 @@ jobs:
         go-version: '^1.17.7'
     - run: go version
     - run: .ci/run-with-credentials.sh units
-  integration:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-java@v1
-      with:
-        java-version: 8
-    - run: java -version
-    - uses: actions/setup-go@v2
-      with:
-        go-version: '^1.17.7'
-    - run: go version
-    - run: .ci/run-with-credentials.sh integration
   lint:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -1,7 +1,5 @@
 on:
   pull_request:
-  # This allows manual activation of this action for testing.
-  workflow_dispatch:
 name: integration
 env:
   GOOGLE_CLOUD_PROJECT: "span-cloud-testing"
@@ -32,12 +30,12 @@ jobs:
         with:
           distribution: zulu
           java-version: 8
-        run: java -version
+      - run: java -version
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
           go-version: '^1.17.7'
-        run: go version
+      - run: go version
       - name: Setup GCloud
         uses: google-github-actions/setup-gcloud@v0
         with:

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -1,0 +1,55 @@
+on:
+  pull_request:
+name: integration
+env:
+  GOOGLE_CLOUD_PROJECT: "span-cloud-testing"
+  GOOGLE_CLOUD_INSTANCE: "pgadapter-testing"
+  GOOGLE_CLOUD_DATABASE: "testdb_integration"
+  GOOGLE_CLOUD_ENDPOINT: "spanner.googleapis.com"
+jobs:
+  check-env:
+    outputs:
+      has-key: ${{ steps.project-id.outputs.defined }}
+    runs-on: ubuntu-latest
+    steps:
+      - id: project-id
+        env:
+          GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
+        if: "${{ env.GCP_PROJECT_ID != '' }}"
+        run: echo "::set-output name=defined::true"
+
+  test:
+    needs: [check-env]
+    if: needs.check-env.outputs.has-key == 'true'
+    timeout-minutes: 30
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup Java
+        uses: actions/setup-java@v3
+        with:
+          distribution: zulu
+          java-version: 8
+        run: java -version
+      - name: Setup Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: '^1.17.7'
+        run: go version
+      - name: Setup GCloud
+        uses: google-github-actions/setup-gcloud@v0
+        with:
+          project_id: ${{ secrets.GCP_PROJECT_ID }}
+          service_account_key: ${{ secrets.JSON_SERVICE_ACCOUNT_CREDENTIALS }}
+          export_default_credentials: true
+      - name: Run tests
+        run: mvn verify -Ptest-all -B -Dclirr.skip=true -DskipITs=false -DPG_ADAPTER_HOST="https://$GOOGLE_CLOUD_ENDPOINT" -DPG_ADAPTER_INSTANCE="$GOOGLE_CLOUD_INSTANCE" -DPG_ADAPTER_DATABASE="$GOOGLE_CLOUD_DATABASE"
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v2
+        with:
+          directory: ./target/site/jacoco
+          fail_ci_if_error: true
+          flags: unittests
+          name: codecov-umbrella
+          path_to_write_report: ./coverage/codecov_report.txt
+          verbose: true

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -49,9 +49,9 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v2
         with:
-          directory: ./target/site/jacoco
+          directory: ./target/site/jacoco-merged-test-coverage-report
           fail_ci_if_error: true
-          flags: unittests
+          flags: all_tests
           name: codecov-umbrella
           path_to_write_report: ./coverage/codecov_report.txt
           verbose: true

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -1,5 +1,7 @@
 on:
   pull_request:
+  # This allows manual activation of this action for testing.
+  workflow_dispatch:
 name: integration
 env:
   GOOGLE_CLOUD_PROJECT: "span-cloud-testing"

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -36,14 +36,16 @@ jobs:
         with:
           go-version: '^1.17.7'
       - run: go version
+      - name: Run unit tests
+        run: mvn test -B -Ptest-all
       - name: Setup GCloud
         uses: google-github-actions/setup-gcloud@v0
         with:
           project_id: ${{ secrets.GCP_PROJECT_ID }}
           service_account_key: ${{ secrets.JSON_SERVICE_ACCOUNT_CREDENTIALS }}
           export_default_credentials: true
-      - name: Run tests
-        run: mvn verify -Ptest-all -B -Dclirr.skip=true -DskipITs=false -DPG_ADAPTER_HOST="https://$GOOGLE_CLOUD_ENDPOINT" -DPG_ADAPTER_INSTANCE="$GOOGLE_CLOUD_INSTANCE" -DPG_ADAPTER_DATABASE="$GOOGLE_CLOUD_DATABASE"
+      - name: Run integration tests
+        run: mvn verify -B -Dclirr.skip=true -DskipITs=false -DPG_ADAPTER_HOST="https://$GOOGLE_CLOUD_ENDPOINT" -DPG_ADAPTER_INSTANCE="$GOOGLE_CLOUD_INSTANCE" -DPG_ADAPTER_DATABASE="$GOOGLE_CLOUD_DATABASE"
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v2
         with:

--- a/.github/workflows/units.yaml
+++ b/.github/workflows/units.yaml
@@ -20,15 +20,6 @@ jobs:
           go-version: '^1.17.7'
       - run: go version
       - run: mvn -B test -Ptest-all
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v2
-        with:
-          directory: ./target/site/jacoco
-          fail_ci_if_error: true
-          flags: unittests
-          name: codecov-umbrella
-          path_to_write_report: ./coverage/codecov_report.txt
-          verbose: true
   windows:
     runs-on: windows-latest
     strategy:

--- a/pom.xml
+++ b/pom.xml
@@ -286,6 +286,7 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <version>3.0.0-M5</version>
         <configuration>
+          <argLine>${surefire.jacoco.args}</argLine>
           <excludedGroups>${excludedTests}</excludedGroups>
           <reportNameSuffix>sponge_log</reportNameSuffix>
           <systemProperties>
@@ -305,17 +306,83 @@
             <goals>
               <goal>prepare-agent</goal>
             </goals>
+            <configuration>
+              <destFile>${project.build.directory}/jacoco-output/jacoco-unit-tests.exec</destFile>
+              <propertyName>surefire.jacoco.args</propertyName>
+            </configuration>
           </execution>
           <execution>
-            <id>report</id>
+            <id>after-unit-test-execution</id>
             <phase>test</phase>
             <goals>
               <goal>report</goal>
             </goals>
+            <configuration>
+              <dataFile>${project.build.directory}/jacoco-output/jacoco-unit-tests.exec</dataFile>
+              <outputDirectory>${project.reporting.outputDirectory}/jacoco-unit-test-coverage-report</outputDirectory>
+            </configuration>
           </execution>
+
+          <execution>
+            <id>before-integration-test-execution</id>
+            <phase>pre-integration-test</phase>
+            <goals>
+              <goal>prepare-agent</goal>
+            </goals>
+            <configuration>
+              <destFile>${project.build.directory}/jacoco-output/jacoco-integration-tests.exec</destFile>
+              <propertyName>failsafe.jacoco.args</propertyName>
+            </configuration>
+          </execution>
+          <execution>
+            <id>after-integration-test-execution</id>
+            <phase>post-integration-test</phase>
+            <goals>
+              <goal>report</goal>
+            </goals>
+            <configuration>
+              <dataFile>${project.build.directory}/jacoco-output/jacoco-integration-tests.exec</dataFile>
+              <outputDirectory>${project.reporting.outputDirectory}/jacoco-integration-test-coverage-report</outputDirectory>
+            </configuration>
+          </execution>
+          <execution>
+            <id>merge-unit-and-integration</id>
+            <phase>post-integration-test</phase>
+            <goals>
+              <goal>merge</goal>
+            </goals>
+            <configuration>
+              <fileSets>
+                <fileSet>
+                  <directory>${project.build.directory}/jacoco-output/</directory>
+                  <includes>
+                    <include>*.exec</include>
+                  </includes>
+                </fileSet>
+              </fileSets>
+              <destFile>${project.build.directory}/jacoco-output/merged.exec</destFile>
+            </configuration>
+          </execution>
+          <execution>
+            <id>create-merged-report</id>
+            <phase>post-integration-test</phase>
+            <goals>
+              <goal>report</goal>
+            </goals>
+            <configuration>
+              <dataFile>${project.build.directory}/jacoco-output/merged.exec</dataFile>
+              <outputDirectory>${project.reporting.outputDirectory}/jacoco-merged-test-coverage-report</outputDirectory>
+            </configuration>
+          </execution>
+<!--          <execution>-->
+<!--            <id>report</id>-->
+<!--            <phase>test</phase>-->
+<!--            <goals>-->
+<!--              <goal>report</goal>-->
+<!--            </goals>-->
+<!--          </execution>-->
         </executions>
         <configuration>
-          <append>true</append>
           <excludes>
             <exclude>com/google/cloud/spanner/pgadapter/parsers/copy/**/*</exclude>
           </excludes>
@@ -334,6 +401,7 @@
           </execution>
         </executions>
         <configuration>
+          <argLine>${failsafe.jacoco.args}</argLine>
           <skipITs>${skipITs}</skipITs>
         </configuration>
       </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -374,13 +374,6 @@
               <outputDirectory>${project.reporting.outputDirectory}/jacoco-merged-test-coverage-report</outputDirectory>
             </configuration>
           </execution>
-<!--          <execution>-->
-<!--            <id>report</id>-->
-<!--            <phase>test</phase>-->
-<!--            <goals>-->
-<!--              <goal>report</goal>-->
-<!--            </goals>-->
-<!--          </execution>-->
         </executions>
         <configuration>
           <excludes>

--- a/pom.xml
+++ b/pom.xml
@@ -315,6 +315,7 @@
           </execution>
         </executions>
         <configuration>
+          <append>true</append>
           <excludes>
             <exclude>com/google/cloud/spanner/pgadapter/parsers/copy/**/*</exclude>
           </excludes>


### PR DESCRIPTION
Execute the integration tests on Github Actions so the test coverage report can include both unit and integration test coverage. Executing the tests on Github Actions also reduces the dependency on the custom bash script that is currently used for most tests.