### PR TITLE
cleanup: remove custom log file for COPY operations

### DIFF
--- a/src/main/java/com/google/cloud/spanner/pgadapter/wireprotocol/CopyDataMessage.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/wireprotocol/CopyDataMessage.java
@@ -56,7 +56,6 @@ public class CopyDataMessage extends ControlMessage {
       try {
         mutationWriter.addCopyData(this.payload);
       } catch (SpannerException exception) {
-        mutationWriter.writeErrorFile(exception);
         statement.handleExecutionException(exception);
         throw exception;
       }

--- a/src/main/java/com/google/cloud/spanner/pgadapter/wireprotocol/CopyDoneMessage.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/wireprotocol/CopyDoneMessage.java
@@ -55,14 +55,10 @@ public class CopyDoneMessage extends ControlMessage {
           this.outputStream.flush();
         } catch (Exception e) {
           // Spanner returned an error when trying to commit the batch of mutations.
-          mutationWriter.writeErrorFile(e);
-          mutationWriter.closeErrorFile();
           this.connection.setStatus(ConnectionStatus.AUTHENTICATED);
           this.connection.removeActiveStatement(this.statement);
           throw e;
         }
-      } else {
-        mutationWriter.closeErrorFile();
       }
     }
     this.connection.setStatus(ConnectionStatus.AUTHENTICATED);

--- a/src/main/java/com/google/cloud/spanner/pgadapter/wireprotocol/CopyFailMessage.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/wireprotocol/CopyFailMessage.java
@@ -50,7 +50,6 @@ public class CopyFailMessage extends ControlMessage {
     if (this.statement != null) {
       MutationWriter mutationWriter = this.statement.getMutationWriter();
       mutationWriter.rollback();
-      mutationWriter.closeErrorFile();
       statement.close();
       if (!statement.hasException()) {
         new ErrorResponse(this.outputStream, new Exception(this.errorMessage), State.IOError)

--- a/src/test/java/com/google/cloud/spanner/pgadapter/CopyInMockServerTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/CopyInMockServerTest.java
@@ -33,7 +33,6 @@ import com.google.spanner.v1.StructType.Field;
 import com.google.spanner.v1.Type;
 import com.google.spanner.v1.TypeCode;
 import io.grpc.Status;
-import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.StringReader;
@@ -237,8 +236,6 @@ public class CopyInMockServerTest extends AbstractMockServerTest {
           exception
               .getMessage()
               .contains("Row length mismatched. Expected 3 columns, but only found 1"));
-    } finally {
-      assertTrue(new File("output.txt").delete());
     }
 
     List<CommitRequest> commitRequests = mockSpanner.getRequestsOfType(CommitRequest.class);

--- a/src/test/java/com/google/cloud/spanner/pgadapter/wireprotocol/ProtocolTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/wireprotocol/ProtocolTest.java
@@ -62,7 +62,6 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
-import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -74,7 +73,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.json.simple.parser.JSONParser;
-import org.junit.AfterClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -131,19 +129,6 @@ public class ProtocolTest {
 
   private static ParsedStatement parse(String sql) {
     return PARSER.parse(Statement.of(sql));
-  }
-
-  @AfterClass
-  public static void cleanup() throws IOException {
-    deleteLogFile();
-  }
-
-  private static void deleteLogFile() {
-    // TODO: Make error log file configurable and turn off writing to a file during tests.
-    try {
-      Files.deleteIfExists(new File("output.txt").toPath());
-    } catch (IOException ignore) {
-    }
   }
 
   @Test
@@ -1498,8 +1483,6 @@ public class ProtocolTest {
         thrown.getMessage());
 
     copyStatement.close();
-
-    deleteLogFile();
   }
 
   @Test
@@ -1516,8 +1499,6 @@ public class ProtocolTest {
     copyStatement.execute();
     assertTrue(copyStatement.isExecuted());
 
-    deleteLogFile();
-
     MutationWriter mw = copyStatement.getMutationWriter();
     mw.addCopyData(payload);
 
@@ -1526,11 +1507,6 @@ public class ProtocolTest {
     assertEquals(
         "INVALID_ARGUMENT: Invalid input syntax for type INT64:\"'5'\"", thrown.getMessage());
 
-    File outputFile = new File("output.txt");
-    assertTrue(outputFile.exists());
-    assertTrue(outputFile.isFile());
-
-    deleteLogFile();
     copyStatement.close();
   }
 
@@ -1540,9 +1516,6 @@ public class ProtocolTest {
 
     byte[] payload =
         Files.readAllBytes(Paths.get("./src/test/resources/test-copy-start-output.txt"));
-
-    // Pre-emptively try to delete the output file if it is lingering from a previous test run.
-    deleteLogFile();
 
     String sql = "COPY keyvalue FROM STDIN;";
     CopyStatement copyStatement =
@@ -1559,11 +1532,6 @@ public class ProtocolTest {
     assertEquals(
         "INVALID_ARGUMENT: Invalid input syntax for type INT64:\"'1'\"", thrown.getMessage());
 
-    File outputFile = new File("output.txt");
-    assertTrue(outputFile.exists());
-    assertTrue(outputFile.isFile());
-
-    deleteLogFile();
     copyStatement.close();
   }
 


### PR DESCRIPTION
The COPY operation had a custom log file that was used to write any
errors that occurred during a COPY operation. This has now been replaced
by writing to the normal log file of PGAdapter, as there is no good
reason why COPY operations should log to a separate file.