### PR TITLE
fix: correctly detect end of unquoted identifier

### DIFF
--- a/src/main/java/com/google/cloud/spanner/pgadapter/statements/SimpleParser.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/statements/SimpleParser.java
@@ -166,6 +166,7 @@ class SimpleParser {
     if (quoted) {
       pos++;
     }
+    boolean first = true;
     while (pos < sql.length()) {
       if (quoted) {
         if (sql.charAt(pos) == '"') {
@@ -176,11 +177,15 @@ class SimpleParser {
           }
         }
       } else {
-        if (Character.isWhitespace(sql.charAt(pos))
-            || sql.charAt(pos) == '.'
-            || sql.charAt(pos) == ','
-            || sql.charAt(pos) == '"') {
-          return sql.substring(start, pos);
+        if (first) {
+          if (!isValidIdentifierFirstChar(sql.charAt(pos))) {
+            return null;
+          }
+          first = false;
+        } else {
+          if (!isValidIdentifierChar(sql.charAt(pos))) {
+            return sql.substring(start, pos);
+          }
         }
       }
       pos++;
@@ -189,6 +194,14 @@ class SimpleParser {
       return null;
     }
     return sql.substring(start);
+  }
+
+  private boolean isValidIdentifierFirstChar(char c) {
+    return Character.isLetter(c) || c == '_';
+  }
+
+  private boolean isValidIdentifierChar(char c) {
+    return isValidIdentifierFirstChar(c) || Character.isDigit(c) || c == '$';
   }
 
   boolean peek(String keyword) {

--- a/src/test/java/com/google/cloud/spanner/pgadapter/statements/DdlExecutorTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/statements/DdlExecutorTest.java
@@ -66,6 +66,8 @@ public class DdlExecutorTest {
         Statement.of("create table foo (id int)"),
         translate("create table foo (id int)", executor));
     assertEquals(
+        Statement.of("create table foo(id int)"), translate("create table foo(id int)", executor));
+    assertEquals(
         Statement.of("create table \"Foo\" (id int)"),
         translate("create table \"Foo\" (id int)", executor));
     assertEquals(

--- a/src/test/java/com/google/cloud/spanner/pgadapter/statements/SimpleParserTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/statements/SimpleParserTest.java
@@ -63,6 +63,18 @@ public class SimpleParserTest {
     assertEquals("\"foo\"", new SimpleParser("\"foo\".bar").readIdentifierPart());
     assertEquals("\"foo\"", new SimpleParser("\"foo\"").readIdentifierPart());
     assertNull(new SimpleParser("\"foo").readIdentifierPart());
+
+    assertEquals("foo", new SimpleParser("foo) bar").readIdentifierPart());
+    assertEquals("foo", new SimpleParser("foo- bar").readIdentifierPart());
+    assertEquals("foo", new SimpleParser("foo/ bar").readIdentifierPart());
+    assertEquals("foo$", new SimpleParser("foo$ bar").readIdentifierPart());
+    assertEquals("f$oo", new SimpleParser("f$oo bar").readIdentifierPart());
+    assertEquals("_foo", new SimpleParser("_foo bar").readIdentifierPart());
+    assertEquals("øfoo", new SimpleParser("øfoo bar").readIdentifierPart());
+    assertNull(new SimpleParser("\\foo").readIdentifierPart());
+    assertNull(new SimpleParser("1foo").readIdentifierPart());
+    assertNull(new SimpleParser("-foo").readIdentifierPart());
+    assertNull(new SimpleParser("$foo").readIdentifierPart());
   }
 
   @Test


### PR DESCRIPTION
Correctly detect the end of an unquoted identifier.

From the PostgreSQL documentation:

> SQL identifiers and key words must begin with a letter (a-z, but also letters with diacritical marks and non-Latin letters) or an underscore (_). Subsequent characters in an identifier or key word can be letters, underscores, digits (0-9), or dollar signs ($).

See https://www.postgresql.org/docs/current/sql-syntax-lexical.html#SQL-SYNTAX-IDENTIFIERS