### PR TITLE
fix: translate queries for all table types in JDBC metadata

### DIFF
--- a/src/main/java/com/google/cloud/spanner/pgadapter/statements/JdbcMetadataStatementHelper.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/statements/JdbcMetadataStatementHelper.java
@@ -247,8 +247,62 @@ class JdbcMetadataStatementHelper {
             "c.relkind IN ('r','p') AND n.nspname !~ '^pg_' AND n.nspname <> 'information_schema'",
             "(CASE WHEN TABLE_TYPE = 'BASE TABLE' THEN 'TABLE' ELSE TABLE_TYPE END) = 'TABLE'")
         .replace(
+            "c.relkind = 'p' AND n.nspname !~ '^pg_' AND n.nspname <> 'information_schema'",
+            "(CASE WHEN TABLE_TYPE = 'BASE TABLE' THEN 'TABLE' ELSE TABLE_TYPE END) = 'TABLE'")
+        .replace(
             "c.relkind = 'v' AND n.nspname <> 'pg_catalog' AND n.nspname <> 'information_schema'",
             "(CASE WHEN TABLE_TYPE = 'BASE TABLE' THEN 'TABLE' ELSE TABLE_TYPE END) = 'VIEW'")
+        .replace(
+            "c.relkind = 'i' AND n.nspname !~ '^pg_' AND n.nspname <> 'information_schema'",
+            "(CASE WHEN TABLE_TYPE = 'BASE TABLE' THEN 'TABLE' ELSE TABLE_TYPE END) = 'INDEX'")
+        .replace(
+            "c.relkind = 'I' AND n.nspname !~ '^pg_' AND n.nspname <> 'information_schema'",
+            "(CASE WHEN TABLE_TYPE = 'BASE TABLE' THEN 'TABLE' ELSE TABLE_TYPE END) = 'INDEX'")
+        .replace(
+            "c.relkind = 'S' AND n.nspname ~ '^pg_temp_'",
+            "(CASE WHEN TABLE_TYPE = 'BASE TABLE' THEN 'TABLE' ELSE TABLE_TYPE END) = 'TEMP SEQUENCE'")
+        .replace(
+            "c.relkind = 'S'",
+            "(CASE WHEN TABLE_TYPE = 'BASE TABLE' THEN 'TABLE' ELSE TABLE_TYPE END) = 'SEQUENCE'")
+        .replace(
+            "c.relkind = 'c' AND n.nspname !~ '^pg_' AND n.nspname <> 'information_schema'",
+            "(CASE WHEN TABLE_TYPE = 'BASE TABLE' THEN 'TABLE' ELSE TABLE_TYPE END) = 'TYPE'")
+        .replace(
+            "c.relkind = 'r' AND (n.nspname = 'pg_catalog' OR n.nspname = 'information_schema')",
+            "(CASE WHEN TABLE_TYPE = 'BASE TABLE' THEN 'TABLE' ELSE TABLE_TYPE END) = 'SYSTEM TABLE'")
+        .replace(
+            "c.relkind = 'r' AND n.nspname = 'pg_toast'",
+            "(CASE WHEN TABLE_TYPE = 'BASE TABLE' THEN 'TABLE' ELSE TABLE_TYPE END) = 'SYSTEM TOAST TABLE'")
+        .replace(
+            "c.relkind = 'i' AND n.nspname = 'pg_toast'",
+            "(CASE WHEN TABLE_TYPE = 'BASE TABLE' THEN 'TABLE' ELSE TABLE_TYPE END) = 'SYSTEM TOAST INDEX'")
+        .replace(
+            "c.relkind = 'v' AND (n.nspname = 'pg_catalog' OR n.nspname = 'information_schema')",
+            "(CASE WHEN TABLE_TYPE = 'BASE TABLE' THEN 'TABLE' ELSE TABLE_TYPE END) = 'SYSTEM VIEW'")
+        .replace(
+            "c.relkind = 'i' AND (n.nspname = 'pg_catalog' OR n.nspname = 'information_schema')",
+            "(CASE WHEN TABLE_TYPE = 'BASE TABLE' THEN 'TABLE' ELSE TABLE_TYPE END) = 'SYSTEM INDEX'")
+        .replace(
+            "c.relkind IN ('r','p') AND n.nspname ~ '^pg_temp_'",
+            "(CASE WHEN TABLE_TYPE = 'BASE TABLE' THEN 'TABLE' ELSE TABLE_TYPE END) = 'TEMP TABLE'")
+        .replace(
+            "c.relkind = 'r' AND n.nspname ~ '^pg_temp_'",
+            "(CASE WHEN TABLE_TYPE = 'BASE TABLE' THEN 'TABLE' ELSE TABLE_TYPE END) = 'TEMP TABLE'")
+        .replace(
+            "c.relkind = 'i' AND n.nspname ~ '^pg_temp_'",
+            "(CASE WHEN TABLE_TYPE = 'BASE TABLE' THEN 'TABLE' ELSE TABLE_TYPE END) = 'TEMP INDEX'")
+        .replace(
+            "c.relkind = 'v' AND n.nspname ~ '^pg_temp_'",
+            "(CASE WHEN TABLE_TYPE = 'BASE TABLE' THEN 'TABLE' ELSE TABLE_TYPE END) = 'TEMP VIEW'")
+        .replace(
+            "c.relkind = 'S' AND n.nspname ~ '^pg_temp_'",
+            "(CASE WHEN TABLE_TYPE = 'BASE TABLE' THEN 'TABLE' ELSE TABLE_TYPE END) = 'TEMP SEQUENCE'")
+        .replace(
+            "c.relkind = 'f'",
+            "(CASE WHEN TABLE_TYPE = 'BASE TABLE' THEN 'TABLE' ELSE TABLE_TYPE END) = 'FOREIGN TABLE'")
+        .replace(
+            "c.relkind = 'm'",
+            "(CASE WHEN TABLE_TYPE = 'BASE TABLE' THEN 'TABLE' ELSE TABLE_TYPE END) = 'MATERIALIZED VIEW'")
         .replace(
             "ORDER BY TABLE_TYPE,TABLE_SCHEM,TABLE_NAME",
             "ORDER BY TABLE_CATALOG, TABLE_SCHEMA, TABLE_NAME");

--- a/src/test/java/com/google/cloud/spanner/pgadapter/ITJdbcMetadataTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/ITJdbcMetadataTest.java
@@ -296,6 +296,54 @@ public class ITJdbcMetadataTest implements IntegrationTest {
   }
 
   @Test
+  public void testDatabaseMetaDataTables_AllTypes() throws Exception {
+    runForAllVersions(
+        connection -> {
+          try {
+            DatabaseMetaData metadata = connection.getMetaData();
+            try (ResultSet tables =
+                metadata.getTables(
+                    null,
+                    "public",
+                    "%a%",
+                    new String[] {
+                      "TABLE",
+                      "PARTITIONED TABLE",
+                      "INDEX",
+                      "PARTITIONED INDEX",
+                      "SEQUENCE",
+                      "TYPE",
+                      "SYSTEM TABLE",
+                      "SYSTEM TOAST TABLE",
+                      "SYSTEM TOAST INDEX",
+                      "SYSTEM VIEW",
+                      "SYSTEM INDEX",
+                      "TEMPORARY TABLE",
+                      "TEMPORARY INDEX",
+                      "TEMPORARY VIEW",
+                      "TEMPORARY SEQUENCE",
+                      "FOREIGN TABLE",
+                      "MATERIALIZED VIEW",
+                      "VIEW"
+                    })) {
+              assertTrue(tables.next());
+              assertEquals("albums", tables.getString("TABLE_NAME"));
+              assertTrue(tables.next());
+              assertEquals("all_types", tables.getString("TABLE_NAME"));
+              assertTrue(tables.next());
+              assertEquals("recording_attempt", tables.getString("TABLE_NAME"));
+              assertTrue(tables.next());
+              assertEquals("tracks", tables.getString("TABLE_NAME"));
+
+              assertFalse(tables.next());
+            }
+          } catch (SQLException e) {
+            throw SpannerExceptionFactory.asSpannerException(e);
+          }
+        });
+  }
+
+  @Test
   public void testDatabaseMetaDataColumns() throws Exception {
     runForAllVersions(
         connection -> {


### PR DESCRIPTION
Add translations for all table types in the JDBC getTables metadata
query.