### PR TITLE
build: run integration tests in parallel

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -411,6 +411,8 @@
         </executions>
         <configuration>
           <forkedProcessTimeoutInSeconds>3600</forkedProcessTimeoutInSeconds>
+          <forkCount>8</forkCount>
+          <reuseForks>true</reuseForks>
           <argLine>${failsafe.jacoco.args}</argLine>
           <skipITs>${skipITs}</skipITs>
         </configuration>


### PR DESCRIPTION
Run integration tests in parallel to speed up build time.