### PR TITLE
build: enable nightly integration test run against Spanner staging

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -26,6 +26,12 @@ jobs:
           GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
         if: "${{ env.GCP_PROJECT_ID != '' }}"
         run: echo "::set-output name=defined::true"
+  integration-test:
+    needs: [check-env]
+    if: needs.check-env.outputs.has-key == 'true'
+    timeout-minutes: 60
+    runs-on: ubuntu-latest
+    steps:
       - id: set-manual-endpoint
         if: "${{ inputs.staging }}"
         run: |
@@ -34,12 +40,6 @@ jobs:
         if: github.event.schedule=='52 4 * * *'
         run: |
           echo "GOOGLE_CLOUD_ENDPOINT=staging-wrenchworks.sandbox.googleapis.com" >> $GITHUB_ENV
-  integration-test:
-    needs: [check-env]
-    if: needs.check-env.outputs.has-key == 'true'
-    timeout-minutes: 60
-    runs-on: ubuntu-latest
-    steps:
       - uses: actions/checkout@v3
       - name: Setup Java
         uses: actions/setup-java@v3

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -1,5 +1,11 @@
 on:
   pull_request:
+  workflow_dispatch:
+    inputs:
+      endpoint:
+        description: "The Cloud Spanner endpoint to use for the integration tests"
+        required: false
+        type: string
 name: integration
 env:
   GOOGLE_CLOUD_PROJECT: "span-cloud-testing"
@@ -17,6 +23,10 @@ jobs:
           GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
         if: "${{ env.GCP_PROJECT_ID != '' }}"
         run: echo "::set-output name=defined::true"
+      - id: endpoint
+        if: "${{ inputs.endpoint != '' }}"
+        env:
+          GOOGLE_CLOUD_ENDPOINT: ${{ inputs.endpoint }}
 
   integration-test:
     needs: [check-env]
@@ -24,6 +34,8 @@ jobs:
     timeout-minutes: 60
     runs-on: ubuntu-latest
     steps:
+      - run: |
+          echo "Running integration tests on endpoint: $GOOGLE_CLOUD_ENDPOINT"
       - uses: actions/checkout@v3
       - name: Setup Java
         uses: actions/setup-java@v3

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -1,11 +1,14 @@
 on:
   pull_request:
+  schedule:
+    # Run at 04:52UTC every day
+    - cron: '52 4 * * *'
   workflow_dispatch:
     inputs:
-      endpoint:
-        description: "The Cloud Spanner endpoint to use for the integration tests"
+      staging:
+        description: "Run the integration tests on the staging environment?"
         required: false
-        type: string
+        type: boolean
 name: integration
 env:
   GOOGLE_CLOUD_PROJECT: "span-cloud-testing"
@@ -23,13 +26,14 @@ jobs:
           GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
         if: "${{ env.GCP_PROJECT_ID != '' }}"
         run: echo "::set-output name=defined::true"
-      - id: endpoint
-        if: "${{ inputs.endpoint != '' }}"
+      - id: set-manual-endpoint
+        if: "${{ inputs.staging }}"
         run: |
-          echo "Running integration tests on endpoint: $GOOGLE_CLOUD_ENDPOINT"
-        env:
-          GOOGLE_CLOUD_ENDPOINT: ${{ inputs.endpoint }}
-
+          echo "GOOGLE_CLOUD_ENDPOINT=staging-wrenchworks.sandbox.googleapis.com" >> $GITHUB_ENV
+      - id: set-scheduled-endpoint
+        if: github.event.schedule=='52 4 * * *'
+        run: |
+          echo "GOOGLE_CLOUD_ENDPOINT=staging-wrenchworks.sandbox.googleapis.com" >> $GITHUB_ENV
   integration-test:
     needs: [check-env]
     if: needs.check-env.outputs.has-key == 'true'

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -25,6 +25,8 @@ jobs:
         run: echo "::set-output name=defined::true"
       - id: endpoint
         if: "${{ inputs.endpoint != '' }}"
+        run: |
+          echo "Running integration tests on endpoint: $GOOGLE_CLOUD_ENDPOINT"
         env:
           GOOGLE_CLOUD_ENDPOINT: ${{ inputs.endpoint }}
 
@@ -34,8 +36,6 @@ jobs:
     timeout-minutes: 60
     runs-on: ubuntu-latest
     steps:
-      - run: |
-          echo "Running integration tests on endpoint: $GOOGLE_CLOUD_ENDPOINT"
       - uses: actions/checkout@v3
       - name: Setup Java
         uses: actions/setup-java@v3


### PR DESCRIPTION
Schedules a nightly integration test run against the Spanner staging endpoint.