### PR TITLE
deps: remove custom Maven plugin versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,6 +30,7 @@
     </excludedTests>
 
     <spanner.version>6.25.5</spanner.version>
+    <junixsocket.version>2.5.0</junixsocket.version>
   </properties>
 
   <modelVersion>4.0.0</modelVersion>
@@ -46,7 +47,7 @@
   <parent>
     <groupId>com.google.cloud</groupId>
     <artifactId>google-cloud-shared-config</artifactId>
-    <version>1.2.7</version>
+    <version>1.5.0</version>
   </parent>
   <scm>
     <connection>scm:git:git@github.com:GoogleCloudPlatform/pgadapter.git</connection>
@@ -79,13 +80,13 @@
     <dependency>
       <groupId>com.kohlschutter.junixsocket</groupId>
       <artifactId>junixsocket-core</artifactId>
-      <version>2.5.0</version>
+      <version>${junixsocket.version}</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.kohlschutter.junixsocket</groupId>
       <artifactId>junixsocket-common</artifactId>
-      <version>2.5.0</version>
+      <version>${junixsocket.version}</version>
     </dependency>
     <dependency>
       <groupId>com.googlecode.json-simple</groupId>
@@ -151,7 +152,6 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-shade-plugin</artifactId>
-            <version>3.3.0</version>
             <executions>
               <execution>
                 <goals>
@@ -218,7 +218,6 @@
         <plugins>
           <plugin>
             <artifactId>maven-resources-plugin</artifactId>
-            <version>3.2.0</version>
             <executions>
               <execution>
                 <id>copy-resources</id>
@@ -290,7 +289,6 @@
       <plugin>
         <groupId>com.coveo</groupId>
         <artifactId>fmt-maven-plugin</artifactId>
-        <version>2.5.1</version>
         <executions>
           <execution>
             <goals>
@@ -302,7 +300,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>3.0.0-M5</version>
         <configuration>
           <forkedProcessTimeoutInSeconds>3600</forkedProcessTimeoutInSeconds>
           <argLine>${surefire.jacoco.args}</argLine>
@@ -319,7 +316,6 @@
       <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
-        <version>0.8.8</version>
         <executions>
           <execution>
             <goals>
@@ -403,7 +399,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-failsafe-plugin</artifactId>
-        <version>3.0.0-M4</version>
         <executions>
           <execution>
             <goals>


### PR DESCRIPTION
Removes custom Maven plugin versions and instead relies on the versions specified in the shared configuration project.