### PR TITLE
test: re-enable DescribeStatement tests for timestamptz and date

### DIFF
--- a/src/test/java/com/google/cloud/spanner/pgadapter/ITJdbcDescribeStatementTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/ITJdbcDescribeStatementTest.java
@@ -38,8 +38,6 @@ import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.sql.Types;
-import java.time.LocalDate;
-import java.time.OffsetDateTime;
 import java.util.Collections;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -204,9 +202,8 @@ public class ITJdbcDescribeStatementTest implements IntegrationTest {
           assertEquals(Types.DOUBLE, metadata.getParameterType(++index));
           assertEquals(Types.BIGINT, metadata.getParameterType(++index));
           assertEquals(Types.NUMERIC, metadata.getParameterType(++index));
-          // TODO: b/237989954
-          //          assertEquals(Types.TIMESTAMP, metadata.getParameterType(++index));
-          //          assertEquals(Types.DATE, metadata.getParameterType(++index));
+          assertEquals(Types.TIMESTAMP, metadata.getParameterType(++index));
+          assertEquals(Types.DATE, metadata.getParameterType(++index));
           assertEquals(Types.VARCHAR, metadata.getParameterType(++index));
         }
       }
@@ -357,16 +354,9 @@ public class ITJdbcDescribeStatementTest implements IntegrationTest {
         statement.setDouble(++index, 3.14d);
         statement.setInt(++index, 1);
         statement.setBigDecimal(++index, new BigDecimal("3.14"));
-        // TODO(b/237989954)
-        statement.setObject(
-            ++index,
-            OffsetDateTime.parse("2022-01-27T17:51:30+01:00"),
-            Types.TIMESTAMP_WITH_TIMEZONE);
-        statement.setObject(++index, LocalDate.parse("2022-04-29"), Types.DATE);
-        //        statement.setTimestamp(
-        //            ++index,
-        // Timestamp.parseTimestamp("2022-01-27T17:51:30+01:00").toSqlTimestamp());
-        //        statement.setDate(++index, Date.valueOf("2022-04-29"));
+        statement.setTimestamp(
+            ++index, Timestamp.parseTimestamp("2022-01-27T17:51:30+01:00").toSqlTimestamp());
+        statement.setDate(++index, Date.valueOf("2022-04-29"));
         statement.setString(++index, "test");
 
         try (ResultSet resultSet = statement.executeQuery()) {
@@ -410,16 +400,9 @@ public class ITJdbcDescribeStatementTest implements IntegrationTest {
         statement.setDouble(++index, 10.1);
         statement.setInt(++index, 100);
         statement.setBigDecimal(++index, new BigDecimal("6.626"));
-        // TODO(b/237989954)
-        statement.setObject(
-            ++index,
-            OffsetDateTime.parse("2022-02-11T13:45:00.123456+01:00"),
-            Types.TIMESTAMP_WITH_TIMEZONE);
-        statement.setObject(++index, LocalDate.parse("2022-04-29"), Types.DATE);
-        //        statement.setTimestamp(
-        //            ++index,
-        // Timestamp.parseTimestamp("2022-02-11T13:45:00.123456+01:00").toSqlTimestamp());
-        //        statement.setDate(++index, Date.valueOf("2022-04-29"));
+        statement.setTimestamp(
+            ++index, Timestamp.parseTimestamp("2022-02-11T13:45:00.123456+01:00").toSqlTimestamp());
+        statement.setDate(++index, Date.valueOf("2022-04-29"));
         statement.setString(++index, "string_test");
 
         assertEquals(1, statement.executeUpdate());
@@ -476,17 +459,10 @@ public class ITJdbcDescribeStatementTest implements IntegrationTest {
         statement.setBigDecimal(++index, new BigDecimal("10.0"));
         // Note that PostgreSQL does not support nanosecond precision, so the JDBC driver therefore
         // truncates this value before it is sent to PG.
-        // TODO(b/237989954)
-        statement.setObject(
+        statement.setTimestamp(
             ++index,
-            OffsetDateTime.parse("2022-02-11T14:04:59.123456789+01:00"),
-            Types.TIMESTAMP_WITH_TIMEZONE);
-        statement.setObject(++index, LocalDate.parse("2000-02-29"), Types.DATE);
-        //        statement.setTimestamp(
-        //            ++index,
-        //
-        // Timestamp.parseTimestamp("2022-02-11T14:04:59.123456789+01:00").toSqlTimestamp());
-        //        statement.setDate(++index, Date.valueOf("2000-02-29"));
+            Timestamp.parseTimestamp("2022-02-11T14:04:59.123456789+01:00").toSqlTimestamp());
+        statement.setDate(++index, Date.valueOf("2000-02-29"));
         statement.setString(++index, "updated");
         statement.setLong(++index, 1);
 
@@ -517,7 +493,6 @@ public class ITJdbcDescribeStatementTest implements IntegrationTest {
     }
   }
 
-  @Ignore("b/237989954")
   @Test
   public void testNullValues() throws SQLException {
     try (Connection connection = DriverManager.getConnection(getConnectionUrl())) {

--- a/src/test/java/com/google/cloud/spanner/pgadapter/golang/ITPgxTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/golang/ITPgxTest.java
@@ -39,7 +39,6 @@ import java.util.List;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -47,7 +46,6 @@ import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameter;
 import org.junit.runners.Parameterized.Parameters;
 
-@Ignore("b/237989954")
 @Category(IntegrationTest.class)
 @RunWith(Parameterized.class)
 public class ITPgxTest implements IntegrationTest {


### PR DESCRIPTION
Re-enable integration tests for `DescribeStatement`.