### PR TITLE
build: use string array for extra files config

### DIFF
--- a/.github/release-please.yml
+++ b/.github/release-please.yml
@@ -2,9 +2,4 @@ primaryBranch: postgresql-dialect
 releaseType: java-yoshi
 bumpMinorPreMajor: true
 handleGHRelease: true
-extraFiles: [
-  {
-    type: "generic",
-    path: "README.md",
-  }
-]
+extraFiles: ["README.md"]


### PR DESCRIPTION
Fix the release-please config so it uses a string array as input for the `extraFiles` attribute.