### PR TITLE
build: add distribution for Java setups

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,6 +31,7 @@ jobs:
     - uses: actions/setup-java@v1
       with:
         java-version: ${{matrix.java}}
+        distribution: 'zulu'
     - run: java -version
     - uses: actions/setup-go@v3
       with:
@@ -54,6 +55,7 @@ jobs:
     - uses: actions/setup-java@v1
       with:
         java-version: 11
+        distribution: 'zulu'
     - run: java -version
     - run: .ci/run-with-credentials.sh lint
   clirr:
@@ -63,6 +65,7 @@ jobs:
       - uses: actions/setup-java@v1
         with:
           java-version: 8
+          distribution: 'zulu'
       - run: java -version
       - run: .ci/run-with-credentials.sh clirr
   e2e-psql-v11:
@@ -74,6 +77,7 @@ jobs:
     - uses: actions/setup-java@v1
       with:
         java-version: 11
+        distribution: 'zulu'
     - run: java -version
     - name: "Install postgresql-client-11"
       run: |
@@ -99,6 +103,7 @@ jobs:
     - uses: actions/setup-java@v1
       with:
         java-version: 11
+        distribution: 'zulu'
     - run: java -version
     - name: "Install postgresql-client-12"
       run: |
@@ -124,6 +129,7 @@ jobs:
     - uses: actions/setup-java@v1
       with:
         java-version: 11
+        distribution: 'zulu'
     - run: java -version
     - name: "Install postgresql-client-13"
       run: |
@@ -149,6 +155,7 @@ jobs:
     - uses: actions/setup-java@v1
       with:
         java-version: 11
+        distribution: 'zulu'
     - run: java -version
     - name: "Install postgresql-client-14"
       run: |

--- a/.github/workflows/integration-tests-against-docker.yaml
+++ b/.github/workflows/integration-tests-against-docker.yaml
@@ -17,6 +17,7 @@ jobs:
       - uses: actions/setup-java@v1
         with:
           java-version: 8
+          distribution: 'zulu'
       - id: 'auth'
         uses: 'google-github-actions/auth@v0'
         with:


### PR DESCRIPTION
Adds a distribution for all java setups in Github actions, as that is required from v2 and further.