### PR TITLE
test: use UUID for random db name

### DIFF
--- a/src/test/java/com/google/cloud/spanner/pgadapter/PgAdapterTestEnv.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/PgAdapterTestEnv.java
@@ -44,7 +44,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.Random;
+import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
@@ -267,10 +267,7 @@ public class PgAdapterTestEnv {
     if (databaseId == null) {
       databaseId = System.getProperty(TEST_DATABASE_PROPERTY, DEFAULT_DATABASE_ID);
     }
-    String id =
-        String.format(
-            "%s_%d_%d",
-            databaseId, System.currentTimeMillis(), new Random().nextInt(Short.MAX_VALUE));
+    String id = String.format("%s_%s", databaseId, UUID.randomUUID().toString().replace('-', '_'));
     // Make sure the database id is not longer than the max allowed 30 characters.
     if (id.length() > 30) {
       id = id.substring(0, 30);


### PR DESCRIPTION
Using the current system time to generate a 'random' test database name is
more prone to duplicates than using a UUID when the integration tests are
running in parallel.