### PR TITLE
build: skip clirr check for integration tests

### DIFF
--- a/.ci/run-with-credentials.sh
+++ b/.ci/run-with-credentials.sh
@@ -36,7 +36,7 @@ lint)
   mvn -B com.coveo:fmt-maven-plugin:check
   ;;
 clirr)
-  mvn -B clirr:check
+  mvn -B clirr:check -Dclirr.skip=false
   ;;
 integration)
   mvn verify -B -Dclirr.skip=true -DskipITs=false -DPG_ADAPTER_HOST="https://${GOOGLE_CLOUD_ENDPOINT}" -DPG_ADAPTER_INSTANCE="${GOOGLE_CLOUD_INSTANCE}" -DPG_ADAPTER_DATABASE="${GOOGLE_CLOUD_DATABASE}"

--- a/pom.xml
+++ b/pom.xml
@@ -19,6 +19,7 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
     <skipITs>true</skipITs>
+    <clirr.skip>true</clirr.skip>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
@@ -287,6 +288,14 @@
       </testResource>
     </testResources>
     <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>clirr-maven-plugin</artifactId>
+        <configuration>
+          <skip>${clirr.skip}</skip>
+        </configuration>
+      </plugin>
+
       <plugin>
         <groupId>com.coveo</groupId>
         <artifactId>fmt-maven-plugin</artifactId>


### PR DESCRIPTION
Adds configuration so the `clirr.check` is actually skipped during integration tests.