### PR TITLE
docs: add documentation for connection options

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,10 +50,10 @@ java -jar pgadapter.jar -p my-project -i my-instance -d my-database
 Use the `-s` option to specify a different local port than the default 5432 if you already have
 PostgreSQL running on your local system.
 
-You can also download a specific version of the jar. Example (replace `v0.4.0` with the version you want to download):
+You can also download a specific version of the jar. Example (replace `v0.5.0` with the version you want to download):
 
 ```shell
-VERSION=v0.4.0
+VERSION=v0.5.0
 wget https://storage.googleapis.com/pgadapter-jar-releases/pgadapter-${VERSION}.tar.gz && tar -xzvf pgadapter-${VERSION}.tar.gz
 java -jar pgadapter.jar -p my-project -i my-instance -d my-database
 ```
@@ -117,16 +117,20 @@ path; All other items map directly to previously mentioned CLI options.
 
 ### Options
 
-#### Required
+#### Connection Options
 
-The following options are required to run the proxy:
+See [connection options](docs/connection_options.md) for more details.
 
 ```    
 -p <projectname>
-  * The project name where the Spanner database(s) is/are running.
+  * The project name where the Spanner database(s) is/are running. If omitted, all connection
+    requests must use a fully qualified database name in the format
+    'projects/my-project/instances/my-instance/databases/my-database'.
     
 -i <instanceid>
-  * The instance ID where the Spanner database(s) is/are running.
+  * The instance ID where the Spanner database(s) is/are running. If omitted, all connection
+    requests must use a fully qualified database name in the format
+    'projects/my-project/instances/my-instance/databases/my-database'.
 
 -d <databasename>
   * The default Spanner database name to connect to. This is only required if you want PGAdapter to

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -1,0 +1,75 @@
+# Authentication Options
+
+PGAdapter supports both credentials that are supplied at startup as a command line argument, as well
+as credentials that are specified in a connection request. The former will cause PGAdapter to use
+the same credentials for all connections. The latter can be used to have different credentials per
+connection.
+
+## Credentials at Startup
+PGAdapter will use credentials that are given at startup if it is started __without the `-a`__
+command line argument. There are two ways that the credentials at startup can be specified:
+1. Use the `-c` command line argument to specify a credentials file. This can be a service account
+   key file, a user credentials file or an external account credentials file.
+2. If the `-c` command line argument is not specified, PGAdapter will look for the default credentials
+   of the current environment. See https://cloud.google.com/spanner/docs/getting-started/set-up#set_up_authentication_and_authorization
+   for more information on authentication and authorization.
+
+__NOTE__: PGAdapter will always try to use fixed credentials for all connections if the `-a` command
+line argument has not been specified. PGAdapter will refuse to start if no credentials can be found.
+Start PGAdapter with `-a` if you want the clients that connect to PGAdapter to specify the credentials.
+
+### Examples
+
+```shell
+# PGAdapter will use the given credentials for all connections.
+java -jar pgadapter.jar -p my-project -i my-instance -c "path/to/credentials.json"
+
+# PGAdapter will use the default credentials of the server environment.
+# It will fail to start if no default credentials could be found.
+java -jar pgadapter.jar -p my-project -i my-instance
+```
+
+## Credentials in Connection Request (Authentication Mode)
+PGAdapter will require all connections to supply credentials for each connection if it is started
+with the `-a` command line argument. The credentials are sent as a password message. The password
+message must contain one of the following:
+1. The password field can contain the JSON payload of a credentials file, for example the contents
+   of a service account key file. The username will be ignored in this case.
+2. The username field can contain the email address of a service account and the password field can
+   contain a private key for that service account. Note: The password must include the
+   `-----BEGIN PRIVATE KEY-----` and `-----END PRIVATE KEY-----` header and footer.
+
+### Examples
+
+```shell
+# The -a argument instructs PGAdapter to require authentication.
+java -jar pgadapter.jar -p my-project -i my-instance -a
+
+# Set the PG password to the contents of a credentials file. This can be both a service account or a
+# user account file. The username will be ignored by PGAdapter.
+PGPASSWORD=$(cat /path/to/credentials.json) psql -h /tmp -d my-database
+
+# Use the private key of a service account and the client email address for the account.
+# This example extracts the private key from a credentials file, but you can also read it from any
+# other file or copy-paste it into the password prompt. 
+PGPASSWORD=$(grep -o '"private_key": "[^"]*' /path/to/credentials.json | grep -o '[^"]*$') \
+   psql -h /tmp -p 5433 -U service-account-name@my-project.iam.gserviceaccount.com -d my-database
+```
+
+## Connect with Fully Qualified Database Name
+PGAdapter can be started with only the `-a` command line argument. All connection options must then
+be given in the connection request from the client. The database name must be given as a fully
+qualified database name.
+
+### Example
+```shell
+# The -a argument instructs PGAdapter to require authentication.
+java -jar pgadapter.jar -a
+
+# Set the PG password to the contents of a credentials file. This can be both a service account or a
+# user account file. The username will be ignored by PGAdapter.
+# Specify the database using a fully qualified name between quotes.
+PGPASSWORD=$(cat /path/to/credentials.json) \
+  psql -h /tmp -d "projects/my-project/instances/my-instance/databases/my-database"
+```
+

--- a/docs/connection_options.md
+++ b/docs/connection_options.md
@@ -57,6 +57,7 @@ java -jar pgadapter.jar -p my-project -i my-instance
 psql -h /tmp -d my-database
 
 # Use a fully qualified database name to connect to a database on a different instance.
-psql -h /tmp -d projects/other-project/instances/other-instance/databases/other-database
+# Note that you must enclose the database name in quotes as it contains slashes.
+psql -h /tmp -d "projects/other-project/instances/other-instance/databases/other-database"
 ```
 

--- a/docs/connection_options.md
+++ b/docs/connection_options.md
@@ -1,0 +1,62 @@
+# Connection Options
+
+PGAdapter can be configured to always connect to a single Cloud Spanner database, or it
+can be configured to allow connections to different databases. This is controlled through
+the `-p <project-id>`, `-i <instance-id>` and `-d <database-id>` command line arguments.
+
+## Always Connect to a Single Database
+PGAdapter will always connect to the database that is specified in the command line if all
+the options `-p <project-id>`, `-i <instance-id>` and `-d <database-id>` have been set. Any
+database name in a connection request will be ignored. The `\c` psql meta-command will have
+no effect.
+
+## Set a Default Instance
+If the command line arguments `-p <project-id>` and `-i <instance-id>` have been set,
+PGAdapter will consider this the default instance where to look for a database. If a
+database request contains only a database id (not the fully qualified database name),
+PGAdapter will try to connect to the database with the given id on the default instance.
+
+## No Connection Options
+Connection requests must contain the fully qualified database name if none of the options
+`-p <project-id>`, `-i <instance-id>` and `-d <database-id>` have been set. Fully qualified
+database names have the form `projects/my-project/instances/my-instance/databases/my-database`.
+
+__NOTE__: Fully qualified database names contain multiple slashes. These must be URL-encoded
+when used in for example JDBC connection strings.
+
+## Credentials
+The `-c <credentialspath>` command line arguments specifies the fixed credentials that should be
+used for all connections from PGAdapter to Cloud Spanner. See [authentication](authentication.md)
+for more authentication options, including options to use different credentials for different
+connections.
+
+## Examples
+
+### Fixed Database
+
+```shell
+# Start PGAdapter with a fixed database 
+java -jar pgadapter.jar -p my-project -i my-instance -d my-database
+
+# No need to specify a database id in a connection request
+psql -h /tmp
+
+# PGAdapter will ignore the 'some-other-database' name in this connection request and instead
+# connect to 'my-database'.
+psql -h /tmp -d some-other-database
+```
+
+### Default Instance
+
+```shell
+# Start PGAdapter with a default instance but no fixed database. 
+java -jar pgadapter.jar -p my-project -i my-instance
+
+# We must specify a database in the connection request. The id is enough for databases
+# on the default instance.
+psql -h /tmp -d my-database
+
+# Use a fully qualified database name to connect to a database on a different instance.
+psql -h /tmp -d projects/other-project/instances/other-instance/databases/other-database
+```
+

--- a/src/main/java/com/google/cloud/spanner/connection/ConnectionOptionsHelper.java
+++ b/src/main/java/com/google/cloud/spanner/connection/ConnectionOptionsHelper.java
@@ -14,14 +14,21 @@
 
 package com.google.cloud.spanner.connection;
 
+import com.google.api.core.InternalApi;
 import com.google.auth.oauth2.GoogleCredentials;
+import com.google.cloud.spanner.Spanner;
 import com.google.cloud.spanner.connection.ConnectionOptions.Builder;
 
 /** Simple helper class to get access to a package-private method in the ConnectionOptions. */
+@InternalApi
 public class ConnectionOptionsHelper {
   // TODO: Remove when Builder.setCredentials(..) has been made public.
   public static Builder setCredentials(
       Builder connectionOptionsBuilder, GoogleCredentials credentials) {
     return connectionOptionsBuilder.setCredentials(credentials);
+  }
+
+  public static Spanner getSpanner(Connection connection) {
+    return ((ConnectionImpl) connection).getSpanner();
   }
 }

--- a/src/main/java/com/google/cloud/spanner/pgadapter/metadata/OptionsMetadata.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/metadata/OptionsMetadata.java
@@ -294,8 +294,7 @@ public class OptionsMetadata {
    *
    * @return The absolute path of the credentials file.
    */
-  @VisibleForTesting
-  String buildCredentialsFile() {
+  public String buildCredentialsFile() {
     if (!commandLine.hasOption(OPTION_CREDENTIALS_FILE)) {
       try {
         // This will throw an IOException if no default credentials are available.
@@ -351,8 +350,8 @@ public class OptionsMetadata {
     return url;
   }
 
-  @VisibleForTesting
-  DatabaseName getDatabaseName(String database) {
+  /** Returns the fully qualified database name based on the given database id or name. */
+  public DatabaseName getDatabaseName(String database) {
     DatabaseName databaseName;
     if (DatabaseName.isParsableFrom(database)) {
       databaseName = DatabaseName.parse(database);

--- a/src/main/java/com/google/cloud/spanner/pgadapter/wireprotocol/PasswordMessage.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/wireprotocol/PasswordMessage.java
@@ -105,13 +105,18 @@ public class PasswordMessage extends ControlMessage {
       // The username is potentially an email address. That means that the password could be a
       // private key. Try to parse it as such.
       try {
+        String privateKeyText = password.replace("\\n", "\n");
         Section privateKeySection =
-            PemReader.readFirstSectionAndClose(new StringReader(password), "PRIVATE KEY");
+            PemReader.readFirstSectionAndClose(new StringReader(privateKeyText), "PRIVATE KEY");
         if (privateKeySection != null) {
           // Successfully identified as a private key. Manually create a ServiceAccountCredentials
           // instance and try to use this when connecting to Spanner.
           return ServiceAccountCredentials.fromPkcs8(
-              /*clientId=*/ null, username, password, /*privateKeyId=*/ null, /*scopes=*/ null);
+              /*clientId=*/ null,
+              username,
+              privateKeyText,
+              /*privateKeyId=*/ null,
+              /*scopes=*/ null);
         }
       } catch (IOException ioException) {
         // Ignore and try to parse it as a credentials file.

--- a/src/test/java/com/google/cloud/spanner/pgadapter/AbstractMockServerTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/AbstractMockServerTest.java
@@ -25,6 +25,7 @@ import com.google.cloud.spanner.SpannerException;
 import com.google.cloud.spanner.SpannerExceptionFactory;
 import com.google.cloud.spanner.Statement;
 import com.google.cloud.spanner.admin.database.v1.MockDatabaseAdminImpl;
+import com.google.cloud.spanner.admin.instance.v1.MockInstanceAdminImpl;
 import com.google.cloud.spanner.connection.SpannerPool;
 import com.google.cloud.spanner.pgadapter.metadata.OptionsMetadata;
 import com.google.cloud.spanner.pgadapter.wireprotocol.WireMessage;
@@ -241,6 +242,7 @@ public abstract class AbstractMockServerTest {
 
   protected static MockSpannerServiceImpl mockSpanner;
   protected static MockDatabaseAdminImpl mockDatabaseAdmin;
+  protected static MockInstanceAdminImpl mockInstanceAdmin;
   private static Server spannerServer;
   protected static ProxyServer pgServer;
 
@@ -314,12 +316,14 @@ public abstract class AbstractMockServerTest {
     mockSpanner.putStatementResult(StatementResult.exception(INVALID_DDL, EXCEPTION));
 
     mockDatabaseAdmin = new MockDatabaseAdminImpl();
+    mockInstanceAdmin = new MockInstanceAdminImpl();
 
     InetSocketAddress address = new InetSocketAddress("localhost", 0);
     spannerServer =
         NettyServerBuilder.forAddress(address)
             .addService(mockSpanner)
             .addService(mockDatabaseAdmin)
+            .addService(mockInstanceAdmin)
             .intercept(
                 new ServerInterceptor() {
                   @Override
@@ -427,6 +431,7 @@ public abstract class AbstractMockServerTest {
   public void clearRequests() {
     mockSpanner.clearRequests();
     mockDatabaseAdmin.reset();
+    mockInstanceAdmin.reset();
     if (pgServer != null) {
       pgServer.clearDebugMessages();
     }


### PR DESCRIPTION
Adds documentation for connection options + adds more information to the error message that is returned if psql tries to connect to a database that does not exist.