### PR TITLE
fix: prepared statement could return error 'This ResultSet is closed'

### DIFF
--- a/src/main/java/com/google/cloud/spanner/pgadapter/metadata/DescribeStatementMetadata.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/metadata/DescribeStatementMetadata.java
@@ -20,7 +20,8 @@ import com.google.cloud.spanner.ResultSet;
 
 /** Simple POJO to hold describe metadata specific to prepared statements. */
 @InternalApi
-public class DescribeStatementMetadata extends DescribeMetadata<Tuple<int[], ResultSet>> {
+public class DescribeStatementMetadata extends DescribeMetadata<Tuple<int[], ResultSet>>
+    implements AutoCloseable {
 
   public DescribeStatementMetadata(int[] parameters, ResultSet resultMetaData) {
     this.metadata = Tuple.of(parameters, resultMetaData);
@@ -32,5 +33,12 @@ public class DescribeStatementMetadata extends DescribeMetadata<Tuple<int[], Res
 
   public ResultSet getResultSet() {
     return metadata.y();
+  }
+
+  @Override
+  public void close() {
+    if (getResultSet() != null) {
+      getResultSet().close();
+    }
   }
 }

--- a/src/main/java/com/google/cloud/spanner/pgadapter/wireprotocol/DescribeMessage.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/wireprotocol/DescribeMessage.java
@@ -166,8 +166,8 @@ public class DescribeMessage extends AbstractQueryProtocolMessage {
    * @throws Exception if sending the message back to the client causes an error.
    */
   public void handleDescribeStatement() throws Exception {
-    try {
-      DescribeStatementMetadata metadata = (DescribeStatementMetadata) this.statement.describe();
+    try (DescribeStatementMetadata metadata =
+        (DescribeStatementMetadata) this.statement.describe()) {
       new ParameterDescriptionResponse(this.outputStream, metadata.getParameters()).send(false);
       if (metadata.getResultSet() != null) {
         new RowDescriptionResponse(

--- a/src/test/java/com/google/cloud/spanner/pgadapter/JdbcMockServerTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/JdbcMockServerTest.java
@@ -65,6 +65,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
+import org.postgresql.PGConnection;
 import org.postgresql.PGStatement;
 import org.postgresql.jdbc.PgStatement;
 
@@ -273,6 +274,27 @@ public class JdbcMockServerTest extends AbstractMockServerTest {
       assertEquals("test", params.get("p9").getStringValue());
 
       mockSpanner.clearRequests();
+    }
+  }
+
+  @Test
+  public void testMultipleQueriesInTransaction() throws SQLException {
+    String sql = "SELECT 1";
+
+    try (Connection connection = DriverManager.getConnection(createUrl())) {
+      // Use a read/write transaction to execute two queries.
+      connection.setAutoCommit(false);
+      // Force the use of prepared statements.
+      connection.unwrap(PGConnection.class).setPrepareThreshold(-1);
+      for (int i = 0; i < 2; i++) {
+        // https://github.com/GoogleCloudPlatform/pgadapter/issues/278
+        // This would return `ERROR: FAILED_PRECONDITION: This ResultSet is closed`
+        try (ResultSet resultSet = connection.createStatement().executeQuery(sql)) {
+          assertTrue(resultSet.next());
+          assertEquals(1L, resultSet.getLong(1));
+          assertFalse(resultSet.next());
+        }
+      }
     }
   }
 


### PR DESCRIPTION
Executing a query using a server side prepared statement in a read/write transaction
would return the error "This ResultSet is closed". This happened because the result
set that was used to describe the statement would be closed before the actual result
was sent.

Fixes #278