### PR TITLE
perf: treat 'flush and sync' as 'sync'

### DIFF
--- a/src/main/java/com/google/cloud/spanner/pgadapter/metadata/ConnectionMetadata.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/metadata/ConnectionMetadata.java
@@ -17,6 +17,7 @@ package com.google.cloud.spanner.pgadapter.metadata;
 import com.google.api.core.InternalApi;
 import com.google.cloud.Tuple;
 import com.google.common.base.Preconditions;
+import com.google.common.base.Stopwatch;
 import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
 import java.io.DataInputStream;
@@ -25,6 +26,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.Stack;
+import java.util.concurrent.TimeUnit;
 
 @InternalApi
 public class ConnectionMetadata implements AutoCloseable {
@@ -83,12 +85,19 @@ public class ConnectionMetadata implements AutoCloseable {
   public DataOutputStream peekOutputStream() {
     return outputStream.peek();
   }
+
   /**
    * Returns the next byte in the input stream without removing it. Returns zero if no bytes are
-   * available.
+   * available. This method will wait for up to maxWaitMillis milliseconds to allow pending data to
+   * become available in the buffer.
    */
-  public char peekNextByte() throws IOException {
+  public char peekNextByte(long maxWaitMillis) throws IOException {
     DataInputStream dataInputStream = inputStream.peek();
+    Stopwatch stopwatch = Stopwatch.createStarted();
+    while (dataInputStream.available() == 0
+        && stopwatch.elapsed(TimeUnit.MILLISECONDS) < maxWaitMillis) {
+      Thread.yield();
+    }
     if (dataInputStream.available() > 0) {
       dataInputStream.mark(1);
       char result = (char) dataInputStream.readUnsignedByte();

--- a/src/main/java/com/google/cloud/spanner/pgadapter/metadata/ConnectionMetadata.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/metadata/ConnectionMetadata.java
@@ -21,6 +21,7 @@ import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
+import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.Stack;
@@ -81,5 +82,20 @@ public class ConnectionMetadata implements AutoCloseable {
   /** Returns the current {@link DataOutputStream} for the connection. */
   public DataOutputStream peekOutputStream() {
     return outputStream.peek();
+  }
+  /**
+   * Returns the next byte in the input stream without removing it. Returns zero if no bytes are
+   * available.
+   */
+  public char peekNextByte() throws IOException {
+    DataInputStream dataInputStream = inputStream.peek();
+    if (dataInputStream.available() > 0) {
+      dataInputStream.mark(1);
+      char result = (char) dataInputStream.readUnsignedByte();
+      dataInputStream.reset();
+
+      return result;
+    }
+    return 0;
   }
 }

--- a/src/main/java/com/google/cloud/spanner/pgadapter/wireprotocol/ControlMessage.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/wireprotocol/ControlMessage.java
@@ -93,7 +93,7 @@ public abstract class ControlMessage extends WireMessage {
     this.manuallyCreatedToken = token;
   }
 
-  protected boolean isExtendedProtocol() {
+  public boolean isExtendedProtocol() {
     return manuallyCreatedToken == null;
   }
 

--- a/src/main/java/com/google/cloud/spanner/pgadapter/wireprotocol/FlushMessage.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/wireprotocol/FlushMessage.java
@@ -37,7 +37,19 @@ public class FlushMessage extends ControlMessage {
 
   @Override
   protected void sendPayload() throws Exception {
-    connection.getExtendedQueryProtocolHandler().flush();
+    // Pretend that this message is a sync if it is followed directly by a sync message.
+    // This allows us to use a more efficient transaction type for single queries, as we know that
+    // no other query will be following after the flush.
+    if (isExtendedProtocol()) {
+      char nextMessage = connection.getConnectionMetadata().peekNextByte();
+      if (nextMessage == SyncMessage.IDENTIFIER) {
+        connection.getExtendedQueryProtocolHandler().sync();
+      } else {
+        connection.getExtendedQueryProtocolHandler().flush();
+      }
+    } else {
+      connection.getExtendedQueryProtocolHandler().flush();
+    }
   }
 
   @Override

--- a/src/main/java/com/google/cloud/spanner/pgadapter/wireprotocol/FlushMessage.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/wireprotocol/FlushMessage.java
@@ -37,20 +37,7 @@ public class FlushMessage extends ControlMessage {
 
   @Override
   protected void sendPayload() throws Exception {
-    // Pretend that this message is a sync if it is followed directly by a sync message.
-    // This allows us to use a more efficient transaction type for single queries, as we know that
-    // no other query will be following after the flush.
-    if (isExtendedProtocol()) {
-      char nextMessage = connection.getConnectionMetadata().peekNextByte();
-      if (nextMessage == SyncMessage.IDENTIFIER) {
-        connection.getExtendedQueryProtocolHandler().sync();
-      } else {
-        connection.getExtendedQueryProtocolHandler().flush();
-      }
-    } else {
-      connection.getExtendedQueryProtocolHandler().flush();
-    }
-    connection.getConnectionMetadata().peekOutputStream().flush();
+    connection.getExtendedQueryProtocolHandler().flush();
   }
 
   @Override

--- a/src/main/java/com/google/cloud/spanner/pgadapter/wireprotocol/FlushMessage.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/wireprotocol/FlushMessage.java
@@ -50,6 +50,7 @@ public class FlushMessage extends ControlMessage {
     } else {
       connection.getExtendedQueryProtocolHandler().flush();
     }
+    connection.getConnectionMetadata().peekOutputStream().flush();
   }
 
   @Override

--- a/src/main/java/com/google/cloud/spanner/pgadapter/wireprotocol/SyncMessage.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/wireprotocol/SyncMessage.java
@@ -26,7 +26,7 @@ import java.text.MessageFormat;
 @InternalApi
 public class SyncMessage extends ControlMessage {
 
-  protected static final char IDENTIFIER = 'S';
+  public static final char IDENTIFIER = 'S';
 
   public SyncMessage(ConnectionHandler connection) throws Exception {
     super(connection);

--- a/src/test/java/com/google/cloud/spanner/pgadapter/AbstractMockServerTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/AbstractMockServerTest.java
@@ -58,6 +58,7 @@ import io.grpc.StatusRuntimeException;
 import io.grpc.netty.shaded.io.grpc.netty.NettyServerBuilder;
 import java.net.InetSocketAddress;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.Base64;
 import java.util.Collections;
 import java.util.List;
@@ -247,6 +248,10 @@ public abstract class AbstractMockServerTest {
   protected static MockInstanceAdminImpl mockInstanceAdmin;
   private static Server spannerServer;
   protected static ProxyServer pgServer;
+
+  protected List<WireMessage> getWireMessages() {
+    return new ArrayList<>(pgServer.getDebugMessages());
+  }
 
   protected <T extends WireMessage> List<T> getWireMessagesOfType(Class<T> type) {
     return pgServer.getDebugMessages().stream()

--- a/src/test/java/com/google/cloud/spanner/pgadapter/statements/ExtendedQueryProtocolHandlerTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/statements/ExtendedQueryProtocolHandlerTest.java
@@ -18,12 +18,16 @@ import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
+import com.google.cloud.spanner.pgadapter.ConnectionHandler;
+import com.google.cloud.spanner.pgadapter.metadata.ConnectionMetadata;
 import com.google.cloud.spanner.pgadapter.wireprotocol.BindMessage;
 import com.google.cloud.spanner.pgadapter.wireprotocol.DescribeMessage;
 import com.google.cloud.spanner.pgadapter.wireprotocol.ExecuteMessage;
 import com.google.cloud.spanner.pgadapter.wireprotocol.ParseMessage;
 import com.google.common.collect.ImmutableList;
+import java.io.DataOutputStream;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -36,6 +40,7 @@ import org.mockito.junit.MockitoRule;
 public class ExtendedQueryProtocolHandlerTest {
   @Rule public MockitoRule rule = MockitoJUnit.rule();
 
+  @Mock private ConnectionHandler connectionHandler;
   @Mock private BackendConnection backendConnection;
 
   @Test
@@ -45,7 +50,8 @@ public class ExtendedQueryProtocolHandlerTest {
     DescribeMessage describeMessage = mock(DescribeMessage.class);
     ExecuteMessage executeMessage = mock(ExecuteMessage.class);
 
-    ExtendedQueryProtocolHandler handler = new ExtendedQueryProtocolHandler(backendConnection);
+    ExtendedQueryProtocolHandler handler =
+        new ExtendedQueryProtocolHandler(connectionHandler, backendConnection);
     handler.buffer(parseMessage);
     handler.buffer(bindMessage);
     handler.buffer(describeMessage);
@@ -58,12 +64,16 @@ public class ExtendedQueryProtocolHandlerTest {
 
   @Test
   public void testFlush() throws Exception {
+    ConnectionMetadata connectionMetadata = mock(ConnectionMetadata.class);
+    when(connectionMetadata.peekOutputStream()).thenReturn(mock(DataOutputStream.class));
+    when(connectionHandler.getConnectionMetadata()).thenReturn(connectionMetadata);
     ParseMessage parseMessage = mock(ParseMessage.class);
     BindMessage bindMessage = mock(BindMessage.class);
     DescribeMessage describeMessage = mock(DescribeMessage.class);
     ExecuteMessage executeMessage = mock(ExecuteMessage.class);
 
-    ExtendedQueryProtocolHandler handler = new ExtendedQueryProtocolHandler(backendConnection);
+    ExtendedQueryProtocolHandler handler =
+        new ExtendedQueryProtocolHandler(connectionHandler, backendConnection);
     handler.buffer(parseMessage);
     handler.buffer(bindMessage);
     handler.buffer(describeMessage);
@@ -85,12 +95,16 @@ public class ExtendedQueryProtocolHandlerTest {
 
   @Test
   public void testSync() throws Exception {
+    ConnectionMetadata connectionMetadata = mock(ConnectionMetadata.class);
+    when(connectionMetadata.peekOutputStream()).thenReturn(mock(DataOutputStream.class));
+    when(connectionHandler.getConnectionMetadata()).thenReturn(connectionMetadata);
     ParseMessage parseMessage = mock(ParseMessage.class);
     BindMessage bindMessage = mock(BindMessage.class);
     DescribeMessage describeMessage = mock(DescribeMessage.class);
     ExecuteMessage executeMessage = mock(ExecuteMessage.class);
 
-    ExtendedQueryProtocolHandler handler = new ExtendedQueryProtocolHandler(backendConnection);
+    ExtendedQueryProtocolHandler handler =
+        new ExtendedQueryProtocolHandler(connectionHandler, backendConnection);
     handler.buffer(parseMessage);
     handler.buffer(bindMessage);
     handler.buffer(describeMessage);

--- a/src/test/java/com/google/cloud/spanner/pgadapter/wireprotocol/ProtocolTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/wireprotocol/ProtocolTest.java
@@ -1185,7 +1185,7 @@ public class ProtocolTest {
     when(connectionMetadata.peekOutputStream()).thenReturn(outputStream);
 
     ExtendedQueryProtocolHandler extendedQueryProtocolHandler =
-        new ExtendedQueryProtocolHandler(backendConnection);
+        new ExtendedQueryProtocolHandler(connectionHandler, backendConnection);
     when(connectionHandler.getExtendedQueryProtocolHandler())
         .thenReturn(extendedQueryProtocolHandler);
 


### PR DESCRIPTION
Some drivers unnecessarily send a Flush and a Sync message after an
extended query protocol sequence. This is unnecessary because Sync
already means that the pipeline should be flushed. It also causes an
inefficiency specifically in PGAdapter, as PGAdapter will choose a
transaction that is efficient for executing one query when it knows
that the implicit transaction only contains a single query. This is
not guaranteed if an extended query protocol sequence is ended by a
flush, as a flush could be followed by additional queries. PGAdapter
would therefore normally need to create an implicit read/write transaction
if it receives a Flush message after a query.

This change makes PGAdapter perform a look-ahead when it receives a
Flush message. If the next message is already available in the pipeline
and it is a Sync message, PGAdapter will treat the Flush message as if
it was a Sync message. This will ensure that a single query will use a
single-use read-only transaction even when it is followed by a flush
and sync message sequence.

The above behavior has been spotted in the NodeJS PostgreSQL driver.