### PR TITLE
build: run integration tests on main branch after push

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -1,4 +1,7 @@
 on:
+  push:
+    branches:
+      - postgresql-dialect
   pull_request:
   schedule:
     # Run at 04:52UTC every day


### PR DESCRIPTION
Run the integration tests on the main branch after push to ensure that
the change does not break anything, and to create a baseline for code
coverage reports.