### PR TITLE
feat: ignore named primary keys with correct name

### DIFF
--- a/src/main/java/com/google/cloud/spanner/pgadapter/statements/SimpleParser.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/statements/SimpleParser.java
@@ -142,12 +142,12 @@ class SimpleParser {
   }
 
   TableOrIndexName readTableOrIndexName() {
-    String nameOrSchema = readTableOrIndexNamePart();
+    String nameOrSchema = readIdentifierPart();
     if (nameOrSchema == null) {
       return null;
     }
     if (eat(".")) {
-      String name = readTableOrIndexNamePart();
+      String name = readIdentifierPart();
       if (name == null) {
         name = "";
       }
@@ -156,8 +156,11 @@ class SimpleParser {
     return new TableOrIndexName(nameOrSchema);
   }
 
-  String readTableOrIndexNamePart() {
+  String readIdentifierPart() {
     skipWhitespaces();
+    if (pos >= sql.length()) {
+      return null;
+    }
     boolean quoted = sql.charAt(pos) == '"';
     int start = pos;
     if (quoted) {

--- a/src/test/java/com/google/cloud/spanner/pgadapter/statements/DdlExecutorTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/statements/DdlExecutorTest.java
@@ -389,4 +389,62 @@ public class DdlExecutorTest {
         translate("drop index if exists \"s\".\"Foo\"", executor));
     assertEquals(Statement.of("drop index if exists"), translate("drop index if exists", executor));
   }
+
+  @Test
+  public void testMaybeRemovePrimaryKeyConstraintName() {
+    DdlExecutor ddlExecutor = new DdlExecutor(mock(BackendConnection.class));
+
+    assertEquals(
+        Statement.of("create table foo (id bigint primary key, value text)"),
+        ddlExecutor.maybeRemovePrimaryKeyConstraintName(
+            Statement.of("create table foo (id bigint primary key, value text)")));
+    assertEquals(
+        Statement.of("create table foo (id bigint, value text, primary key (id))"),
+        ddlExecutor.maybeRemovePrimaryKeyConstraintName(
+            Statement.of("create table foo (id bigint, value text, primary key (id))")));
+    assertEquals(
+        Statement.of(
+            "create table foo (value1 varchar, value2 text, primary key (value1, value2))"),
+        ddlExecutor.maybeRemovePrimaryKeyConstraintName(
+            Statement.of(
+                "create table foo (value1 varchar, value2 text, primary key (value1, value2))")));
+    assertEquals(
+        Statement.of(
+            "create table foo (id bigint primary key, value text, constraint chk_bar check (length(value) < 100))"),
+        ddlExecutor.maybeRemovePrimaryKeyConstraintName(
+            Statement.of(
+                "create table foo (id bigint primary key, value text, constraint chk_bar check (length(value) < 100))")));
+
+    // Only primary key constraints that are literally named 'pk_<table-name>' are replaced.
+    assertEquals(
+        Statement.of(
+            "create table foo (id bigint, value text, constraint pk_a1b2 primary key (id) )"),
+        ddlExecutor.maybeRemovePrimaryKeyConstraintName(
+            Statement.of(
+                "create table foo (id bigint, value text, constraint pk_a1b2 primary key (id) )")));
+
+    assertEquals(
+        Statement.of("create table foo (id bigint, value text,  primary key (id) )"),
+        ddlExecutor.maybeRemovePrimaryKeyConstraintName(
+            Statement.of(
+                "create table foo (id bigint, value text, constraint pk_foo primary key (id) )")));
+    assertEquals(
+        Statement.of(
+            "create table foo (id bigint, value text,  primary key (id), constraint fk_bar foreign key (value) references bar (id))"),
+        ddlExecutor.maybeRemovePrimaryKeyConstraintName(
+            Statement.of(
+                "create table foo (id bigint, value text, constraint pk_foo primary key (id), constraint fk_bar foreign key (value) references bar (id))")));
+    assertEquals(
+        Statement.of("create table public.foo (id bigint, value text,  primary key (id) )"),
+        ddlExecutor.maybeRemovePrimaryKeyConstraintName(
+            Statement.of(
+                "create table public.foo (id bigint, value text, constraint pk_foo primary key (id) )")));
+
+    assertEquals(
+        Statement.of(
+            "CREATE TABLE \"user\" (\"id\" integer NOT NULL, \"firstName\" character varying NOT NULL, \"lastName\" character varying NOT NULL, \"age\" integer NOT NULL,  PRIMARY KEY (\"id\"))"),
+        ddlExecutor.maybeRemovePrimaryKeyConstraintName(
+            Statement.of(
+                "CREATE TABLE \"user\" (\"id\" integer NOT NULL, \"firstName\" character varying NOT NULL, \"lastName\" character varying NOT NULL, \"age\" integer NOT NULL, CONSTRAINT \"PK_user\" PRIMARY KEY (\"id\"))")));
+  }
 }

--- a/src/test/java/com/google/cloud/spanner/pgadapter/statements/SimpleParserTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/statements/SimpleParserTest.java
@@ -48,21 +48,21 @@ public class SimpleParserTest {
 
   @Test
   public void testReadTableOrIndexNamePart() {
-    assertEquals("foo", new SimpleParser("foo bar").readTableOrIndexNamePart());
-    assertEquals("foo", new SimpleParser("foo").readTableOrIndexNamePart());
-    assertEquals("\"foo\"", new SimpleParser("\"foo\" bar").readTableOrIndexNamePart());
-    assertEquals("\"foo\"", new SimpleParser("\"foo\"").readTableOrIndexNamePart());
-    assertEquals("foo", new SimpleParser(" foo bar").readTableOrIndexNamePart());
-    assertEquals("foo", new SimpleParser("\tfoo").readTableOrIndexNamePart());
-    assertEquals("\"foo\"", new SimpleParser("\n\"foo\" bar").readTableOrIndexNamePart());
-    assertEquals("\"foo\"", new SimpleParser("    \"foo\"").readTableOrIndexNamePart());
-    assertEquals("\"foo\"\"bar\"", new SimpleParser("\"foo\"\"bar\"").readTableOrIndexNamePart());
-    assertEquals("foo", new SimpleParser("foo\"bar\"").readTableOrIndexNamePart());
-    assertEquals("foo", new SimpleParser("foo.bar").readTableOrIndexNamePart());
-    assertEquals("foo", new SimpleParser("foo").readTableOrIndexNamePart());
-    assertEquals("\"foo\"", new SimpleParser("\"foo\".bar").readTableOrIndexNamePart());
-    assertEquals("\"foo\"", new SimpleParser("\"foo\"").readTableOrIndexNamePart());
-    assertNull(new SimpleParser("\"foo").readTableOrIndexNamePart());
+    assertEquals("foo", new SimpleParser("foo bar").readIdentifierPart());
+    assertEquals("foo", new SimpleParser("foo").readIdentifierPart());
+    assertEquals("\"foo\"", new SimpleParser("\"foo\" bar").readIdentifierPart());
+    assertEquals("\"foo\"", new SimpleParser("\"foo\"").readIdentifierPart());
+    assertEquals("foo", new SimpleParser(" foo bar").readIdentifierPart());
+    assertEquals("foo", new SimpleParser("\tfoo").readIdentifierPart());
+    assertEquals("\"foo\"", new SimpleParser("\n\"foo\" bar").readIdentifierPart());
+    assertEquals("\"foo\"", new SimpleParser("    \"foo\"").readIdentifierPart());
+    assertEquals("\"foo\"\"bar\"", new SimpleParser("\"foo\"\"bar\"").readIdentifierPart());
+    assertEquals("foo", new SimpleParser("foo\"bar\"").readIdentifierPart());
+    assertEquals("foo", new SimpleParser("foo.bar").readIdentifierPart());
+    assertEquals("foo", new SimpleParser("foo").readIdentifierPart());
+    assertEquals("\"foo\"", new SimpleParser("\"foo\".bar").readIdentifierPart());
+    assertEquals("\"foo\"", new SimpleParser("\"foo\"").readIdentifierPart());
+    assertNull(new SimpleParser("\"foo").readIdentifierPart());
   }
 
   @Test


### PR DESCRIPTION
CREATE TABLE statements that contain a named primary key constraint are
rejected by the backend, as the name of a primary key is fixed to 'PK_<table_name>'.
This change parses and removes named primary key constraint from CREATE TABLE
statements when these specify the same name as the generated name. This enables
the usage of frameworks that always generate CREATE TABLE statements with a named
primary key constraint, as long as the name that has been configured is equal to
the fixed name. The fact that the named constraint is stripped from the DDL
statement does not have any effect on the result of the statement, as the
generated name will be equal to the name specified in the statement.