### PR TITLE
fix: catch unknown types in RowDescription

### DIFF
--- a/src/main/java/com/google/cloud/spanner/pgadapter/wireoutput/RowDescriptionResponse.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/wireoutput/RowDescriptionResponse.java
@@ -130,8 +130,12 @@ public class RowDescriptionResponse extends WireOutput {
   }
 
   int getOidType(int column_index) {
-    Type type = this.resultSet.getColumnType(column_index);
-    return Parser.toOid(type);
+    try {
+      Type type = this.resultSet.getColumnType(column_index);
+      return Parser.toOid(type);
+    } catch (Exception ignored) {
+      return Oid.UNSPECIFIED;
+    }
   }
 
   int getOidTypeSize(int oid_type) {

--- a/src/test/java/com/google/cloud/spanner/pgadapter/wireoutput/RowDescriptionTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/wireoutput/RowDescriptionTest.java
@@ -15,9 +15,12 @@
 package com.google.cloud.spanner.pgadapter.wireoutput;
 
 import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import com.google.cloud.spanner.ErrorCode;
 import com.google.cloud.spanner.ResultSet;
+import com.google.cloud.spanner.SpannerExceptionFactory;
 import com.google.cloud.spanner.Type;
 import com.google.cloud.spanner.Type.StructField;
 import com.google.cloud.spanner.pgadapter.ConnectionHandler.QueryMode;
@@ -339,5 +342,22 @@ public final class RowDescriptionTest {
       // format code
       assertEquals(i, outputReader.readShort());
     }
+  }
+
+  @Test
+  public void testUnknownTypeReturnsUnspecified() throws Exception {
+    ResultSet resultSet = mock(ResultSet.class);
+    when(resultSet.getColumnType(0))
+        .thenThrow(SpannerExceptionFactory.newSpannerException(ErrorCode.INTERNAL, "unknown type"));
+
+    RowDescriptionResponse response =
+        new RowDescriptionResponse(
+            mock(DataOutputStream.class),
+            mock(IntermediateStatement.class),
+            resultSet,
+            mock(OptionsMetadata.class),
+            QueryMode.SIMPLE);
+
+    assertEquals(Oid.UNSPECIFIED, response.getOidType(0));
   }
 }

--- a/src/test/java/com/google/cloud/spanner/pgadapter/wireoutput/RowDescriptionTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/wireoutput/RowDescriptionTest.java
@@ -110,6 +110,13 @@ public final class RowDescriptionTest {
     // Types.TIMESTAMP
     assertEquals(Oid.TIMESTAMPTZ, response.getOidType(7));
     assertEquals(12, response.getOidTypeSize(Oid.TIMESTAMPTZ));
+
+    assertEquals(4, response.getOidTypeSize(Oid.INT4));
+    assertEquals(2, response.getOidTypeSize(Oid.INT2));
+    assertEquals(4, response.getOidTypeSize(Oid.FLOAT4));
+    assertEquals(1, response.getOidTypeSize(Oid.CHAR));
+    assertEquals(-1, response.getOidTypeSize(Oid.TEXT));
+    assertEquals(8, response.getOidTypeSize(Oid.TIME));
   }
 
   @Test


### PR DESCRIPTION
Catch any errors when converting from a Spanner type to an OID to
prevent unknown types from making PGAdapter return an incomplete
response. An unknown type would now cause the RowDescriptionResponse to
fail halfway, which meant that half a message would be written to the
output buffer. This could then make a client hang, as it was waiting for
more data for the specific message.