### PR TITLE
fix: backslash is not a valid quote escape

### DIFF
--- a/src/main/java/com/google/cloud/spanner/pgadapter/statements/SimpleParser.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/statements/SimpleParser.java
@@ -119,8 +119,12 @@ class SimpleParser {
     int parens = 0;
     while (pos < sql.length()) {
       if (quoted) {
-        if (sql.charAt(pos) == startQuote && sql.charAt(pos - 1) != '\\') {
-          quoted = false;
+        if (sql.charAt(pos) == startQuote) {
+          if (pos == (sql.length() - 1) || sql.charAt(pos + 1) != startQuote) {
+            quoted = false;
+          } else {
+            pos++;
+          }
         }
       } else {
         if (sql.charAt(pos) == '\'' || sql.charAt(pos) == '"') {
@@ -257,18 +261,27 @@ class SimpleParser {
       boolean skipWhitespaceBefore,
       boolean requireWhitespaceAfter,
       boolean updatePos) {
+    int originalPos = pos;
     if (skipWhitespaceBefore) {
       skipWhitespaces();
     }
     if (pos + keyword.length() > sql.length()) {
+      if (!updatePos) {
+        pos = originalPos;
+      }
       return false;
     }
     if (sql.substring(pos, pos + keyword.length()).equalsIgnoreCase(keyword)
         && (!requireWhitespaceAfter || isValidEndOfKeyword(pos + keyword.length()))) {
       if (updatePos) {
         pos = pos + keyword.length();
+      } else {
+        pos = originalPos;
       }
       return true;
+    }
+    if (!updatePos) {
+      pos = originalPos;
     }
     return false;
   }

--- a/src/test/java/com/google/cloud/spanner/pgadapter/statements/IntermediateStatementTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/statements/IntermediateStatementTest.java
@@ -244,7 +244,7 @@ public class IntermediateStatementTest {
         "select $1, $2, $3 from (select col1=$1, col2=$2 from foo where id=$3) p",
         transformUpdate("update foo set col1=$1, col2=$2  where id=$3").getSql());
     assertEquals(
-        "select $1, $2, $3 from (select col1=col2 + $1 , "
+        "select $1, $2, $3 from (select col1=col2 + $1, "
             + "col2=coalesce($1, $2, $3, to_char(current_timestamp())), "
             + "col3 = 15 "
             + "from foo where id=$3 and value>100) p",


### PR DESCRIPTION
The SimpleParser would accept backslash+quote as a valid escape mechanism
for a quote inside a quoted string. This is not correct for PostgreSQL,
and instead should be two equal quotes directly following each other.