### PR TITLE
fix: correctly skip nested block comments

### DIFF
--- a/src/main/java/com/google/cloud/spanner/pgadapter/utils/StatementParser.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/utils/StatementParser.java
@@ -140,10 +140,17 @@ public class StatementParser {
   }
 
   static int skipMultiLineComment(String sql, int startIndex) {
+    int level = 1;
     int i = startIndex + 2;
     while (i < sql.length()) {
+      if (sql.charAt(i) == SLASH && sql.length() > (i + 1) && sql.charAt(i + 1) == ASTERISK) {
+        level++;
+      }
       if (sql.charAt(i) == ASTERISK && sql.length() > (i + 1) && sql.charAt(i + 1) == SLASH) {
-        return i + 2;
+        level--;
+        if (level == 0) {
+          return i + 2;
+        }
       }
       i++;
     }

--- a/src/test/java/com/google/cloud/spanner/pgadapter/utils/StatementParserTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/utils/StatementParserTest.java
@@ -217,6 +217,10 @@ public class StatementParserTest {
     assertEquals(13, skipMultiLineComment("bar /* foo */", 4));
     assertEquals(13, skipMultiLineComment("bar /* foo */bar", 4));
     assertEquals(10, skipMultiLineComment("bar /* foo", 4));
+
+    assertEquals(
+        "/* foo /* inner comment */ not in inner comment */".length(),
+        skipMultiLineComment("/* foo /* inner comment */ not in inner comment */ bar", 0));
   }
 
   @Test
@@ -294,6 +298,29 @@ public class StatementParserTest {
     assertEquals(
         ImmutableList.of("select * from \"my';table\"", "select 1"),
         splitStatements("select * from \"my';table\"; select 1"));
+    assertEquals(
+        ImmutableList.of(
+            "/* This block comment surrounds a query which itself has a block comment...\n"
+                + "SELECT /* embedded single line */ 'embedded' AS x2;\n"
+                + "*/\n"
+                + "SELECT 1"),
+        splitStatements(
+            "/* This block comment surrounds a query which itself has a block comment...\n"
+                + "SELECT /* embedded single line */ 'embedded' AS x2;\n"
+                + "*/\n"
+                + "SELECT 1;"));
+    assertEquals(
+        ImmutableList.of(
+            "/* This block comment surrounds a query which itself has a block comment...\n"
+                + "SELECT /* embedded single line */ 'embedded' AS x2;\n"
+                + "*/\n"
+                + "SELECT 1",
+            "SELECT 2"),
+        splitStatements(
+            "/* This block comment surrounds a query which itself has a block comment...\n"
+                + "SELECT /* embedded single line */ 'embedded' AS x2;\n"
+                + "*/\n"
+                + "SELECT 1; SELECT 2;"));
 
     assertEquals(
         ImmutableList.of("select $$Hello World!$$"), splitStatements("select $$Hello World!$$"));


### PR DESCRIPTION
Block comments with nested block comments were not correctly skipped.
The end tag of a nested block comment would be considered the end of the
entire comment block, instead of only reducing the block comment level.

Fixes b/236784930