### PR TITLE
build: disable clirr plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -291,6 +291,12 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>clirr-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <!-- Disable this plugin for now as it regularly times out when being downloaded -->
+            <phase>none</phase>
+          </execution>
+        </executions>
         <configuration>
           <skip>${clirr.skip}</skip>
         </configuration>


### PR DESCRIPTION
Disable clirr for now as it regularly times out when the plugin is downloaded.