### PR TITLE
docs: add docs tag for dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,11 +88,13 @@ This option is only available for Java/JVM-based applications.
 
 <!--- {x-version-update-start:google-cloud-spanner-pgadapter:released} -->
 ```xml
+<!-- [START pgadapter_dependency] -->
 <dependency>
   <groupId>com.google.cloud</groupId>
   <artifactId>google-cloud-spanner-pgadapter</artifactId>
   <version>0.8.0</version>
 </dependency>
+<!-- [END pgadapter_dependency] -->
 ```
 <!--- {x-version-update-end} -->
 


### PR DESCRIPTION
Adds a tag to the dependency example in the README file, so this can be reused in the Cloud documentation.