### PR TITLE
Describe statement parameter description

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,8 @@
       com.google.cloud.spanner.pgadapter.python.PythonTest
     </excludedTests>
 
-    <spanner.version>6.25.7</spanner.version>
+    <!-- Will update post the Spanner client code is pushed -->
+    <spanner.version>6.27.1-SNAPSHOT</spanner.version>
     <junixsocket.version>2.5.1</junixsocket.version>
   </properties>
 

--- a/src/main/java/com/google/cloud/spanner/pgadapter/metadata/DescribeStatementMetadata.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/metadata/DescribeStatementMetadata.java
@@ -15,24 +15,19 @@
 package com.google.cloud.spanner.pgadapter.metadata;
 
 import com.google.api.core.InternalApi;
-import com.google.cloud.Tuple;
 import com.google.cloud.spanner.ResultSet;
 
 /** Simple POJO to hold describe metadata specific to prepared statements. */
 @InternalApi
-public class DescribeStatementMetadata extends DescribeMetadata<Tuple<int[], ResultSet>>
+public class DescribeStatementMetadata extends DescribeMetadata<ResultSet>
     implements AutoCloseable {
 
-  public DescribeStatementMetadata(int[] parameters, ResultSet resultMetaData) {
-    this.metadata = Tuple.of(parameters, resultMetaData);
-  }
-
-  public int[] getParameters() {
-    return metadata.x();
+  public DescribeStatementMetadata(ResultSet resultSet) {
+    this.metadata = resultSet;
   }
 
   public ResultSet getResultSet() {
-    return metadata.y();
+    return metadata;
   }
 
   @Override

--- a/src/main/java/com/google/cloud/spanner/pgadapter/parsers/Parser.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/parsers/Parser.java
@@ -250,6 +250,41 @@ public abstract class Parser<T> {
     }
   }
 
+  public static int getOidTypeSize(int oid_type) {
+    switch (oid_type) {
+      case Oid.INT2:
+        return 2;
+      case Oid.INT4:
+        return 4;
+      case Oid.INT8:
+        return 8;
+      case Oid.NUMERIC:
+        return -1;
+      case Oid.FLOAT4:
+        return 4;
+      case Oid.FLOAT8:
+        return 8;
+      case Oid.CHAR:
+        return 1;
+      case Oid.TEXT:
+        return -1;
+      case Oid.VARCHAR:
+        return -1;
+      case Oid.BYTEA:
+        return -1;
+      case Oid.BOOL:
+        return 1;
+      case Oid.DATE:
+        return 8;
+      case Oid.TIME:
+        return 8;
+      case Oid.TIMESTAMPTZ:
+        return 12;
+      default:
+        return -1;
+    }
+  }
+
   /** Returns the item helder by this parser. */
   public T getItem() {
     return this.item;

--- a/src/main/java/com/google/cloud/spanner/pgadapter/statements/IntermediatePreparedStatement.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/statements/IntermediatePreparedStatement.java
@@ -17,7 +17,6 @@ package com.google.cloud.spanner.pgadapter.statements;
 import com.google.api.core.InternalApi;
 import com.google.cloud.spanner.ReadContext.QueryAnalyzeMode;
 import com.google.cloud.spanner.ResultSet;
-import com.google.cloud.spanner.SpannerException;
 import com.google.cloud.spanner.Statement;
 import com.google.cloud.spanner.Type.StructField;
 import com.google.cloud.spanner.connection.AbstractStatementParser.ParsedStatement;
@@ -29,16 +28,8 @@ import com.google.cloud.spanner.pgadapter.metadata.OptionsMetadata;
 import com.google.cloud.spanner.pgadapter.parsers.Parser;
 import com.google.cloud.spanner.pgadapter.parsers.Parser.FormatCode;
 import com.google.cloud.spanner.pgadapter.statements.SimpleParser.TableOrIndexName;
-import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Strings;
-import com.google.common.collect.ImmutableSortedSet;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Comparator;
 import java.util.List;
-import java.util.Set;
 import java.util.stream.Collectors;
-import javax.annotation.Nullable;
 import org.postgresql.core.Oid;
 
 /**
@@ -133,216 +124,18 @@ public class IntermediatePreparedStatement extends IntermediateStatement {
 
   @Override
   public DescribeMetadata<?> describe() {
-    Set<String> parameters = extractParameters(this.parsedStatement.getSqlWithoutComments());
-
-    ResultSet columnsResultSet = null;
-    if (this.parsedStatement.isQuery()) {
-      Statement statement = Statement.of(this.parsedStatement.getSqlWithoutComments());
-      columnsResultSet = connection.analyzeQuery(statement, QueryAnalyzeMode.PLAN);
-    }
-
-    boolean describeFailed = false;
-    if (parameters.isEmpty()) {
-      ensureParameterLength(0);
-    } else if (parameters.size() != this.parameterDataTypes.length
-        || Arrays.stream(this.parameterDataTypes).anyMatch(p -> p == 0)) {
-      // Note: We are only asking the backend to parse the types if there is at least one
-      // parameter with unspecified type. Otherwise, we will rely on the types given in PARSE.
-
-      // Transform the statement into a select statement that selects the parameters, and then
-      // extract the types from the result set metadata.
-      Statement selectParamsStatement = transformToSelectParams(parameters);
-      if (selectParamsStatement == null) {
-        // The transformation failed. Just rely on the types given in the PARSE message. If the
-        // transformation failed because the statement was malformed, the backend will catch that
-        // at a later stage.
-        describeFailed = true;
-        ensureParameterLength(parameters.size());
-      } else {
-        try (ResultSet paramsResultSet =
-            connection.analyzeQuery(selectParamsStatement, QueryAnalyzeMode.PLAN)) {
-          extractParameterTypes(paramsResultSet);
-        } catch (SpannerException exception) {
-          // Ignore here and rely on the types given in PARSE.
-          describeFailed = true;
-          ensureParameterLength(parameters.size());
-        }
+    ResultSet planResultSet = null;
+    try {
+      if (this.parsedStatement.isQuery()) {
+        Statement statement = Statement.of(this.parsedStatement.getSqlWithoutComments());
+        planResultSet = connection.analyzeQuery(statement, QueryAnalyzeMode.PLAN);
+      }
+      return new DescribeStatementMetadata(planResultSet);
+    } finally {
+      if (planResultSet != null) {
+        planResultSet.close();
       }
     }
-    if (columnsResultSet != null) {
-      return new DescribeStatementMetadata(this.parameterDataTypes, columnsResultSet);
-    }
-
-    if (this.parsedStatement.isUpdate() && (describeFailed || !Strings.isNullOrEmpty(this.name))) {
-      // Let the backend analyze the statement if it is a named prepared statement or if the query
-      // that was used to determine the parameter types failed, so we can return a reasonable
-      // error message if the statement is invalid. If it is the unnamed statement or getting the
-      // param types succeeded, we will let the following EXECUTE message handle that, instead of
-      // sending the statement twice to the backend.
-      connection.analyzeUpdate(
-          Statement.of(this.parsedStatement.getSqlWithoutComments()), QueryAnalyzeMode.PLAN);
-    }
-    return new DescribeStatementMetadata(this.parameterDataTypes, null);
-  }
-
-  /**
-   * Extracts the statement parameters from the given sql string and returns these as a sorted set.
-   * The parameters are ordered by their index and not by the textual value (i.e. "$9" comes before
-   * "$10").
-   */
-  @VisibleForTesting
-  static ImmutableSortedSet<String> extractParameters(String sql) {
-    return ImmutableSortedSet.<String>orderedBy(
-            Comparator.comparing(o -> Integer.valueOf(o.substring(1))))
-        .addAll(PARSER.getQueryParameters(sql))
-        .build();
-  }
-
-  /**
-   * Transforms a query or DML statement into a SELECT statement that selects the parameters in the
-   * statements. Examples:
-   *
-   * <ul>
-   *   <li><code>select * from foo where id=$1</code> is transformed to <code>
-   *       select $1 from (select * from foo where id=$1) p</code>
-   *   <li><code>insert into foo (id, value) values ($1, $2)</code> is transformed to <code>
-   *       select $1, $2 from (select id=$1, value=$2 from foo) p</code>
-   * </ul>
-   */
-  @VisibleForTesting
-  Statement transformToSelectParams(Set<String> parameters) {
-    switch (this.parsedStatement.getType()) {
-      case QUERY:
-        return transformSelectToSelectParams(
-            this.parsedStatement.getSqlWithoutComments(), parameters);
-      case UPDATE:
-        return transformDmlToSelectParams(parameters);
-      case CLIENT_SIDE:
-      case DDL:
-      case UNKNOWN:
-      default:
-        return Statement.of(this.parsedStatement.getSqlWithoutComments());
-    }
-  }
-
-  /**
-   * Transforms a query into one that selects the parameters in the query.
-   *
-   * <p>Example: <code>select id, value from foo where value like $1</code> is transformed to <code>
-   * select $1, $2 from (select id, value from foo where value like $1) p</code>
-   */
-  private static Statement transformSelectToSelectParams(String sql, Set<String> parameters) {
-    return Statement.of(String.format("select %s from (%s) p", String.join(", ", parameters), sql));
-  }
-
-  /**
-   * Transforms a DML statement into a SELECT statement that selects the parameters in the DML
-   * statement.
-   */
-  private Statement transformDmlToSelectParams(Set<String> parameters) {
-    switch (getCommand()) {
-      case "INSERT":
-        return transformInsertToSelectParams(
-            this.connection, this.parsedStatement.getSqlWithoutComments(), parameters);
-      case "UPDATE":
-        return transformUpdateToSelectParams(
-            this.parsedStatement.getSqlWithoutComments(), parameters);
-      case "DELETE":
-        return transformDeleteToSelectParams(
-            this.parsedStatement.getSqlWithoutComments(), parameters);
-      default:
-        return null;
-    }
-  }
-
-  /**
-   * Transforms an INSERT statement into a SELECT statement that selects the parameters in the
-   * insert statement. The way this is done depends on whether the INSERT statement uses a VALUES
-   * clause or a SELECT statement. If the INSERT statement uses a SELECT clause, the same strategy
-   * is used as for normal SELECT statements. For INSERT statements with a VALUES clause, a SELECT
-   * statement is created that selects a comparison between the column where a value is inserted and
-   * the expression that is used to insert a value in the column.
-   *
-   * <p>Examples:
-   *
-   * <ul>
-   *   <li><code>insert into foo (id, value) values ($1, $2)</code> is transformed to <code>
-   *       select $1, $2 from (select id=$1, value=$2 from foo) p</code>
-   *   <li><code>
-   *       insert into bar (id, value, created_at) values (1, $1 + sqrt($2), current_timestamp())
-   *       </code> is transformed to <code>
-   *       select $1, $2 from (select value=$1 + sqrt($2) from bar) p</code>
-   *   <li><code>insert into foo values ($1, $2)</code> is transformed to <code>
-   *       select $1, $2 from (select id=$1, value=$2 from foo) p</code>
-   * </ul>
-   */
-  @VisibleForTesting
-  static @Nullable Statement transformInsertToSelectParams(
-      Connection connection, String sql, Set<String> parameters) {
-    SimpleParser parser = new SimpleParser(sql);
-    if (!parser.eat("insert")) {
-      return null;
-    }
-    parser.eat("into");
-    TableOrIndexName table = parser.readTableOrIndexName();
-    if (table == null) {
-      return null;
-    }
-    parser.skipWhitespaces();
-
-    List<String> columnsList = null;
-    if (parser.eat("(")) {
-      columnsList = parser.parseExpressionList();
-      if (!parser.eat(")")) {
-        return null;
-      }
-    }
-
-    parser.skipWhitespaces();
-    int potentialSelectStart = parser.getPos();
-    if (parser.eat("select")) {
-      // This is an `insert into <table> [(...)] select ...` statement. Then we can just use the
-      // select statement as the result.
-      return transformSelectToSelectParams(
-          parser.getSql().substring(potentialSelectStart), parameters);
-    } else if (!parser.eat("values")) {
-      return null;
-    }
-
-    if (columnsList == null || columnsList.isEmpty()) {
-      columnsList = getAllColumns(connection, table);
-    }
-    List<List<String>> rows = new ArrayList<>();
-    while (parser.eat("(")) {
-      List<String> row = parser.parseExpressionList();
-      if (row == null || row.isEmpty() || !parser.eat(")") || row.size() != columnsList.size()) {
-        return null;
-      }
-      rows.add(row);
-      if (!parser.eat(",")) {
-        break;
-      }
-    }
-    if (rows.isEmpty()) {
-      return null;
-    }
-    StringBuilder select = new StringBuilder("select ");
-    select.append(String.join(", ", parameters)).append(" from (select ");
-
-    int columnIndex = 0;
-    int colCount = rows.size() * columnsList.size();
-    for (List<String> row : rows) {
-      for (int index = 0; index < row.size(); index++) {
-        select.append(columnsList.get(index)).append("=").append(row.get(index));
-        columnIndex++;
-        if (columnIndex < colCount) {
-          select.append(", ");
-        }
-      }
-    }
-    select.append(" from ").append(table).append(") p");
-
-    return Statement.of(select.toString());
   }
 
   /**
@@ -357,127 +150,6 @@ public class IntermediatePreparedStatement extends IntermediateStatement {
       return resultSet.getType().getStructFields().stream()
           .map(StructField::getName)
           .collect(Collectors.toList());
-    }
-  }
-
-  /**
-   * Transforms an UPDATE statement into a SELECT statement that selects the parameters in the
-   * update statement. This is done by creating a SELECT statement that selects the assignment
-   * expressions in the UPDATE statement, followed by the WHERE clause of the UPDATE statement.
-   *
-   * <p>Examples:
-   *
-   * <ul>
-   *   <li><code>update foo set value=$1 where id=$2</code> is transformed to <code>
-   *       select $1, $2 from (select value=$1 from foo where id=$2) p</code>
-   *   <li><code>update bar set value=$1+sqrt($2), updated_at=current_timestamp()</code> is
-   *       transformed to <code>select $1, $2 from (select value=$1+sqrt($2) from foo) p</code>
-   * </ul>
-   */
-  @VisibleForTesting
-  static Statement transformUpdateToSelectParams(String sql, Set<String> parameters) {
-    SimpleParser parser = new SimpleParser(sql);
-    if (!parser.eat("update")) {
-      return null;
-    }
-    parser.eat("only");
-    TableOrIndexName table = parser.readTableOrIndexName();
-    if (table == null) {
-      return null;
-    }
-    if (!parser.eat("set")) {
-      return null;
-    }
-    List<String> assignmentsList = parser.parseExpressionListUntil("where");
-    if (assignmentsList == null || assignmentsList.isEmpty()) {
-      return null;
-    }
-    int whereStart = parser.getPos();
-    if (!parser.eat("where")) {
-      whereStart = -1;
-    }
-
-    StringBuilder select = new StringBuilder("select ");
-    select
-        .append(String.join(", ", parameters))
-        .append(" from (select ")
-        .append(String.join(", ", assignmentsList))
-        .append(" from ")
-        .append(table);
-    if (whereStart > -1) {
-      select.append(" ").append(sql.substring(whereStart));
-    }
-    select.append(") p");
-
-    return Statement.of(select.toString());
-  }
-
-  /**
-   * Transforms a DELETE statement into a SELECT statement that selects the parameters of the DELETE
-   * statement. This is done by creating a SELECT 1 FROM table_name WHERE ... statement from the
-   * DELETE statement.
-   *
-   * <p>Example:
-   *
-   * <ul>
-   *   <li><code>DELETE FROM foo WHERE id=$1</code> is transformed to <code>
-   *       SELECT $1 FROM (SELECT 1 FROM foo WHERE id=$1) p</code>
-   * </ul>
-   */
-  @VisibleForTesting
-  static Statement transformDeleteToSelectParams(String sql, Set<String> parameters) {
-    SimpleParser parser = new SimpleParser(sql);
-    if (!parser.eat("delete")) {
-      return null;
-    }
-    parser.eat("from");
-    TableOrIndexName table = parser.readTableOrIndexName();
-    if (table == null) {
-      return null;
-    }
-    parser.skipWhitespaces();
-    int whereStart = parser.getPos();
-    if (!parser.eat("where")) {
-      // Deletes must have a where clause, otherwise there cannot be any parameters.
-      return null;
-    }
-
-    StringBuilder select =
-        new StringBuilder("select ")
-            .append(String.join(", ", parameters))
-            .append(" from (select 1 from ")
-            .append(table)
-            .append(" ")
-            .append(sql.substring(whereStart))
-            .append(") p");
-
-    return Statement.of(select.toString());
-  }
-
-  /**
-   * Returns the parameter types in the SQL string of this statement. The current implementation
-   * always returns any parameters that may have been specified in the PARSE message, and
-   * OID.Unspecified for all other parameters.
-   */
-  private void extractParameterTypes(ResultSet paramsResultSet) {
-    ensureParameterLength(paramsResultSet.getColumnCount());
-    for (int i = 0; i < paramsResultSet.getColumnCount(); i++) {
-      // Only override parameter types that were not specified by the frontend.
-      if (this.parameterDataTypes[i] == 0) {
-        this.parameterDataTypes[i] = Parser.toOid(paramsResultSet.getColumnType(i));
-      }
-    }
-  }
-
-  /**
-   * Enlarges the size of the parameter types of this statement to match the given count. Existing
-   * parameter types are preserved. New parameters are set to OID.Unspecified.
-   */
-  private void ensureParameterLength(int parameterCount) {
-    if (this.parameterDataTypes == null) {
-      this.parameterDataTypes = new int[parameterCount];
-    } else if (this.parameterDataTypes.length != parameterCount) {
-      this.parameterDataTypes = Arrays.copyOf(this.parameterDataTypes, parameterCount);
     }
   }
 }

--- a/src/main/java/com/google/cloud/spanner/pgadapter/statements/IntermediatePreparedStatement.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/statements/IntermediatePreparedStatement.java
@@ -125,17 +125,11 @@ public class IntermediatePreparedStatement extends IntermediateStatement {
   @Override
   public DescribeMetadata<?> describe() {
     ResultSet planResultSet = null;
-    try {
-      if (this.parsedStatement.isQuery()) {
-        Statement statement = Statement.of(this.parsedStatement.getSqlWithoutComments());
-        planResultSet = connection.analyzeQuery(statement, QueryAnalyzeMode.PLAN);
-      }
-      return new DescribeStatementMetadata(planResultSet);
-    } finally {
-      if (planResultSet != null) {
-        planResultSet.close();
-      }
+    if (this.parsedStatement.isQuery()) {
+      Statement statement = Statement.of(this.parsedStatement.getSqlWithoutComments());
+      planResultSet = connection.analyzeQuery(statement, QueryAnalyzeMode.PLAN);
     }
+    return new DescribeStatementMetadata(planResultSet);
   }
 
   /**

--- a/src/main/java/com/google/cloud/spanner/pgadapter/wireoutput/RowDescriptionResponse.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/wireoutput/RowDescriptionResponse.java
@@ -24,7 +24,6 @@ import com.google.cloud.spanner.pgadapter.parsers.Parser;
 import com.google.cloud.spanner.pgadapter.statements.IntermediateStatement;
 import java.io.DataOutputStream;
 import java.text.MessageFormat;
-import org.postgresql.core.Oid;
 
 /** Sends back qualifier for a row. */
 @InternalApi
@@ -98,7 +97,7 @@ public class RowDescriptionResponse extends WireOutput {
       this.outputStream.writeShort(DEFAULT_FLAG);
       int oidType = getOidType(column_index);
       this.outputStream.writeInt(oidType);
-      this.outputStream.writeShort(getOidTypeSize(oidType));
+      this.outputStream.writeShort(Parser.getOidTypeSize(oidType));
       // The type modifier. The meaning of the modifier is type-specific.
       // No modifier is indicated by -1.
       this.outputStream.writeInt(-1);
@@ -132,40 +131,5 @@ public class RowDescriptionResponse extends WireOutput {
   int getOidType(int column_index) {
     Type type = this.resultSet.getColumnType(column_index);
     return Parser.toOid(type);
-  }
-
-  int getOidTypeSize(int oid_type) {
-    switch (oid_type) {
-      case Oid.INT2:
-        return 2;
-      case Oid.INT4:
-        return 4;
-      case Oid.INT8:
-        return 8;
-      case Oid.NUMERIC:
-        return -1;
-      case Oid.FLOAT4:
-        return 4;
-      case Oid.FLOAT8:
-        return 8;
-      case Oid.CHAR:
-        return 1;
-      case Oid.TEXT:
-        return -1;
-      case Oid.VARCHAR:
-        return -1;
-      case Oid.BYTEA:
-        return -1;
-      case Oid.BOOL:
-        return 1;
-      case Oid.DATE:
-        return 8;
-      case Oid.TIME:
-        return 8;
-      case Oid.TIMESTAMPTZ:
-        return 12;
-      default:
-        return -1;
-    }
   }
 }

--- a/src/main/java/com/google/cloud/spanner/pgadapter/wireprotocol/DescribeMessage.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/wireprotocol/DescribeMessage.java
@@ -166,9 +166,9 @@ public class DescribeMessage extends AbstractQueryProtocolMessage {
    * @throws Exception if sending the message back to the client causes an error.
    */
   public void handleDescribeStatement() throws Exception {
-    try (DescribeStatementMetadata metadata =
-        (DescribeStatementMetadata) this.statement.describe()) {
-      new ParameterDescriptionResponse(this.outputStream, metadata.getParameters()).send(false);
+    try {
+      DescribeStatementMetadata metadata = (DescribeStatementMetadata) this.statement.describe();
+      new ParameterDescriptionResponse(this.outputStream, metadata.getResultSet()).send(false);
       if (metadata.getResultSet() != null) {
         new RowDescriptionResponse(
                 this.outputStream,

--- a/src/test/java/com/google/cloud/spanner/pgadapter/statements/IntermediateStatementTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/statements/IntermediateStatementTest.java
@@ -14,15 +14,10 @@
 
 package com.google.cloud.spanner.pgadapter.statements;
 
-import static com.google.cloud.spanner.pgadapter.statements.IntermediatePreparedStatement.extractParameters;
-import static com.google.cloud.spanner.pgadapter.statements.IntermediatePreparedStatement.transformDeleteToSelectParams;
-import static com.google.cloud.spanner.pgadapter.statements.IntermediatePreparedStatement.transformInsertToSelectParams;
-import static com.google.cloud.spanner.pgadapter.statements.IntermediatePreparedStatement.transformUpdateToSelectParams;
 import static com.google.cloud.spanner.pgadapter.utils.StatementParser.splitStatements;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
@@ -154,149 +149,5 @@ public class IntermediateStatementTest {
     assertEquals(0, statement.getUpdateCount());
     assertNotNull(statement.getStatementResult());
     assertEquals(ResultType.NO_RESULT, statement.getStatementResult().getResultType());
-  }
-
-  @Test
-  public void testTransformInsertValuesToSelectParams() {
-    assertEquals(
-        "select $1, $2 from (select col1=$1, col2=$2 from foo) p",
-        transformInsert("insert into foo (col1, col2) values ($1, $2)").getSql());
-    assertEquals(
-        "select $1, $2 from (select col1=$1, col2=$2 from foo) p",
-        transformInsert("insert foo (col1, col2) values ($1, $2)").getSql());
-    assertEquals(
-        "select $1, $2, $3, $4 from (select col1=$1, col2=$2, col1=$3, col2=$4 from foo) p",
-        transformInsert("insert into foo (col1, col2) values ($1, $2), ($3, $4)").getSql());
-    assertEquals(
-        "select $1, $2 from (select col1=$1::varchar, col2=$2::bigint from foo) p",
-        transformInsert("insert into foo (col1, col2) values ($1::varchar, $2::bigint)").getSql());
-    assertEquals(
-        "select $1, $2, $3, $4 from (select col1=($1 + $2), col2=$3 || to_char($4) from foo) p",
-        transformInsert("insert into foo (col1, col2) values (($1 + $2), $3 || to_char($4))")
-            .getSql());
-    assertEquals(
-        "select $1, $2, $3, $4 from (select col1=($1 + $2), col2=$3 || to_char($4) from foo) p",
-        transformInsert("insert into foo (col1, col2) values (($1 + $2), $3 || to_char($4))")
-            .getSql());
-    assertEquals(
-        "select $1, $2, $3, $4, $5 from (select col1=$1 + $2 + 5, col2=$3 || to_char($4) || coalesce($5, '') from foo) p",
-        transformInsert(
-                "insert\ninto\nfoo\n(col1,\ncol2  ) values ($1 + $2 + 5, $3 || to_char($4) || coalesce($5, ''))")
-            .getSql());
-    assertEquals(
-        "select $1, $2, $3, $4, $5, $6, $7, $8, $9, $10 from "
-            + "(select col1=$1, col2=$2, col3=$3, col4=$4, col5=$5, col6=$6, col7=$7, col8=$8, col9=$9, col10=$10 from foo) p",
-        transformInsert(
-                "insert into foo (col1, col2, col3, col4, col5, col6, col7, col8, col9, col10) "
-                    + "values ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)")
-            .getSql());
-  }
-
-  @Test
-  public void testTransformInsertSelectToSelectParams() {
-    assertEquals(
-        "select $1 from (select * from bar where some_col=$1) p",
-        transformInsert("insert into foo select * from bar where some_col=$1").getSql());
-    assertEquals(
-        "select $1 from (select * from bar where some_col=$1) p",
-        transformInsert("insert foo select * from bar where some_col=$1").getSql());
-    assertEquals(
-        "select $1 from (select * from bar where some_col=$1) p",
-        transformInsert("insert into foo (col1, col2) select * from bar where some_col=$1")
-            .getSql());
-    assertEquals(
-        "select $1 from (select * from bar where some_col=$1) p",
-        transformInsert("insert foo (col1, col2, col3) select * from bar where some_col=$1")
-            .getSql());
-    assertEquals(
-        "select $1, $2 from (select * from bar where some_col=$1 limit $2) p",
-        transformInsert(
-                "insert foo (col1, col2, col3) select * from bar where some_col=$1 limit $2")
-            .getSql());
-  }
-
-  @Test
-  public void testTransformUpdateToSelectParams() {
-    assertEquals(
-        "select $1, $2, $3 from (select col1=$1, col2=$2 from foo where id=$3) p",
-        transformUpdate("update foo set col1=$1, col2=$2  where id=$3").getSql());
-    assertEquals(
-        "select $1, $2, $3 from (select col1=col2 + $1 , "
-            + "col2=coalesce($1, $2, $3, to_char(current_timestamp())), "
-            + "col3 = 15 "
-            + "from foo where id=$3 and value>100) p",
-        transformUpdate(
-                "update foo set col1=col2 + $1 , "
-                    + "col2=coalesce($1, $2, $3, to_char(current_timestamp())), "
-                    + "col3 = 15 "
-                    + "where id=$3 and value>100")
-            .getSql());
-    assertEquals(
-        "select $1 from (select col1=$1 from foo) p",
-        transformUpdate("update foo set col1=$1").getSql());
-
-    assertNull(transformUpdate("update foo col1=1"));
-    assertNull(transformUpdate("update foo col1=1 hwere col1=2"));
-    assertNull(transformUpdate("udpate foo col1=1 where col1=2"));
-
-    assertEquals(
-        "select $1, $2, $3, $4, $5, $6, $7, $8, $9, $10 from (select col1=$1, col2=$2, col3=$3, col4=$4, col5=$5, col6=$6, col7=$7, col8=$8, col9=$9 from foo where id=$10) p",
-        transformUpdate(
-                "update foo set col1=$1, col2=$2, col3=$3, col4=$4, col5=$5, col6=$6, col7=$7, col8=$8, col9=$9  where id=$10")
-            .getSql());
-  }
-
-  @Test
-  public void testTransformDeleteToSelectParams() {
-    assertEquals(
-        "select $1 from (select 1 from foo where id=$1) p",
-        transformDelete("delete from foo where id=$1").getSql());
-    assertEquals(
-        "select $1, $2 from (select 1 from foo where id=$1 and bar > $2) p",
-        transformDelete("delete foo\nwhere id=$1 and bar > $2").getSql());
-    assertEquals(
-        "select $1, $2, $3, $4, $5, $6, $7, $8, $9, $10 "
-            + "from (select 1 from all_types "
-            + "where col_bigint=$1 "
-            + "and col_bool=$2 "
-            + "and col_bytea=$3 "
-            + "and col_float8=$4 "
-            + "and col_int=$5 "
-            + "and col_numeric=$6 "
-            + "and col_timestamptz=$7 "
-            + "and col_date=$8 "
-            + "and col_varchar=$9 "
-            + "and col_jsonb=$10"
-            + ") p",
-        transformDelete(
-                "delete "
-                    + "from all_types "
-                    + "where col_bigint=$1 "
-                    + "and col_bool=$2 "
-                    + "and col_bytea=$3 "
-                    + "and col_float8=$4 "
-                    + "and col_int=$5 "
-                    + "and col_numeric=$6 "
-                    + "and col_timestamptz=$7 "
-                    + "and col_date=$8 "
-                    + "and col_varchar=$9 "
-                    + "and col_jsonb=$10")
-            .getSql());
-
-    assertNull(transformDelete("delete from foo"));
-    assertNull(transformDelete("dlete from foo where id=$1"));
-    assertNull(transformDelete("delete from foo hwere col1=2"));
-  }
-
-  private static Statement transformInsert(String sql) {
-    return transformInsertToSelectParams(mock(Connection.class), sql, extractParameters(sql));
-  }
-
-  private static Statement transformUpdate(String sql) {
-    return transformUpdateToSelectParams(sql, extractParameters(sql));
-  }
-
-  private static Statement transformDelete(String sql) {
-    return transformDeleteToSelectParams(sql, extractParameters(sql));
   }
 }

--- a/src/test/java/com/google/cloud/spanner/pgadapter/wireoutput/RowDescriptionTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/wireoutput/RowDescriptionTest.java
@@ -23,6 +23,7 @@ import com.google.cloud.spanner.Type.StructField;
 import com.google.cloud.spanner.pgadapter.ConnectionHandler.QueryMode;
 import com.google.cloud.spanner.pgadapter.metadata.OptionsMetadata;
 import com.google.cloud.spanner.pgadapter.metadata.OptionsMetadata.TextFormat;
+import com.google.cloud.spanner.pgadapter.parsers.Parser;
 import com.google.cloud.spanner.pgadapter.statements.IntermediateStatement;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -85,28 +86,28 @@ public final class RowDescriptionTest {
 
     // Types.BIGINT
     assertEquals(Oid.INT8, response.getOidType(0));
-    assertEquals(8, response.getOidTypeSize(Oid.INT8));
+    assertEquals(8, Parser.getOidTypeSize(Oid.INT8));
     // Types.NUMERIC
     assertEquals(Oid.NUMERIC, response.getOidType(1));
-    assertEquals(-1, response.getOidTypeSize(Oid.NUMERIC));
+    assertEquals(-1, Parser.getOidTypeSize(Oid.NUMERIC));
     // Types.DOUBLE
     assertEquals(Oid.FLOAT8, response.getOidType(2));
-    assertEquals(8, response.getOidTypeSize(Oid.FLOAT8));
+    assertEquals(8, Parser.getOidTypeSize(Oid.FLOAT8));
     // Types.VARCHAR
     assertEquals(Oid.VARCHAR, response.getOidType(3));
-    assertEquals(-1, response.getOidTypeSize(Oid.VARCHAR));
+    assertEquals(-1, Parser.getOidTypeSize(Oid.VARCHAR));
     // Types.BINARY
     assertEquals(Oid.BYTEA, response.getOidType(4));
-    assertEquals(-1, response.getOidTypeSize(Oid.BYTEA));
+    assertEquals(-1, Parser.getOidTypeSize(Oid.BYTEA));
     // Types.BIT
     assertEquals(Oid.BOOL, response.getOidType(5));
-    assertEquals(1, response.getOidTypeSize(Oid.BOOL));
+    assertEquals(1, Parser.getOidTypeSize(Oid.BOOL));
     // Types.DATE
     assertEquals(Oid.DATE, response.getOidType(6));
-    assertEquals(8, response.getOidTypeSize(Oid.DATE));
+    assertEquals(8, Parser.getOidTypeSize(Oid.DATE));
     // Types.TIMESTAMP
     assertEquals(Oid.TIMESTAMPTZ, response.getOidType(7));
-    assertEquals(12, response.getOidTypeSize(Oid.TIMESTAMPTZ));
+    assertEquals(12, Parser.getOidTypeSize(Oid.TIMESTAMPTZ));
   }
 
   @Test


### PR DESCRIPTION
Implementing describe statement using the undeclared parameters in analyse response. This contains the following details:
1. Parameter description response updated to use undeclared parameters in
response.
2. Removed local parser that was used
3. Removed the typecast of queries to retrieve type of undeclared
   parameters
