### PR TITLE
test: ignore errors after connection failure

### DIFF
--- a/src/test/java/com/google/cloud/spanner/pgadapter/AbstractMockServerTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/AbstractMockServerTest.java
@@ -405,11 +405,15 @@ public abstract class AbstractMockServerTest {
     }
   }
 
+  protected void closeSpannerPool() {
+    closeSpannerPool(false);
+  }
+
   /**
    * Closes all open Spanner instances in the pool. Use this to force the recreation of a Spanner
    * instance for a test case. This method will ignore any errors and retry if closing fails.
    */
-  protected void closeSpannerPool() {
+  protected void closeSpannerPool(boolean ignoreException) {
     SpannerException exception = null;
     for (int attempt = 0; attempt < 1000; attempt++) {
       try {
@@ -424,7 +428,9 @@ public abstract class AbstractMockServerTest {
         exception = e;
       }
     }
-    throw exception;
+    if (!ignoreException) {
+      throw exception;
+    }
   }
 
   @Before

--- a/src/test/java/com/google/cloud/spanner/pgadapter/EmulatedPsqlMockServerTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/EmulatedPsqlMockServerTest.java
@@ -22,7 +22,6 @@ import static org.junit.Assert.assertTrue;
 import com.google.cloud.spanner.MockSpannerServiceImpl.SimulatedExecutionTime;
 import com.google.cloud.spanner.MockSpannerServiceImpl.StatementResult;
 import com.google.cloud.spanner.Statement;
-import com.google.cloud.spanner.connection.SpannerPool;
 import com.google.common.collect.ImmutableList;
 import com.google.rpc.ResourceInfo;
 import com.google.spanner.admin.database.v1.Database;
@@ -177,7 +176,7 @@ public class EmulatedPsqlMockServerTest extends AbstractMockServerTest {
           exception.getMessage(),
           exception.getMessage().contains("\tprojects/p/instances/i/databases/google-sql-db\n"));
     } finally {
-      SpannerPool.closeSpannerPool();
+      closeSpannerPool(true);
     }
   }
 
@@ -215,7 +214,7 @@ public class EmulatedPsqlMockServerTest extends AbstractMockServerTest {
       assertTrue(
           exception.getMessage(), exception.getMessage().contains("\tprojects/p/instances/i\n"));
     } finally {
-      SpannerPool.closeSpannerPool();
+      closeSpannerPool(true);
     }
   }
 


### PR DESCRIPTION
Ignore errors that happen after a connection failure happen, because an invalid database name was specified.