### PR TITLE
docs: document pgx COPY limitation

### DIFF
--- a/docs/pgx.md
+++ b/docs/pgx.md
@@ -103,3 +103,10 @@ batch.Queue("create table singers (singerid varchar primary key, name varchar)")
 batch.Queue("create index idx_singers_name on singers (name)")
 res := conn.SendBatch(context.Background(), batch)
 ```
+
+## Known Issues
+- Copy operations can fail at startup because `pgx` does not wait for a CopyInResponse before
+  sending data to the backend. This can cause PGAdapter to miss the first CopyData message which
+  contains the binary copy header. No data corruption will occur, as the copy operation will be
+  aborted when the required binary header is missing. Retrying the copy operation will normally
+  work. A proposed solution for this problem has been submitted her: https://github.com/jackc/pgconn/pull/127

--- a/src/test/java/com/google/cloud/spanner/pgadapter/golang/PgxMockServerTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/golang/PgxMockServerTest.java
@@ -988,7 +988,7 @@ public class PgxMockServerTest extends AbstractMockServerTest {
   }
 
   @Ignore(
-      "pgx copy implementation seems buggy (CopyDone message can be sent before all data has been sent)")
+      "The pgx copy implementation does not wait for the CopyInResponse before sending data to the backend")
   @Test
   public void testCopyIn() {
     CopyInMockServerTest.setupCopyInformationSchemaResults(mockSpanner, true);


### PR DESCRIPTION
Documents a limitation when using `COPY` with pgx.