### PR TITLE
test: update psql tests to include schema_owner

### DIFF
--- a/.ci/e2e-expected/backslash-dn-param.txt
+++ b/.ci/e2e-expected/backslash-dn-param.txt
@@ -1,6 +1,6 @@
                                                                                 List of schemas
     catalog_name     | schema_name | schema_owner | default_character_set_catalog | default_character_set_schema | default_character_set_name | sql_path | effective_timestamp 
 +++++++
- testdb_e2e_psql_v?? | public      |              |                               |                              |                            |          |
+ testdb_e2e_psql_v?? | public      | spanner_admin |                               |                              |                            |          |
 (1 row)
 

--- a/.ci/e2e-expected/backslash-dn.txt
+++ b/.ci/e2e-expected/backslash-dn.txt
@@ -1,9 +1,9 @@
                                                                                 List of schemas
  catalog_name |    schema_name     | schema_owner | default_character_set_catalog | default_character_set_schema | default_character_set_name | sql_path | effective_timestamp 
 +++++++
- testdb_e2e_psql_v?? | public             |              |                               |                              |                            |          |
- testdb_e2e_psql_v?? | pg_catalog         |              |                               |                              |                            |          |
- testdb_e2e_psql_v?? | information_schema |              |                               |                              |                            |          |
- testdb_e2e_psql_v?? | spanner_sys        |              |                               |                              |                            |          |                    
+ testdb_e2e_psql_v?? | public             | spanner_admin  |                               |                              |                            |          |
+ testdb_e2e_psql_v?? | pg_catalog         | spanner_system |                               |                              |                            |          |
+ testdb_e2e_psql_v?? | information_schema | spanner_system |                               |                              |                            |          |
+ testdb_e2e_psql_v?? | spanner_sys        | spanner_system |                               |                              |                            |          |
 (4 rows)
 


### PR DESCRIPTION
Update the expected output of `psql` tests to include the `schema_owner`.