### PR TITLE
feat: support \l meta command

### DIFF
--- a/.ci/e2e-expected/backslash-l.txt
+++ b/.ci/e2e-expected/backslash-l.txt
@@ -1,6 +1,6 @@
                                List of databases
-         Name        | Owner | Encoding | Collate | Ctype | Access privileges
----------------------+-------+----------+---------+-------+-------------------
+  Name | Owner | Encoding | Collate | Ctype | Access privileges
++++++
  testdb_e2e_psql_v?? |       | UTF8     |         |       |
 (1 row)
 

--- a/.ci/e2e-expected/backslash-l.txt
+++ b/.ci/e2e-expected/backslash-l.txt
@@ -1,0 +1,6 @@
+                               List of databases
+         Name        | Owner | Encoding | Collate | Ctype | Access privileges
+---------------------+-------+----------+---------+-------+-------------------
+ testdb_e2e_psql_v?? |       | UTF8     |         |       |
+(1 row)
+

--- a/.ci/evaluate-with-psql.sh
+++ b/.ci/evaluate-with-psql.sh
@@ -7,6 +7,7 @@ sed -i "s/testdb_e2e_psql_v../$GOOGLE_CLOUD_DATABASE_WITH_VERSION/" .ci/e2e-expe
 sed -i "s/testdb_e2e_psql_v../$GOOGLE_CLOUD_DATABASE_WITH_VERSION/" .ci/e2e-expected/backslash-di-param.txt
 sed -i "s/testdb_e2e_psql_v../$GOOGLE_CLOUD_DATABASE_WITH_VERSION/" .ci/e2e-expected/backslash-dn.txt
 sed -i "s/testdb_e2e_psql_v../$GOOGLE_CLOUD_DATABASE_WITH_VERSION/" .ci/e2e-expected/backslash-dn-param.txt
+sed -i "s/testdb_e2e_psql_v../$GOOGLE_CLOUD_DATABASE_WITH_VERSION/" .ci/e2e-expected/backslash-l.txt
 # remove --- hyphenated formatting lines for diff comparison
 sed -i "s/---[-]*//g" .ci/e2e-expected/backslash-dt.txt
 sed -i "s/---[-]*//g" .ci/e2e-expected/backslash-dt-param.txt
@@ -14,6 +15,7 @@ sed -i "s/---[-]*//g" .ci/e2e-expected/backslash-di.txt
 sed -i "s/---[-]*//g" .ci/e2e-expected/backslash-di-param.txt
 sed -i "s/---[-]*//g" .ci/e2e-expected/backslash-dn.txt
 sed -i "s/---[-]*//g" .ci/e2e-expected/backslash-dn-param.txt
+sed -i "s/---[-]*//g" .ci/e2e-expected/backslash-l.txt
 
 echo "------Test \"select 1::int8\"------"
 echo "select 1::int8;" | /usr/lib/postgresql/"${PSQL_VERSION}"/bin/psql -h /tmp -p 4242 -d "${GOOGLE_CLOUD_DATABASE_WITH_VERSION}" > .ci/e2e-result/select-one.txt

--- a/.ci/evaluate-with-psql.sh
+++ b/.ci/evaluate-with-psql.sh
@@ -75,6 +75,14 @@ sed -i "s/---[-]*//g" .ci/e2e-result/backslash-dn-param.txt
 diff -i -w -s .ci/e2e-result/backslash-dn-param.txt .ci/e2e-expected/backslash-dn-param.txt
 RETURN_CODE=$((${RETURN_CODE}||$?))
 
+echo "------Test \"\\l\"------"
+echo "\l" | /usr/lib/postgresql/"${PSQL_VERSION}"/bin/psql -h localhost -p 4242 -d "${GOOGLE_CLOUD_DATABASE_WITH_VERSION}" > .ci/e2e-result/backslash-dn.txt
+# ignore effective_timestamp
+sed -i -E 's/[0-9]{16,}//' .ci/e2e-result/backslash-l.txt
+sed -i "s/---[-]*//g" .ci/e2e-result/backslash-l.txt
+diff -i -w -s .ci/e2e-result/backslash-l.txt .ci/e2e-expected/backslash-l.txt
+RETURN_CODE=$((${RETURN_CODE}||$?))
+
 echo "------Test \"-c option dml batching\"------"
 /usr/lib/postgresql/"${PSQL_VERSION}"/bin/psql -h localhost -p 4242 -d "${GOOGLE_CLOUD_DATABASE_WITH_VERSION}" -c "$(cat .ci/e2e-batching/dml-batch.txt)" > .ci/e2e-result/dml-batching.txt
 diff -i -w -s .ci/e2e-result/dml-batching.txt .ci/e2e-expected/dml-batching.txt

--- a/.ci/evaluate-with-psql.sh
+++ b/.ci/evaluate-with-psql.sh
@@ -76,7 +76,7 @@ diff -i -w -s .ci/e2e-result/backslash-dn-param.txt .ci/e2e-expected/backslash-d
 RETURN_CODE=$((${RETURN_CODE}||$?))
 
 echo "------Test \"\\l\"------"
-echo "\l" | /usr/lib/postgresql/"${PSQL_VERSION}"/bin/psql -h localhost -p 4242 -d "${GOOGLE_CLOUD_DATABASE_WITH_VERSION}" > .ci/e2e-result/backslash-dn.txt
+echo "\l" | /usr/lib/postgresql/"${PSQL_VERSION}"/bin/psql -h localhost -p 4242 -d "${GOOGLE_CLOUD_DATABASE_WITH_VERSION}" > .ci/e2e-result/backslash-l.txt
 # ignore effective_timestamp
 sed -i -E 's/[0-9]{16,}//' .ci/e2e-result/backslash-l.txt
 sed -i "s/---[-]*//g" .ci/e2e-result/backslash-l.txt

--- a/src/main/java/com/google/cloud/spanner/connection/ConnectionOptionsHelper.java
+++ b/src/main/java/com/google/cloud/spanner/connection/ConnectionOptionsHelper.java
@@ -15,6 +15,7 @@
 package com.google.cloud.spanner.connection;
 
 import com.google.auth.oauth2.GoogleCredentials;
+import com.google.cloud.spanner.Spanner;
 import com.google.cloud.spanner.connection.ConnectionOptions.Builder;
 
 /** Simple helper class to get access to a package-private method in the ConnectionOptions. */
@@ -23,5 +24,9 @@ public class ConnectionOptionsHelper {
   public static Builder setCredentials(
       Builder connectionOptionsBuilder, GoogleCredentials credentials) {
     return connectionOptionsBuilder.setCredentials(credentials);
+  }
+
+  public static Spanner getSpanner(Connection connection) {
+    return ((ConnectionImpl) connection).getSpanner();
   }
 }

--- a/src/main/java/com/google/cloud/spanner/pgadapter/ConnectionHandler.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/ConnectionHandler.java
@@ -16,6 +16,7 @@ package com.google.cloud.spanner.pgadapter;
 
 import com.google.api.core.InternalApi;
 import com.google.auth.oauth2.GoogleCredentials;
+import com.google.cloud.spanner.DatabaseId;
 import com.google.cloud.spanner.Dialect;
 import com.google.cloud.spanner.ErrorCode;
 import com.google.cloud.spanner.SpannerException;
@@ -88,6 +89,7 @@ public class ConnectionHandler extends Thread {
   private ConnectionMetadata connectionMetadata;
   private WireMessage message;
   private Connection spannerConnection;
+  private DatabaseId databaseId;
   private WellKnownClient wellKnownClient;
   private ExtendedQueryProtocolHandler extendedQueryProtocolHandler;
 
@@ -142,7 +144,8 @@ public class ConnectionHandler extends Thread {
       connectionOptionsBuilder =
           ConnectionOptionsHelper.setCredentials(connectionOptionsBuilder, credentials);
     }
-    Connection spannerConnection = connectionOptionsBuilder.build().getConnection();
+    ConnectionOptions connectionOptions = connectionOptionsBuilder.build();
+    Connection spannerConnection = connectionOptions.getConnection();
     try {
       // Note: Calling getDialect() will cause a SpannerException if the connection itself is
       // invalid, for example as a result of the credentials being wrong.
@@ -159,6 +162,7 @@ public class ConnectionHandler extends Thread {
       throw e;
     }
     this.spannerConnection = spannerConnection;
+    this.databaseId = connectionOptions.getDatabaseId();
     this.extendedQueryProtocolHandler = new ExtendedQueryProtocolHandler(this);
   }
 
@@ -444,6 +448,10 @@ public class ConnectionHandler extends Thread {
 
   public Connection getSpannerConnection() {
     return this.spannerConnection;
+  }
+
+  public DatabaseId getDatabaseId() {
+    return this.databaseId;
   }
 
   public int getConnectionId() {

--- a/src/main/java/com/google/cloud/spanner/pgadapter/commands/Command.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/commands/Command.java
@@ -68,8 +68,7 @@ public abstract class Command {
       commandList.add(new DynamicCommand(sql, currentMetadata));
     }
 
-    commandList.addAll(
-        Arrays.asList(new ListCommand(sql, connection), new InvalidMetaCommand(sql)));
+    commandList.addAll(Arrays.asList(new ListCommand(sql), new InvalidMetaCommand(sql)));
 
     return commandList;
   }

--- a/src/main/java/com/google/cloud/spanner/pgadapter/commands/ListCommand.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/commands/ListCommand.java
@@ -15,14 +15,10 @@
 package com.google.cloud.spanner.pgadapter.commands;
 
 import com.google.api.core.InternalApi;
-import com.google.cloud.spanner.connection.Connection;
+import com.google.cloud.spanner.pgadapter.statements.local.ListDatabasesStatement;
 import java.util.regex.Pattern;
 
-/**
- * This command is equivalent to the PSQL \l and \l <param> meta-commands. The original expectation
- * would be to print database and database attributes, however As we do not have easy access to
- * those, we just print the current database name.
- */
+/** This command is equivalent to the PSQL \l and \l <param> meta-commands. */
 @InternalApi
 public class ListCommand extends Command {
 
@@ -35,13 +31,8 @@ public class ListCommand extends Command {
               + "FROM pg_catalog\\.pg_database d\n.*\n?"
               + "ORDER BY 1;?$");
 
-  private static final String OUTPUT_QUERY = "SELECT '%s' AS Name;";
-
-  private final Connection connection;
-
-  ListCommand(String sql, Connection connection) {
+  ListCommand(String sql) {
     super(sql);
-    this.connection = connection;
   }
 
   @Override
@@ -51,7 +42,6 @@ public class ListCommand extends Command {
 
   @Override
   public String translate() {
-    // TODO: Pass in the database name, or add it to the Connection API surface and get it here.
-    return String.format(OUTPUT_QUERY, "");
+    return ListDatabasesStatement.LIST_DATABASES_SQL;
   }
 }

--- a/src/main/java/com/google/cloud/spanner/pgadapter/metadata/OptionsMetadata.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/metadata/OptionsMetadata.java
@@ -15,7 +15,9 @@
 package com.google.cloud.spanner.pgadapter.metadata;
 
 import com.google.auth.oauth2.GoogleCredentials;
+import com.google.cloud.spanner.DatabaseId;
 import com.google.cloud.spanner.ErrorCode;
+import com.google.cloud.spanner.InstanceId;
 import com.google.cloud.spanner.SpannerExceptionFactory;
 import com.google.cloud.spanner.SpannerOptions;
 import com.google.cloud.spanner.pgadapter.Server;
@@ -657,6 +659,31 @@ public class OptionsMetadata {
    */
   public boolean hasDefaultConnectionUrl() {
     return this.defaultConnectionUrl != null;
+  }
+
+  /** Returns the id of the default database or null if no default has been selected. */
+  public DatabaseId getDefaultDatabaseId() {
+    return this.hasDefaultConnectionUrl()
+        ? DatabaseId.of(
+            commandLine.getOptionValue(OPTION_PROJECT_ID),
+            commandLine.getOptionValue(OPTION_INSTANCE_ID),
+            commandLine.getOptionValue(OPTION_DATABASE_NAME))
+        : null;
+  }
+
+  /** Returns true if these options contain a default instance id. */
+  public boolean hasDefaultInstanceId() {
+    return commandLine.hasOption(OPTION_PROJECT_ID) && commandLine.hasOption(OPTION_INSTANCE_ID);
+  }
+
+  /** Returns the id of the default instance or null if no default has been selected. */
+  public InstanceId getDefaultInstanceId() {
+    if (hasDefaultInstanceId()) {
+      return InstanceId.of(
+          commandLine.getOptionValue(OPTION_PROJECT_ID),
+          commandLine.getOptionValue(OPTION_INSTANCE_ID));
+    }
+    return null;
   }
 
   /**

--- a/src/main/java/com/google/cloud/spanner/pgadapter/statements/ExtendedQueryProtocolHandler.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/statements/ExtendedQueryProtocolHandler.java
@@ -14,9 +14,13 @@
 
 package com.google.cloud.spanner.pgadapter.statements;
 
+import static com.google.cloud.spanner.pgadapter.utils.ClientAutoDetector.EMPTY_LOCAL_STATEMENTS;
+
 import com.google.cloud.spanner.pgadapter.ConnectionHandler;
+import com.google.cloud.spanner.pgadapter.statements.local.LocalStatement;
 import com.google.cloud.spanner.pgadapter.wireprotocol.AbstractQueryProtocolMessage;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
 import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
@@ -31,10 +35,15 @@ public class ExtendedQueryProtocolHandler {
 
   /** Creates an {@link ExtendedQueryProtocolHandler} for the given connection. */
   public ExtendedQueryProtocolHandler(ConnectionHandler connectionHandler) {
+    ImmutableList<LocalStatement> localStatements =
+        connectionHandler.getWellKnownClient() == null
+            ? EMPTY_LOCAL_STATEMENTS
+            : connectionHandler.getWellKnownClient().getLocalStatements(connectionHandler);
     this.backendConnection =
         new BackendConnection(
             connectionHandler.getSpannerConnection(),
-            connectionHandler.getServer().getOptions().getDdlTransactionMode());
+            connectionHandler.getServer().getOptions().getDdlTransactionMode(),
+            localStatements);
   }
 
   /** Constructor only intended for testing. */

--- a/src/main/java/com/google/cloud/spanner/pgadapter/statements/local/ListDatabasesStatement.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/statements/local/ListDatabasesStatement.java
@@ -30,9 +30,11 @@ import com.google.cloud.spanner.connection.ConnectionOptionsHelper;
 import com.google.cloud.spanner.connection.StatementResult;
 import com.google.cloud.spanner.pgadapter.ConnectionHandler;
 import com.google.cloud.spanner.pgadapter.statements.BackendConnection.QueryResult;
+import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
@@ -42,7 +44,21 @@ public class ListDatabasesStatement implements LocalStatement {
   private final ConnectionHandler connectionHandler;
 
   public ListDatabasesStatement(ConnectionHandler connectionHandler) {
-    this.connectionHandler = connectionHandler;
+    this.connectionHandler = Preconditions.checkNotNull(connectionHandler);
+  }
+
+  @Override
+  public boolean equals(Object other) {
+    if (!(other instanceof ListDatabasesStatement)) {
+      return false;
+    }
+    return Objects.equals(
+        this.connectionHandler, ((ListDatabasesStatement) other).connectionHandler);
+  }
+
+  @Override
+  public int hashCode() {
+    return this.connectionHandler.hashCode();
   }
 
   @Override

--- a/src/main/java/com/google/cloud/spanner/pgadapter/statements/local/ListDatabasesStatement.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/statements/local/ListDatabasesStatement.java
@@ -1,0 +1,122 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.cloud.spanner.pgadapter.statements.local;
+
+import com.google.api.core.InternalApi;
+import com.google.cloud.spanner.Database;
+import com.google.cloud.spanner.DatabaseAdminClient;
+import com.google.cloud.spanner.Dialect;
+import com.google.cloud.spanner.InstanceId;
+import com.google.cloud.spanner.ResultSet;
+import com.google.cloud.spanner.ResultSets;
+import com.google.cloud.spanner.Spanner;
+import com.google.cloud.spanner.Struct;
+import com.google.cloud.spanner.Type;
+import com.google.cloud.spanner.Type.StructField;
+import com.google.cloud.spanner.connection.Connection;
+import com.google.cloud.spanner.connection.ConnectionOptionsHelper;
+import com.google.cloud.spanner.connection.StatementResult;
+import com.google.cloud.spanner.pgadapter.ConnectionHandler;
+import com.google.cloud.spanner.pgadapter.statements.BackendConnection.QueryResult;
+import com.google.common.collect.ImmutableList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+@InternalApi
+public class ListDatabasesStatement implements LocalStatement {
+  public static final String LIST_DATABASES_SQL = "select reachable databases";
+  private final ConnectionHandler connectionHandler;
+
+  public ListDatabasesStatement(ConnectionHandler connectionHandler) {
+    this.connectionHandler = connectionHandler;
+  }
+
+  @Override
+  public String getSql() {
+    return LIST_DATABASES_SQL;
+  }
+
+  @Override
+  public StatementResult execute(Connection connection) {
+    Spanner spanner = ConnectionOptionsHelper.getSpanner(connection);
+    InstanceId defaultInstanceId =
+        connectionHandler.getServer().getOptions().getDefaultInstanceId();
+    ResultSet resultSet =
+        ResultSets.forRows(
+            Type.struct(
+                StructField.of("Name", Type.string()),
+                StructField.of("Owner", Type.string()),
+                StructField.of("Encoding", Type.string()),
+                StructField.of("Collate", Type.string()),
+                StructField.of("Ctype", Type.string()),
+                StructField.of("Access privileges", Type.string())),
+            listDatabases(spanner).stream()
+                .map(
+                    database ->
+                        Struct.newBuilder()
+                            .set("Name")
+                            .to(
+                                database.getId().getInstanceId().equals(defaultInstanceId)
+                                    ? database.getId().getDatabase()
+                                    : database.getId().toString())
+                            .set("Owner")
+                            .to("")
+                            .set("Encoding")
+                            .to("UTF8")
+                            .set("Collate")
+                            .to("")
+                            .set("Ctype")
+                            .to("")
+                            .set("Access privileges")
+                            .to("")
+                            .build())
+                .sorted(Comparator.comparing(row -> row.getString("Name")))
+                .collect(Collectors.toList()));
+    return new QueryResult(resultSet);
+  }
+
+  /**
+   * Returns the databases that are:
+   *
+   * <ol>
+   *   <li>The same as the current database
+   *   <li>On the default instance of this instance of PGAdapter
+   *   <li>On the same instance as the current connection
+   * </ol>
+   */
+  private List<Database> listDatabases(Spanner spanner) {
+    DatabaseAdminClient databaseAdminClient = spanner.getDatabaseAdminClient();
+    if (connectionHandler.getServer().getOptions().hasDefaultConnectionUrl()) {
+      // Only return the current database, as that is the only one that is reachable.
+      return ImmutableList.of(
+          databaseAdminClient
+              .newDatabaseBuilder(connectionHandler.getServer().getOptions().getDefaultDatabaseId())
+              .setDialect(Dialect.POSTGRESQL)
+              .build());
+    }
+    // Return all the databases on the same instance as the database that we are currently connected
+    // to.
+    return StreamSupport.stream(
+            databaseAdminClient
+                .listDatabases(connectionHandler.getDatabaseId().getInstanceId().getInstance())
+                .iterateAll()
+                .spliterator(),
+            false)
+        .filter(database -> database.getDialect() == Dialect.POSTGRESQL)
+        .collect(Collectors.toList());
+  }
+}

--- a/src/main/java/com/google/cloud/spanner/pgadapter/statements/local/LocalStatement.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/statements/local/LocalStatement.java
@@ -1,0 +1,30 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.cloud.spanner.pgadapter.statements.local;
+
+import com.google.cloud.spanner.connection.Connection;
+import com.google.cloud.spanner.connection.StatementResult;
+
+/**
+ * Interface for statements that are handled locally in PGAdapter instead of being sent to
+ * Connection API.
+ */
+public interface LocalStatement {
+  /** Returns the static SQL string associated with this local statement. */
+  String getSql();
+
+  /** Executes the local statement and returns the result. */
+  StatementResult execute(Connection connection);
+}

--- a/src/test/java/com/google/cloud/spanner/connection/ConnectionOptionsHelperTest.java
+++ b/src/test/java/com/google/cloud/spanner/connection/ConnectionOptionsHelperTest.java
@@ -1,0 +1,58 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.cloud.spanner.connection;
+
+import static org.junit.Assert.assertSame;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.cloud.spanner.Spanner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class ConnectionOptionsHelperTest {
+
+  public static Connection setupMockConnection(Spanner spanner) {
+    ConnectionImpl connection = mock(ConnectionImpl.class);
+    when(connection.getSpanner()).thenReturn(spanner);
+
+    return connection;
+  }
+
+  @Test
+  public void testSetCredentials() {
+    ConnectionOptions.Builder builder = mock(ConnectionOptions.Builder.class);
+    GoogleCredentials credentials = mock(GoogleCredentials.class);
+
+    ConnectionOptionsHelper.setCredentials(builder, credentials);
+
+    verify(builder).setCredentials(credentials);
+  }
+
+  @Test
+  public void testGetSpanner() {
+    ConnectionImpl connection = mock(ConnectionImpl.class);
+    Spanner expected = mock(Spanner.class);
+    when(connection.getSpanner()).thenReturn(expected);
+
+    Spanner got = ConnectionOptionsHelper.getSpanner(connection);
+
+    assertSame(expected, got);
+  }
+}

--- a/src/test/java/com/google/cloud/spanner/pgadapter/statements/BackendConnectionTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/statements/BackendConnectionTest.java
@@ -1,0 +1,106 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.cloud.spanner.pgadapter.statements;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.cloud.spanner.ResultSet;
+import com.google.cloud.spanner.Statement;
+import com.google.cloud.spanner.connection.AbstractStatementParser.ParsedStatement;
+import com.google.cloud.spanner.connection.Connection;
+import com.google.cloud.spanner.connection.StatementResult;
+import com.google.cloud.spanner.connection.StatementResult.ResultType;
+import com.google.cloud.spanner.pgadapter.metadata.OptionsMetadata.DdlTransactionMode;
+import com.google.cloud.spanner.pgadapter.statements.BackendConnection.QueryResult;
+import com.google.cloud.spanner.pgadapter.statements.local.ListDatabasesStatement;
+import com.google.cloud.spanner.pgadapter.statements.local.LocalStatement;
+import com.google.common.collect.ImmutableList;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class BackendConnectionTest {
+
+  @Test
+  public void testExecuteLocalStatement() throws ExecutionException, InterruptedException {
+    Connection connection = mock(Connection.class);
+    StatementResult listDatabasesResult = mock(StatementResult.class);
+    when(listDatabasesResult.getResultType()).thenReturn(ResultType.RESULT_SET);
+    ListDatabasesStatement listDatabasesStatement = mock(ListDatabasesStatement.class);
+    when(listDatabasesStatement.getSql()).thenReturn(ListDatabasesStatement.LIST_DATABASES_SQL);
+    when(listDatabasesStatement.execute(connection)).thenReturn(listDatabasesResult);
+    ImmutableList<LocalStatement> localStatements = ImmutableList.of(listDatabasesStatement);
+    ParsedStatement parsedListDatabasesStatement = mock(ParsedStatement.class);
+    when(parsedListDatabasesStatement.getSqlWithoutComments())
+        .thenReturn(ListDatabasesStatement.LIST_DATABASES_SQL);
+
+    BackendConnection backendConnection =
+        new BackendConnection(connection, DdlTransactionMode.Batch, localStatements);
+    Future<StatementResult> resultFuture =
+        backendConnection.execute(
+            parsedListDatabasesStatement, Statement.of(ListDatabasesStatement.LIST_DATABASES_SQL));
+    backendConnection.flush();
+
+    verify(listDatabasesStatement).execute(connection);
+    assertTrue(resultFuture.isDone());
+    assertEquals(listDatabasesResult, resultFuture.get());
+  }
+
+  @Test
+  public void testExecuteOtherStatementWithLocalStatements()
+      throws ExecutionException, InterruptedException {
+    Connection connection = mock(Connection.class);
+    ListDatabasesStatement listDatabasesStatement = mock(ListDatabasesStatement.class);
+    when(listDatabasesStatement.getSql()).thenReturn(ListDatabasesStatement.LIST_DATABASES_SQL);
+    ImmutableList<LocalStatement> localStatements = ImmutableList.of(listDatabasesStatement);
+
+    StatementResult statementResult = mock(StatementResult.class);
+    when(statementResult.getResultType()).thenReturn(ResultType.RESULT_SET);
+    ParsedStatement parsedStatement = mock(ParsedStatement.class);
+    String sql = "SELECT * FROM foo";
+    when(parsedStatement.getSqlWithoutComments()).thenReturn(sql);
+    Statement statement = Statement.of(sql);
+    when(connection.execute(statement)).thenReturn(statementResult);
+
+    BackendConnection backendConnection =
+        new BackendConnection(connection, DdlTransactionMode.Batch, localStatements);
+    Future<StatementResult> resultFuture = backendConnection.execute(parsedStatement, statement);
+    backendConnection.flush();
+
+    verify(listDatabasesStatement, never()).execute(connection);
+    assertTrue(resultFuture.isDone());
+    assertEquals(statementResult, resultFuture.get());
+  }
+
+  @Test
+  public void testQueryResult() {
+    ResultSet resultSet = mock(ResultSet.class);
+    QueryResult queryResult = new QueryResult(resultSet);
+
+    assertEquals(ResultType.RESULT_SET, queryResult.getResultType());
+    assertEquals(resultSet, queryResult.getResultSet());
+    assertThrows(UnsupportedOperationException.class, queryResult::getClientSideStatementType);
+    assertThrows(UnsupportedOperationException.class, queryResult::getUpdateCount);
+  }
+}

--- a/src/test/java/com/google/cloud/spanner/pgadapter/statements/PSQLTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/statements/PSQLTest.java
@@ -25,6 +25,7 @@ import com.google.cloud.spanner.pgadapter.ConnectionHandler;
 import com.google.cloud.spanner.pgadapter.ProxyServer;
 import com.google.cloud.spanner.pgadapter.metadata.CommandMetadataParser;
 import com.google.cloud.spanner.pgadapter.metadata.OptionsMetadata;
+import com.google.cloud.spanner.pgadapter.statements.local.ListDatabasesStatement;
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
 import org.junit.Before;
@@ -283,7 +284,7 @@ public class PSQLTest {
             + "       pg_catalog.array_to_string(d.datacl, '\\n') AS \"Access privileges\"\n"
             + "FROM pg_catalog.pg_database d\n"
             + "ORDER BY 1;";
-    String expected = "SELECT '' AS Name";
+    String expected = ListDatabasesStatement.LIST_DATABASES_SQL;
 
     assertEquals(expected, translate(sql));
   }
@@ -299,7 +300,7 @@ public class PSQLTest {
             + "FROM pg_catalog.pg_database d\n"
             + "WHERE d.datname OPERATOR(pg_catalog.~) '^(users)$'\n"
             + "ORDER BY 1;";
-    String expected = "SELECT '' AS Name";
+    String expected = ListDatabasesStatement.LIST_DATABASES_SQL;
 
     assertEquals(expected, translate(sql));
   }
@@ -315,10 +316,8 @@ public class PSQLTest {
             + "FROM pg_catalog.pg_database d\n"
             + "WHERE d.datname OPERATOR(pg_catalog.~) '^(users)$'\n"
             + "ORDER BY 1;";
-    String expected = "SELECT '' AS Name";
+    String expected = ListDatabasesStatement.LIST_DATABASES_SQL;
 
-    // TODO: Add Connection#getDatabase() to Connection API and test here what happens if that
-    // method throws an exception.
     assertEquals(expected, translate(sql));
   }
 

--- a/src/test/java/com/google/cloud/spanner/pgadapter/statements/StatementTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/statements/StatementTest.java
@@ -14,6 +14,7 @@
 
 package com.google.cloud.spanner.pgadapter.statements;
 
+import static com.google.cloud.spanner.pgadapter.utils.ClientAutoDetector.EMPTY_LOCAL_STATEMENTS;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -154,7 +155,7 @@ public class StatementTest {
         new IntermediatePortalStatement(
             connectionHandler, options, "", parse(sql), Statement.of(sql));
     BackendConnection backendConnection =
-        new BackendConnection(connection, DdlTransactionMode.Batch);
+        new BackendConnection(connection, DdlTransactionMode.Batch, EMPTY_LOCAL_STATEMENTS);
 
     assertFalse(intermediateStatement.isExecuted());
     assertEquals("UPDATE", intermediateStatement.getCommand());
@@ -226,7 +227,7 @@ public class StatementTest {
         new IntermediatePortalStatement(
             connectionHandler, options, "", parse(sql), Statement.of(sql));
     BackendConnection backendConnection =
-        new BackendConnection(connection, DdlTransactionMode.Batch);
+        new BackendConnection(connection, DdlTransactionMode.Batch, EMPTY_LOCAL_STATEMENTS);
 
     intermediateStatement.executeAsync(backendConnection);
     backendConnection.flush();
@@ -251,7 +252,7 @@ public class StatementTest {
             .to(30)
             .build();
     BackendConnection backendConnection =
-        new BackendConnection(connection, DdlTransactionMode.Batch);
+        new BackendConnection(connection, DdlTransactionMode.Batch, EMPTY_LOCAL_STATEMENTS);
 
     IntermediatePreparedStatement intermediateStatement =
         new IntermediatePreparedStatement(
@@ -318,7 +319,7 @@ public class StatementTest {
         new IntermediatePortalStatement(
             connectionHandler, options, "", parse(sqlStatement), Statement.of(sqlStatement));
     BackendConnection backendConnection =
-        new BackendConnection(connection, DdlTransactionMode.Batch);
+        new BackendConnection(connection, DdlTransactionMode.Batch, EMPTY_LOCAL_STATEMENTS);
 
     intermediateStatement.describeAsync(backendConnection);
     backendConnection.flush();
@@ -362,7 +363,7 @@ public class StatementTest {
         new IntermediatePortalStatement(
             connectionHandler, options, "", parse(sqlStatement), Statement.of(sqlStatement));
     BackendConnection backendConnection =
-        new BackendConnection(connection, DdlTransactionMode.Batch);
+        new BackendConnection(connection, DdlTransactionMode.Batch, EMPTY_LOCAL_STATEMENTS);
 
     when(connection.execute(Statement.of(sqlStatement)))
         .thenThrow(
@@ -462,7 +463,7 @@ public class StatementTest {
         new IntermediatePortalStatement(
             connectionHandler, options, "", parse(sql), Statement.of(sql));
     BackendConnection backendConnection =
-        new BackendConnection(connection, DdlTransactionMode.Batch);
+        new BackendConnection(connection, DdlTransactionMode.Batch, EMPTY_LOCAL_STATEMENTS);
 
     intermediateStatement.executeAsync(backendConnection);
 

--- a/src/test/java/com/google/cloud/spanner/pgadapter/statements/local/ListDatabasesStatementTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/statements/local/ListDatabasesStatementTest.java
@@ -1,0 +1,252 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.cloud.spanner.pgadapter.statements.local;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.google.api.gax.paging.Page;
+import com.google.cloud.spanner.Database;
+import com.google.cloud.spanner.DatabaseAdminClient;
+import com.google.cloud.spanner.DatabaseId;
+import com.google.cloud.spanner.Dialect;
+import com.google.cloud.spanner.InstanceId;
+import com.google.cloud.spanner.ResultSet;
+import com.google.cloud.spanner.Spanner;
+import com.google.cloud.spanner.connection.Connection;
+import com.google.cloud.spanner.connection.ConnectionOptionsHelperTest;
+import com.google.cloud.spanner.connection.StatementResult;
+import com.google.cloud.spanner.connection.StatementResult.ResultType;
+import com.google.cloud.spanner.pgadapter.ConnectionHandler;
+import com.google.cloud.spanner.pgadapter.ProxyServer;
+import com.google.cloud.spanner.pgadapter.metadata.OptionsMetadata;
+import com.google.common.collect.ImmutableList;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class ListDatabasesStatementTest {
+
+  @Test
+  public void testGetSql() {
+    ConnectionHandler connectionHandler = mock(ConnectionHandler.class);
+    ListDatabasesStatement statement = new ListDatabasesStatement(connectionHandler);
+
+    assertEquals(ListDatabasesStatement.LIST_DATABASES_SQL, statement.getSql());
+  }
+
+  @Test
+  public void testEquals() {
+    ConnectionHandler connectionHandler = mock(ConnectionHandler.class);
+    ListDatabasesStatement statement1 = new ListDatabasesStatement(connectionHandler);
+    ListDatabasesStatement statement2 = new ListDatabasesStatement(connectionHandler);
+    ListDatabasesStatement statement3 = new ListDatabasesStatement(mock(ConnectionHandler.class));
+
+    assertEquals(statement1, statement2);
+    assertNotEquals(statement1, statement3);
+    assertNotEquals(statement1, null);
+  }
+
+  @Test
+  public void testHashCode() {
+    ConnectionHandler connectionHandler1 = mock(ConnectionHandler.class);
+    ConnectionHandler connectionHandler2 = mock(ConnectionHandler.class);
+    ListDatabasesStatement statement1 = new ListDatabasesStatement(connectionHandler1);
+    ListDatabasesStatement statement2 = new ListDatabasesStatement(connectionHandler1);
+    ListDatabasesStatement statement3 = new ListDatabasesStatement(connectionHandler2);
+
+    assertEquals(statement1.hashCode(), statement2.hashCode());
+    assertNotEquals(statement1.hashCode(), statement3.hashCode());
+  }
+
+  @Test
+  public void testExecuteNoDefault() {
+    Spanner spanner = mock(Spanner.class);
+    DatabaseAdminClient databaseAdminClient = mock(DatabaseAdminClient.class);
+    when(spanner.getDatabaseAdminClient()).thenReturn(databaseAdminClient);
+    Connection connection = ConnectionOptionsHelperTest.setupMockConnection(spanner);
+    OptionsMetadata options = mock(OptionsMetadata.class);
+    DatabaseId currentDatabaseId = DatabaseId.of("my-project", "my-instance", "my-database");
+    ConnectionHandler connectionHandler = setupMockConnectionHandler(options, currentDatabaseId);
+
+    // Setup results for databaseAdminClient.listDatabases(currentInstanceId);
+    Database currentDatabase = mock(Database.class);
+    when(currentDatabase.getId()).thenReturn(currentDatabaseId);
+    when(currentDatabase.getDialect()).thenReturn(Dialect.POSTGRESQL);
+    Database otherPgDatabase = mock(Database.class);
+    when(otherPgDatabase.getId())
+        .thenReturn(DatabaseId.of("my-project", "my-instance", "other-pg-database"));
+    when(otherPgDatabase.getDialect()).thenReturn(Dialect.POSTGRESQL);
+    Database otherGsqlDatabase = mock(Database.class);
+    when(otherGsqlDatabase.getId())
+        .thenReturn(DatabaseId.of("my-project", "my-instance", "other-gsql-database"));
+    when(otherGsqlDatabase.getDialect()).thenReturn(Dialect.GOOGLE_STANDARD_SQL);
+    Page<Database> page =
+        createMockPage(ImmutableList.of(otherPgDatabase, otherGsqlDatabase, currentDatabase));
+    when(databaseAdminClient.listDatabases(currentDatabaseId.getInstanceId().getInstance()))
+        .thenReturn(page);
+
+    ListDatabasesStatement statement = new ListDatabasesStatement(connectionHandler);
+    StatementResult result = statement.execute(connection);
+
+    assertEquals(ResultType.RESULT_SET, result.getResultType());
+    ResultSet resultSet = result.getResultSet();
+    assertTrue(resultSet.next());
+    assertEquals(currentDatabaseId.toString(), resultSet.getString("Name"));
+    assertTrue(resultSet.next());
+    assertEquals(otherPgDatabase.getId().toString(), resultSet.getString("Name"));
+    assertFalse(resultSet.next());
+  }
+
+  @Test
+  public void testExecuteWithDefaultInstance() {
+    Spanner spanner = mock(Spanner.class);
+    DatabaseAdminClient databaseAdminClient = mock(DatabaseAdminClient.class);
+    when(spanner.getDatabaseAdminClient()).thenReturn(databaseAdminClient);
+    Connection connection = ConnectionOptionsHelperTest.setupMockConnection(spanner);
+    DatabaseId currentDatabaseId = DatabaseId.of("my-project", "my-instance", "my-database");
+    OptionsMetadata options = mock(OptionsMetadata.class);
+    when(options.hasDefaultInstanceId()).thenReturn(true);
+    when(options.getDefaultInstanceId()).thenReturn(currentDatabaseId.getInstanceId());
+    ConnectionHandler connectionHandler = setupMockConnectionHandler(options, currentDatabaseId);
+
+    // Setup results for databaseAdminClient.listDatabases(currentInstanceId);
+    Database currentDatabase = mock(Database.class);
+    when(currentDatabase.getId()).thenReturn(currentDatabaseId);
+    when(currentDatabase.getDialect()).thenReturn(Dialect.POSTGRESQL);
+    Database otherPgDatabase = mock(Database.class);
+    when(otherPgDatabase.getId())
+        .thenReturn(DatabaseId.of("my-project", "my-instance", "other-pg-database"));
+    when(otherPgDatabase.getDialect()).thenReturn(Dialect.POSTGRESQL);
+    Database otherGsqlDatabase = mock(Database.class);
+    when(otherGsqlDatabase.getId())
+        .thenReturn(DatabaseId.of("my-project", "my-instance", "other-gsql-database"));
+    when(otherGsqlDatabase.getDialect()).thenReturn(Dialect.GOOGLE_STANDARD_SQL);
+    Page<Database> page =
+        createMockPage(ImmutableList.of(otherPgDatabase, otherGsqlDatabase, currentDatabase));
+    when(databaseAdminClient.listDatabases(currentDatabaseId.getInstanceId().getInstance()))
+        .thenReturn(page);
+
+    ListDatabasesStatement statement = new ListDatabasesStatement(connectionHandler);
+    StatementResult result = statement.execute(connection);
+
+    assertEquals(ResultType.RESULT_SET, result.getResultType());
+    ResultSet resultSet = result.getResultSet();
+    assertTrue(resultSet.next());
+    assertEquals(currentDatabaseId.getDatabase(), resultSet.getString("Name"));
+    assertTrue(resultSet.next());
+    assertEquals(otherPgDatabase.getId().getDatabase(), resultSet.getString("Name"));
+    assertFalse(resultSet.next());
+  }
+
+  @Test
+  public void testExecuteWithDefaultInstanceWhileConnectedToDifferentInstance() {
+    Spanner spanner = mock(Spanner.class);
+    DatabaseAdminClient databaseAdminClient = mock(DatabaseAdminClient.class);
+    when(spanner.getDatabaseAdminClient()).thenReturn(databaseAdminClient);
+    Connection connection = ConnectionOptionsHelperTest.setupMockConnection(spanner);
+    DatabaseId currentDatabaseId = DatabaseId.of("my-project", "my-instance", "my-database");
+    OptionsMetadata options = mock(OptionsMetadata.class);
+    when(options.hasDefaultInstanceId()).thenReturn(true);
+    when(options.getDefaultInstanceId())
+        .thenReturn(InstanceId.of("my-project", "default-instance"));
+    ConnectionHandler connectionHandler = setupMockConnectionHandler(options, currentDatabaseId);
+
+    // Setup results for databaseAdminClient.listDatabases(currentInstanceId);
+    Database currentDatabase = mock(Database.class);
+    when(currentDatabase.getId()).thenReturn(currentDatabaseId);
+    when(currentDatabase.getDialect()).thenReturn(Dialect.POSTGRESQL);
+    Database otherPgDatabase = mock(Database.class);
+    when(otherPgDatabase.getId())
+        .thenReturn(DatabaseId.of("my-project", "my-instance", "other-pg-database"));
+    when(otherPgDatabase.getDialect()).thenReturn(Dialect.POSTGRESQL);
+    Database otherGsqlDatabase = mock(Database.class);
+    when(otherGsqlDatabase.getId())
+        .thenReturn(DatabaseId.of("my-project", "my-instance", "other-gsql-database"));
+    when(otherGsqlDatabase.getDialect()).thenReturn(Dialect.GOOGLE_STANDARD_SQL);
+    Page<Database> page =
+        createMockPage(ImmutableList.of(otherPgDatabase, otherGsqlDatabase, currentDatabase));
+    when(databaseAdminClient.listDatabases(currentDatabaseId.getInstanceId().getInstance()))
+        .thenReturn(page);
+
+    ListDatabasesStatement statement = new ListDatabasesStatement(connectionHandler);
+    StatementResult result = statement.execute(connection);
+
+    assertEquals(ResultType.RESULT_SET, result.getResultType());
+    ResultSet resultSet = result.getResultSet();
+    assertTrue(resultSet.next());
+    assertEquals(currentDatabaseId.toString(), resultSet.getString("Name"));
+    assertTrue(resultSet.next());
+    assertEquals(otherPgDatabase.getId().toString(), resultSet.getString("Name"));
+    assertFalse(resultSet.next());
+  }
+
+  @Test
+  public void testExecuteWithDefaultDatabase() {
+    Spanner spanner = mock(Spanner.class);
+    DatabaseAdminClient databaseAdminClient = mock(DatabaseAdminClient.class);
+    when(spanner.getDatabaseAdminClient()).thenReturn(databaseAdminClient);
+    Connection connection = ConnectionOptionsHelperTest.setupMockConnection(spanner);
+    DatabaseId currentDatabaseId = DatabaseId.of("my-project", "my-instance", "my-database");
+    OptionsMetadata options = mock(OptionsMetadata.class);
+    when(options.hasDefaultConnectionUrl()).thenReturn(true);
+    when(options.getDefaultDatabaseId()).thenReturn(currentDatabaseId);
+    when(options.hasDefaultInstanceId()).thenReturn(true);
+    when(options.getDefaultInstanceId()).thenReturn(currentDatabaseId.getInstanceId());
+    ConnectionHandler connectionHandler = setupMockConnectionHandler(options, currentDatabaseId);
+
+    // Setup results for databaseAdminClient.listDatabases(currentInstanceId);
+    Database currentDatabase = mock(Database.class);
+    when(currentDatabase.getId()).thenReturn(currentDatabaseId);
+    when(currentDatabase.getDialect()).thenReturn(Dialect.POSTGRESQL);
+    Database.Builder databaseBuilder = mock(Database.Builder.class);
+    when(databaseBuilder.setDialect(Dialect.POSTGRESQL)).thenReturn(databaseBuilder);
+    when(databaseBuilder.build()).thenReturn(currentDatabase);
+    when(databaseAdminClient.newDatabaseBuilder(currentDatabaseId)).thenReturn(databaseBuilder);
+
+    ListDatabasesStatement statement = new ListDatabasesStatement(connectionHandler);
+    StatementResult result = statement.execute(connection);
+
+    assertEquals(ResultType.RESULT_SET, result.getResultType());
+    ResultSet resultSet = result.getResultSet();
+    assertTrue(resultSet.next());
+    assertEquals(currentDatabaseId.getDatabase(), resultSet.getString("Name"));
+    assertFalse(resultSet.next());
+  }
+
+  private ConnectionHandler setupMockConnectionHandler(
+      OptionsMetadata options, DatabaseId databaseId) {
+    ProxyServer server = mock(ProxyServer.class);
+    ConnectionHandler connectionHandler = mock(ConnectionHandler.class);
+    when(connectionHandler.getServer()).thenReturn(server);
+    when(connectionHandler.getDatabaseId()).thenReturn(databaseId);
+    when(server.getOptions()).thenReturn(options);
+
+    return connectionHandler;
+  }
+
+  @SuppressWarnings("unchecked")
+  private Page<Database> createMockPage(Iterable<Database> databases) {
+    Page<Database> result = mock(Page.class);
+    when(result.iterateAll()).thenReturn(databases);
+
+    return result;
+  }
+}

--- a/src/test/java/com/google/cloud/spanner/pgadapter/utils/ClientAutoDetectorTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/utils/ClientAutoDetectorTest.java
@@ -14,9 +14,13 @@
 
 package com.google.cloud.spanner.pgadapter.utils;
 
+import static com.google.cloud.spanner.pgadapter.utils.ClientAutoDetector.EMPTY_LOCAL_STATEMENTS;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
+import static org.mockito.Mockito.mock;
 
+import com.google.cloud.spanner.pgadapter.ConnectionHandler;
+import com.google.cloud.spanner.pgadapter.statements.local.ListDatabasesStatement;
 import com.google.cloud.spanner.pgadapter.utils.ClientAutoDetector.WellKnownClient;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -143,6 +147,10 @@ public class ClientAutoDetectorTest {
                   "DateStyle", "ISO",
                   "TimeZone", "some-time-zone")));
     }
+
+    assertEquals(
+        EMPTY_LOCAL_STATEMENTS,
+        WellKnownClient.JDBC.getLocalStatements(mock(ConnectionHandler.class)));
   }
 
   @Test
@@ -182,6 +190,11 @@ public class ClientAutoDetectorTest {
         WellKnownClient.PSQL,
         ClientAutoDetector.detectClient(
             ImmutableList.of("application_name"), ImmutableMap.of("application_name", "PSQL")));
+
+    ConnectionHandler connectionHandler = mock(ConnectionHandler.class);
+    assertEquals(
+        ImmutableList.of(new ListDatabasesStatement(connectionHandler)),
+        WellKnownClient.PSQL.getLocalStatements(connectionHandler));
   }
 
   @Test
@@ -193,5 +206,9 @@ public class ClientAutoDetectorTest {
         WellKnownClient.PGX,
         ClientAutoDetector.detectClient(
             ImmutableList.of("some-param"), ImmutableMap.of("some-param", "some-value")));
+
+    assertEquals(
+        EMPTY_LOCAL_STATEMENTS,
+        WellKnownClient.PGX.getLocalStatements(mock(ConnectionHandler.class)));
   }
 }


### PR DESCRIPTION
Adds support for the `\l` psql meta command to list all databases on the same 'server'. The meta command behaves as follows in PGAdapter:
1. If PGAdapter has been started with `-d` (a fixed database) it will only show the current database, as no other database can be 'reached' by using `\c`.
2. If `-d` has not been specified, PGAdapter shows all the databases on the same instance as the current connection.
3. The databases in step 2 are shown with only the database id if the current connection is to the default instance of this instance of PGAdapter. Otherwise, the fully qualified name is shown.