### PR TITLE
fix: unix domain sockets failed for msg size > 8Kb on MacOS

### DIFF
--- a/.github/workflows/units.yaml
+++ b/.github/workflows/units.yaml
@@ -56,3 +56,32 @@ jobs:
           python-version: '3.9'
       - run: pip install -r ./src/test/python/requirements.txt
       - run: mvn -B test
+  macos:
+    runs-on: macos-latest
+    env:
+      DOTNET_NOLOGO: true
+    strategy:
+      fail-fast: false
+      matrix:
+        java: [8, 11, 17]
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-java@v3
+        with:
+          distribution: zulu
+          java-version: ${{matrix.java}}
+      - run: java -version
+      - uses: actions/setup-go@v2
+        with:
+          go-version: '^1.17.7'
+      - run: go version
+      - uses: actions/setup-python@v3
+        with:
+          python-version: '3.9'
+      - run: python --version
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v3
+        with:
+          python-version: '3.9'
+      - run: pip install -r ./src/test/python/requirements.txt
+      - run: mvn -B test -Ptest-all

--- a/.github/workflows/units.yaml
+++ b/.github/workflows/units.yaml
@@ -25,10 +25,6 @@ jobs:
         with:
           python-version: '3.9'
       - run: python --version
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v3
-        with:
-          python-version: '3.9'
       - run: pip install -r ./src/test/python/requirements.txt
       - run: mvn -B test -Ptest-all
   windows:
@@ -50,10 +46,6 @@ jobs:
         with:
           python-version: '3.9'
       - run: python --version
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v3
-        with:
-          python-version: '3.9'
       - run: pip install -r ./src/test/python/requirements.txt
       - run: mvn -B test
   macos:
@@ -79,9 +71,8 @@ jobs:
         with:
           python-version: '3.9'
       - run: python --version
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v3
-        with:
-          python-version: '3.9'
       - run: pip install -r ./src/test/python/requirements.txt
+      - uses: actions/setup-dotnet@v2
+        with:
+          dotnet-version: '6.0.x'
       - run: mvn -B test -Ptest-all

--- a/src/main/java/com/google/cloud/spanner/pgadapter/ConnectionHandler.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/ConnectionHandler.java
@@ -189,9 +189,10 @@ public class ConnectionHandler extends Thread {
                 getName(), socket.getInetAddress().getHostAddress()));
 
     try (DataInputStream input =
-            new DataInputStream(new BufferedInputStream(this.socket.getInputStream()));
+            new DataInputStream(new BufferedInputStream(this.socket.getInputStream(), 1 << 16));
         DataOutputStream output =
-            new DataOutputStream(new BufferedOutputStream(this.socket.getOutputStream()))) {
+            new DataOutputStream(
+                new BufferedOutputStream(this.socket.getOutputStream(), 1 << 16))) {
       if (!server.getOptions().disableLocalhostCheck()
           && !this.socket.getInetAddress().isAnyLocalAddress()
           && !this.socket.getInetAddress().isLoopbackAddress()) {

--- a/src/main/java/com/google/cloud/spanner/pgadapter/ConnectionHandler.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/ConnectionHandler.java
@@ -68,6 +68,7 @@ import javax.annotation.Nullable;
 @InternalApi
 public class ConnectionHandler extends Thread {
   private static final Logger logger = Logger.getLogger(ConnectionHandler.class.getName());
+  private static final int SOCKET_BUFFER_SIZE = 1 << 16;
   private static final AtomicLong CONNECTION_HANDLER_ID_GENERATOR = new AtomicLong(0L);
   private static final String CHANNEL_PROVIDER_PROPERTY = "CHANNEL_PROVIDER";
 
@@ -189,10 +190,11 @@ public class ConnectionHandler extends Thread {
                 getName(), socket.getInetAddress().getHostAddress()));
 
     try (DataInputStream input =
-            new DataInputStream(new BufferedInputStream(this.socket.getInputStream(), 1 << 16));
+            new DataInputStream(
+                new BufferedInputStream(this.socket.getInputStream(), SOCKET_BUFFER_SIZE));
         DataOutputStream output =
             new DataOutputStream(
-                new BufferedOutputStream(this.socket.getOutputStream(), 1 << 16))) {
+                new BufferedOutputStream(this.socket.getOutputStream(), SOCKET_BUFFER_SIZE))) {
       if (!server.getOptions().disableLocalhostCheck()
           && !this.socket.getInetAddress().isAnyLocalAddress()
           && !this.socket.getInetAddress().isLoopbackAddress()) {

--- a/src/main/java/com/google/cloud/spanner/pgadapter/ProxyServer.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/ProxyServer.java
@@ -22,12 +22,8 @@ import com.google.cloud.spanner.pgadapter.ConnectionHandler.QueryMode;
 import com.google.cloud.spanner.pgadapter.metadata.OptionsMetadata;
 import com.google.cloud.spanner.pgadapter.metadata.OptionsMetadata.TextFormat;
 import com.google.cloud.spanner.pgadapter.statements.IntermediateStatement;
-import com.google.cloud.spanner.pgadapter.wireoutput.ErrorResponse;
-import com.google.cloud.spanner.pgadapter.wireoutput.ErrorResponse.Severity;
 import com.google.cloud.spanner.pgadapter.wireprotocol.WireMessage;
 import com.google.common.collect.ImmutableList;
-import java.io.BufferedOutputStream;
-import java.io.DataOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.net.ServerSocket;
@@ -245,12 +241,7 @@ public class ProxyServer extends AbstractApiService {
     awaitRunning();
     try {
       while (isRunning()) {
-        Socket socket = serverSocket.accept();
-        try {
-          createConnectionHandler(socket);
-        } catch (SpannerException exception) {
-          handleConnectionError(exception, socket);
-        }
+        createConnectionHandler(serverSocket.accept());
       }
     } catch (SocketException e) {
       // This is a normal exception, as this will occur when Server#stopServer() is called.
@@ -263,34 +254,6 @@ public class ProxyServer extends AbstractApiService {
     } finally {
       logger.log(Level.INFO, () -> String.format("Socket %s stopped", serverSocket));
       stoppedLatch.countDown();
-    }
-  }
-
-  /**
-   * Sends a message to the client that the connection could not be established.
-   *
-   * @param exception The exception that caused the connection request to fail.
-   * @param socket The socket that was created for the connection.
-   */
-  private void handleConnectionError(SpannerException exception, Socket socket) {
-    logger.log(
-        Level.SEVERE,
-        exception,
-        () ->
-            String.format(
-                "Something went wrong in establishing a Spanner connection: %s",
-                exception.getMessage()));
-    try {
-      DataOutputStream output =
-          new DataOutputStream(new BufferedOutputStream(socket.getOutputStream(), 1 << 16));
-      new ErrorResponse(output, exception, ErrorResponse.State.ConnectionException, Severity.FATAL)
-          .send();
-      output.flush();
-    } catch (Exception e) {
-      logger.log(
-          Level.WARNING,
-          e,
-          () -> String.format("Failed to send fatal error message to client: %s", e.getMessage()));
     }
   }
 

--- a/src/main/java/com/google/cloud/spanner/pgadapter/ProxyServer.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/ProxyServer.java
@@ -282,7 +282,7 @@ public class ProxyServer extends AbstractApiService {
                 exception.getMessage()));
     try {
       DataOutputStream output =
-          new DataOutputStream(new BufferedOutputStream(socket.getOutputStream()));
+          new DataOutputStream(new BufferedOutputStream(socket.getOutputStream(), 1 << 16));
       new ErrorResponse(output, exception, ErrorResponse.State.ConnectionException, Severity.FATAL)
           .send();
       output.flush();

--- a/src/test/java/com/google/cloud/spanner/pgadapter/CopyInMockServerTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/CopyInMockServerTest.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.assertTrue;
 
 import com.google.cloud.spanner.MockSpannerServiceImpl.SimulatedExecutionTime;
 import com.google.cloud.spanner.MockSpannerServiceImpl.StatementResult;
+import com.google.cloud.spanner.pgadapter.metadata.OptionsMetadata;
 import com.google.protobuf.ListValue;
 import com.google.protobuf.Value;
 import com.google.spanner.v1.CommitRequest;
@@ -33,6 +34,7 @@ import com.google.spanner.v1.Type;
 import com.google.spanner.v1.TypeCode;
 import io.grpc.Status;
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.StringReader;
 import java.nio.charset.StandardCharsets;
@@ -44,7 +46,10 @@ import java.util.List;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+import org.postgresql.PGConnection;
 import org.postgresql.copy.CopyIn;
 import org.postgresql.copy.CopyManager;
 import org.postgresql.core.BaseConnection;
@@ -53,8 +58,16 @@ import org.postgresql.core.QueryExecutorBase;
 import org.postgresql.core.v3.CopyOperationImpl;
 import org.postgresql.core.v3.QueryExecutorImpl;
 
-@RunWith(JUnit4.class)
+@RunWith(Parameterized.class)
 public class CopyInMockServerTest extends AbstractMockServerTest {
+
+  @Parameter public boolean useDomainSocket;
+
+  @Parameters(name = "useDomainSocket = {0}")
+  public static Object[] data() {
+    OptionsMetadata options = new OptionsMetadata(new String[] {"-p p", "-i i"});
+    return options.isDomainSocketEnabled() ? new Object[] {true, false} : new Object[] {false};
+  }
 
   @BeforeClass
   public static void loadPgJdbcDriver() throws Exception {
@@ -67,6 +80,13 @@ public class CopyInMockServerTest extends AbstractMockServerTest {
    * mode for queries and DML statements.
    */
   private String createUrl() {
+    if (useDomainSocket) {
+      return String.format(
+          "jdbc:postgresql://localhost/?"
+              + "socketFactory=org.newsclub.net.unix.AFUNIXSocketFactory$FactoryArg"
+              + "&socketFactoryArg=/tmp/.s.PGSQL.%d",
+          pgServer.getLocalPort());
+    }
     return String.format("jdbc:postgresql://localhost:%d/", pgServer.getLocalPort());
   }
 
@@ -94,6 +114,21 @@ public class CopyInMockServerTest extends AbstractMockServerTest {
     Mutation mutation = commitRequest.getMutations(0);
     assertEquals(OperationCase.INSERT, mutation.getOperationCase());
     assertEquals(3, mutation.getInsert().getValuesCount());
+  }
+
+  @Test
+  public void testCopyIn_Small() throws SQLException, IOException {
+    setupCopyInformationSchemaResults();
+
+    try (Connection connection = DriverManager.getConnection(createUrl())) {
+      PGConnection pgConnection = connection.unwrap(PGConnection.class);
+      CopyManager copyManager = pgConnection.getCopyAPI();
+      long copyCount =
+          copyManager.copyIn(
+              "copy all_types from stdin;",
+              new FileInputStream("./src/test/resources/all_types_data_small.txt"));
+      assertEquals(100L, copyCount);
+    }
   }
 
   @Test
@@ -365,6 +400,64 @@ public class CopyInMockServerTest extends AbstractMockServerTest {
                 .to("users")
                 .build(),
             resultSet));
+    com.google.spanner.v1.ResultSet allTypesResultSet =
+        com.google.spanner.v1.ResultSet.newBuilder()
+            .addRows(
+                ListValue.newBuilder()
+                    .addValues(Value.newBuilder().setStringValue("col_bigint").build())
+                    .addValues(Value.newBuilder().setStringValue("bigint").build())
+                    .build())
+            .addRows(
+                ListValue.newBuilder()
+                    .addValues(Value.newBuilder().setStringValue("col_bool").build())
+                    .addValues(Value.newBuilder().setStringValue("boolean").build())
+                    .build())
+            .addRows(
+                ListValue.newBuilder()
+                    .addValues(Value.newBuilder().setStringValue("col_bytea").build())
+                    .addValues(Value.newBuilder().setStringValue("bytea").build())
+                    .build())
+            .addRows(
+                ListValue.newBuilder()
+                    .addValues(Value.newBuilder().setStringValue("col_float8").build())
+                    .addValues(Value.newBuilder().setStringValue("float8").build())
+                    .build())
+            .addRows(
+                ListValue.newBuilder()
+                    .addValues(Value.newBuilder().setStringValue("col_int").build())
+                    .addValues(Value.newBuilder().setStringValue("bigint").build())
+                    .build())
+            .addRows(
+                ListValue.newBuilder()
+                    .addValues(Value.newBuilder().setStringValue("col_numeric").build())
+                    .addValues(Value.newBuilder().setStringValue("numeric").build())
+                    .build())
+            .addRows(
+                ListValue.newBuilder()
+                    .addValues(Value.newBuilder().setStringValue("col_timestamptz").build())
+                    .addValues(
+                        Value.newBuilder().setStringValue("timestamp with time zone").build())
+                    .build())
+            .addRows(
+                ListValue.newBuilder()
+                    .addValues(Value.newBuilder().setStringValue("col_date").build())
+                    .addValues(Value.newBuilder().setStringValue("date").build())
+                    .build())
+            .addRows(
+                ListValue.newBuilder()
+                    .addValues(Value.newBuilder().setStringValue("col_varchar").build())
+                    .addValues(Value.newBuilder().setStringValue("character varying").build())
+                    .build())
+            .setMetadata(metadata)
+            .build();
+    mockSpanner.putStatementResult(
+        StatementResult.query(
+            com.google.cloud.spanner.Statement.newBuilder(
+                    "SELECT column_name, data_type FROM information_schema.columns WHERE table_name = $1")
+                .bind("p1")
+                .to("all_types")
+                .build(),
+            allTypesResultSet));
 
     String indexedColumnsCountSql =
         "SELECT COUNT(*) FROM information_schema.index_columns WHERE table_schema='public' and table_name=$1 and column_name in ($2, $3, $4)";
@@ -400,5 +493,52 @@ public class CopyInMockServerTest extends AbstractMockServerTest {
                 .to("name")
                 .build(),
             indexedColumnsCountResultSet));
+
+    String allTypesIndexedColumnsCountSql =
+        "SELECT COUNT(*) FROM information_schema.index_columns WHERE table_schema='public' and table_name=$1 and column_name in ($2, $3, $4, $5, $6, $7, $8, $9, $10)";
+    ResultSetMetadata allTypesIndexedColumnsCountMetadata =
+        ResultSetMetadata.newBuilder()
+            .setRowType(
+                StructType.newBuilder()
+                    .addFields(
+                        Field.newBuilder()
+                            .setName("")
+                            .setType(Type.newBuilder().setCode(TypeCode.INT64).build())
+                            .build())
+                    .build())
+            .build();
+    com.google.spanner.v1.ResultSet allTypesIndexedColumnsCountResultSet =
+        com.google.spanner.v1.ResultSet.newBuilder()
+            .addRows(
+                ListValue.newBuilder()
+                    .addValues(Value.newBuilder().setStringValue("1").build())
+                    .build())
+            .setMetadata(allTypesIndexedColumnsCountMetadata)
+            .build();
+    mockSpanner.putStatementResult(
+        StatementResult.query(
+            com.google.cloud.spanner.Statement.newBuilder(allTypesIndexedColumnsCountSql)
+                .bind("p1")
+                .to("all_types")
+                .bind("p2")
+                .to("col_bigint")
+                .bind("p3")
+                .to("col_bool")
+                .bind("p4")
+                .to("col_bytea")
+                .bind("p5")
+                .to("col_float8")
+                .bind("p6")
+                .to("col_int")
+                .bind("p7")
+                .to("col_numeric")
+                .bind("p8")
+                .to("col_timestamptz")
+                .bind("p9")
+                .to("col_date")
+                .bind("p10")
+                .to("col_varchar")
+                .build(),
+            allTypesIndexedColumnsCountResultSet));
   }
 }

--- a/src/test/java/com/google/cloud/spanner/pgadapter/wireprotocol/ProtocolTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/wireprotocol/ProtocolTest.java
@@ -135,11 +135,9 @@ public class ProtocolTest {
   }
 
   @AfterClass
-  public static void cleanup() {
+  public static void cleanup() throws IOException {
     // TODO: Make error log file configurable and turn off writing to a file during tests.
-    File outputFile = new File("output.txt");
-    //noinspection ResultOfMethodCallIgnored
-    outputFile.delete();
+    Files.deleteIfExists(new File("output.txt").toPath());
   }
 
   @Test
@@ -1499,10 +1497,7 @@ public class ProtocolTest {
 
     copyStatement.close();
 
-    File outputFile = new File("output.txt");
-    if (outputFile.exists()) {
-      assertTrue(outputFile.delete());
-    }
+    Files.deleteIfExists(new File("output.txt").toPath());
   }
 
   @Test
@@ -1519,10 +1514,7 @@ public class ProtocolTest {
     copyStatement.execute();
     assertTrue(copyStatement.isExecuted());
 
-    File outputFile = new File("output.txt");
-    if (outputFile.exists()) {
-      assertTrue(outputFile.delete());
-    }
+    Files.deleteIfExists(new File("output.txt").toPath());
 
     MutationWriter mw = copyStatement.getMutationWriter();
     mw.addCopyData(payload);
@@ -1532,7 +1524,7 @@ public class ProtocolTest {
     assertEquals(
         "INVALID_ARGUMENT: Invalid input syntax for type INT64:\"'5'\"", thrown.getMessage());
 
-    outputFile = new File("output.txt");
+    File outputFile = new File("output.txt");
     assertTrue(outputFile.exists());
     assertTrue(outputFile.isFile());
 
@@ -1549,10 +1541,7 @@ public class ProtocolTest {
 
     // Pre-emptively try to delete the output file if it is lingering from a previous test run.
     // TODO: Make the output file for COPY configurable, so we can use a temp file for this.
-    File outputFile = new File("output.txt");
-    if (outputFile.exists()) {
-      assertTrue(outputFile.delete());
-    }
+    Files.deleteIfExists(new File("output.txt").toPath());
 
     String sql = "COPY keyvalue FROM STDIN;";
     CopyStatement copyStatement =
@@ -1569,7 +1558,7 @@ public class ProtocolTest {
     assertEquals(
         "INVALID_ARGUMENT: Invalid input syntax for type INT64:\"'1'\"", thrown.getMessage());
 
-    outputFile = new File("output.txt");
+    File outputFile = new File("output.txt");
     assertTrue(outputFile.exists());
     assertTrue(outputFile.isFile());
 

--- a/src/test/java/com/google/cloud/spanner/pgadapter/wireprotocol/ProtocolTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/wireprotocol/ProtocolTest.java
@@ -136,8 +136,15 @@ public class ProtocolTest {
 
   @AfterClass
   public static void cleanup() throws IOException {
+    deleteLogFile();
+  }
+
+  private static void deleteLogFile() {
     // TODO: Make error log file configurable and turn off writing to a file during tests.
-    Files.deleteIfExists(new File("output.txt").toPath());
+    try {
+      Files.deleteIfExists(new File("output.txt").toPath());
+    } catch (IOException ignore) {
+    }
   }
 
   @Test
@@ -1497,7 +1504,7 @@ public class ProtocolTest {
 
     copyStatement.close();
 
-    Files.deleteIfExists(new File("output.txt").toPath());
+    deleteLogFile();
   }
 
   @Test
@@ -1514,7 +1521,7 @@ public class ProtocolTest {
     copyStatement.execute();
     assertTrue(copyStatement.isExecuted());
 
-    Files.deleteIfExists(new File("output.txt").toPath());
+    deleteLogFile();
 
     MutationWriter mw = copyStatement.getMutationWriter();
     mw.addCopyData(payload);
@@ -1540,8 +1547,7 @@ public class ProtocolTest {
         Files.readAllBytes(Paths.get("./src/test/resources/test-copy-start-output.txt"));
 
     // Pre-emptively try to delete the output file if it is lingering from a previous test run.
-    // TODO: Make the output file for COPY configurable, so we can use a temp file for this.
-    Files.deleteIfExists(new File("output.txt").toPath());
+    deleteLogFile();
 
     String sql = "COPY keyvalue FROM STDIN;";
     CopyStatement copyStatement =

--- a/src/test/java/com/google/cloud/spanner/pgadapter/wireprotocol/ProtocolTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/wireprotocol/ProtocolTest.java
@@ -1535,7 +1535,7 @@ public class ProtocolTest {
     assertTrue(outputFile.exists());
     assertTrue(outputFile.isFile());
 
-    assertTrue(outputFile.delete());
+    deleteLogFile();
     copyStatement.close();
   }
 
@@ -1568,7 +1568,7 @@ public class ProtocolTest {
     assertTrue(outputFile.exists());
     assertTrue(outputFile.isFile());
 
-    assertTrue(outputFile.delete());
+    deleteLogFile();
     copyStatement.close();
   }
 


### PR DESCRIPTION
Domain sockets on MacOS failed if it received a message that was bigger than the reader buffer size (8192 bytes).