### PR TITLE
deps: bump google-cloud-spanner from 6.27.0 to 6.28.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
       com.google.cloud.spanner.pgadapter.python.PythonTest
     </excludedTests>
 
-    <spanner.version>6.27.0</spanner.version>
+    <spanner.version>6.28.0</spanner.version>
     <junixsocket.version>2.5.1</junixsocket.version>
   </properties>
 
@@ -109,6 +109,11 @@
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-model</artifactId>
       <version>3.8.6</version>
+    </dependency>
+    <dependency>
+      <groupId>org.bouncycastle</groupId>
+      <artifactId>bcpkix-jdk15on</artifactId>
+      <version>1.70</version>
     </dependency>
 
     <!-- Test dependencies -->


### PR DESCRIPTION
Bumps the Spanner client library to version 6.28.0 and adds bouncycastle
as a dependency, as that has been removed from the list of dependencies
of the client library.