### PR TITLE
build: rename integration test job

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -18,7 +18,7 @@ jobs:
         if: "${{ env.GCP_PROJECT_ID != '' }}"
         run: echo "::set-output name=defined::true"
 
-  test:
+  integration-test:
     needs: [check-env]
     if: needs.check-env.outputs.has-key == 'true'
     timeout-minutes: 30


### PR DESCRIPTION
Rename the integration test job so it is easier to reference in the Github configuration.