### PR TITLE
build: create a Github issue if the scheduled integration tests fail

### DIFF
--- a/.github/integration-test-failed-template.md
+++ b/.github/integration-test-failed-template.md
@@ -3,4 +3,4 @@ title: PGAdapter integration tests failed
 assignees: pratickchokhani, gauravsnj, olavloite
 labels: integration-test-failure
 ---
-PGAdapter integration tests failed. Please investigate!
+PGAdapter integration tests failed for endpoint {{ env.ENDPOINT }} ({{ env.GOOGLE_CLOUD_ENDPOINT }})

--- a/.github/integration-test-failed-template.md
+++ b/.github/integration-test-failed-template.md
@@ -3,4 +3,4 @@ title: PGAdapter integration tests failed
 assignees: pratickchokhani, gauravsnj, olavloite
 labels: integration-test-failure
 ---
-PGAdapter integration tests failed for endpoint {{ env.ENDPOINT }} ({{ env.GOOGLE_CLOUD_ENDPOINT }})
+PGAdapter integration tests failed for endpoint {{ env.ENDPOINT }}

--- a/.github/integration-test-failed-template.md
+++ b/.github/integration-test-failed-template.md
@@ -1,6 +1,6 @@
 ---
 title: PGAdapter integration tests failed
 assignees: pratickchokhani, gauravsnj, olavloite
-labels: priority: p1, integration-test-failure
+labels: "priority: p1", "integration-test-failure"
 ---
 PGAdapter integration tests failed. Please investigate!

--- a/.github/integration-test-failed-template.md
+++ b/.github/integration-test-failed-template.md
@@ -1,6 +1,6 @@
 ---
 title: PGAdapter integration tests failed
 assignees: pratickchokhani, gauravsnj, olavloite
-labels: "priority: p1", "integration-test-failure"
+labels: integration-test-failure
 ---
 PGAdapter integration tests failed. Please investigate!

--- a/.github/integration-test-failed-template.md
+++ b/.github/integration-test-failed-template.md
@@ -1,0 +1,6 @@
+---
+title: PGAdapter integration tests failed
+assignees: pratickchokhani, gauravsnj, olavloite
+labels: priority: p1, integration-test-failure
+---
+PGAdapter integration tests failed. Please investigate!

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -134,5 +134,3 @@ jobs:
         with:
           filename: .github/integration-test-failed-template.md
           assignees: pratickchokhani, gauravsnj, olavloite
-          update_existing: true
-          search_existing: open

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -131,7 +131,7 @@ jobs:
         uses: JasonEtco/create-an-issue@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          ENDPOINT: ${{ GOOGLE_CLOUD_ENDPOINT }}
+          ENDPOINT: ${{ env.GOOGLE_CLOUD_ENDPOINT }}
         with:
           filename: .github/integration-test-failed-template.md
           assignees: pratickchokhani, gauravsnj, olavloite

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -123,11 +123,7 @@ jobs:
           path_to_write_report: ./coverage/codecov_report.txt
           verbose: true
       - id: create-issue-on-failure
-        if: |
-          ${{ 
-            failure() &&
-            (github.event.schedule=='52 4 * * *' || github.event.schedule=='14 3 * * *' || inputs.endpoint)
-          }}
+        if: "${{ failure() && (github.event.schedule=='52 4 * * *' || github.event.schedule=='14 3 * * *' || inputs.endpoint != '')}}"
         uses: JasonEtco/create-an-issue@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -131,6 +131,7 @@ jobs:
         uses: JasonEtco/create-an-issue@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ENDPOINT: ${{ GOOGLE_CLOUD_ENDPOINT }}
         with:
           filename: .github/integration-test-failed-template.md
           assignees: pratickchokhani, gauravsnj, olavloite

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -122,3 +122,17 @@ jobs:
           name: codecov-umbrella
           path_to_write_report: ./coverage/codecov_report.txt
           verbose: true
+      - id: create-issue-on-failure
+        if: |
+          ${{ 
+            failure() &&
+            (github.event.schedule=='52 4 * * *' || github.event.schedule=='14 3 * * *' || inputs.endpoint)
+          }}
+        uses: JasonEtco/create-an-issue@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          filename: .github/integration-test-failed-template.md
+          assignees: pratickchokhani, gauravsnj, olavloite
+          update_existing: true
+          search_existing: open

--- a/src/test/java/com/google/cloud/spanner/pgadapter/ITJdbcTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/ITJdbcTest.java
@@ -154,7 +154,7 @@ public class ITJdbcTest implements IntegrationTest {
       try (ResultSet resultSet =
           connection.createStatement().executeQuery("SELECT 'Hello World!'")) {
         assertTrue(resultSet.next());
-        assertEquals("Hello World! - fail", resultSet.getString(1));
+        assertEquals("Hello World!", resultSet.getString(1));
         assertFalse(resultSet.next());
       }
     }

--- a/src/test/java/com/google/cloud/spanner/pgadapter/ITJdbcTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/ITJdbcTest.java
@@ -154,7 +154,8 @@ public class ITJdbcTest implements IntegrationTest {
       try (ResultSet resultSet =
           connection.createStatement().executeQuery("SELECT 'Hello World!'")) {
         assertTrue(resultSet.next());
-        assertEquals("Hello World!", resultSet.getString(1));
+        // TODO: Remove, this is only to verify that the automated issue generation works.
+        assertEquals("Hello World! - fail", resultSet.getString(1));
         assertFalse(resultSet.next());
       }
     }

--- a/src/test/java/com/google/cloud/spanner/pgadapter/ITJdbcTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/ITJdbcTest.java
@@ -154,8 +154,7 @@ public class ITJdbcTest implements IntegrationTest {
       try (ResultSet resultSet =
           connection.createStatement().executeQuery("SELECT 'Hello World!'")) {
         assertTrue(resultSet.next());
-        // TODO: Remove, this is only to verify that the automated issue generation works.
-        assertEquals("Hello World! - fail", resultSet.getString(1));
+        assertEquals("Hello World!", resultSet.getString(1));
         assertFalse(resultSet.next());
       }
     }

--- a/src/test/java/com/google/cloud/spanner/pgadapter/ITJdbcTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/ITJdbcTest.java
@@ -154,7 +154,7 @@ public class ITJdbcTest implements IntegrationTest {
       try (ResultSet resultSet =
           connection.createStatement().executeQuery("SELECT 'Hello World!'")) {
         assertTrue(resultSet.next());
-        assertEquals("Hello World!", resultSet.getString(1));
+        assertEquals("Hello World! - fail", resultSet.getString(1));
         assertFalse(resultSet.next());
       }
     }


### PR DESCRIPTION
Create an issue if the scheduled integration tests fail. This issue will be assigned to the maintainers, be assigned the label `integration-test-failure`, and be mirrored to buganizer.