### PR TITLE
chore: remove unnecessary flushing

### DIFF
--- a/src/main/java/com/google/cloud/spanner/pgadapter/wireprotocol/BindMessage.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/wireprotocol/BindMessage.java
@@ -75,7 +75,7 @@ public class BindMessage extends AbstractQueryProtocolMessage {
   public void flush() throws Exception {
     // The simple query protocol does not expect a BindComplete response.
     if (isExtendedProtocol()) {
-      new BindCompleteResponse(this.outputStream).send();
+      new BindCompleteResponse(this.outputStream).send(false);
     }
   }
 

--- a/src/main/java/com/google/cloud/spanner/pgadapter/wireprotocol/DescribeMessage.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/wireprotocol/DescribeMessage.java
@@ -129,7 +129,7 @@ public class DescribeMessage extends AbstractQueryProtocolMessage {
                   getPortalMetadata().getMetadata(),
                   this.connection.getServer().getOptions(),
                   this.queryMode)
-              .send();
+              .send(false);
         } catch (SpannerException exception) {
           this.handleError(exception);
         }
@@ -137,7 +137,7 @@ public class DescribeMessage extends AbstractQueryProtocolMessage {
         // The simple query protocol does not expect a NoData response in case of a non-query
         // statement.
         if (isExtendedProtocol()) {
-          new NoDataResponse(this.outputStream).send();
+          new NoDataResponse(this.outputStream).send(false);
         }
       }
     }
@@ -165,7 +165,7 @@ public class DescribeMessage extends AbstractQueryProtocolMessage {
   public void handleDescribeStatement() throws Exception {
     try {
       DescribeStatementMetadata metadata = (DescribeStatementMetadata) this.statement.describe();
-      new ParameterDescriptionResponse(this.outputStream, metadata.getParameters()).send();
+      new ParameterDescriptionResponse(this.outputStream, metadata.getParameters()).send(false);
       if (metadata.getResultSet() != null) {
         new RowDescriptionResponse(
                 this.outputStream,
@@ -173,9 +173,9 @@ public class DescribeMessage extends AbstractQueryProtocolMessage {
                 metadata.getResultSet(),
                 this.connection.getServer().getOptions(),
                 this.queryMode)
-            .send();
+            .send(false);
       } else {
-        new NoDataResponse(this.outputStream).send();
+        new NoDataResponse(this.outputStream).send(false);
       }
     } catch (SpannerException exception) {
       this.handleError(exception);

--- a/src/main/java/com/google/cloud/spanner/pgadapter/wireprotocol/ParseMessage.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/wireprotocol/ParseMessage.java
@@ -90,7 +90,7 @@ public class ParseMessage extends AbstractQueryProtocolMessage {
   public void flush() throws Exception {
     // The simple query protocol does not need the ParseComplete response.
     if (isExtendedProtocol()) {
-      new ParseCompleteResponse(this.outputStream).send();
+      new ParseCompleteResponse(this.outputStream).send(false);
     }
   }
 


### PR DESCRIPTION
Remove unnecessary flushing in the extended query protocol. Data only needs to
be flushed when a flush or sync message is received.