### PR TITLE
fix: exceptions without messages could cause NullPointerExceptions

### DIFF
--- a/src/main/java/com/google/cloud/spanner/pgadapter/ConnectionHandler.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/ConnectionHandler.java
@@ -259,7 +259,11 @@ public class ConnectionHandler extends Thread {
       runConnection(true);
     } catch (IOException ioException) {
       PGException pgException =
-          PGException.newBuilder("Failed to create SSL socket: " + ioException.getMessage())
+          PGException.newBuilder(
+                  "Failed to create SSL socket: "
+                      + (ioException.getMessage() == null
+                          ? ioException.getClass().getName()
+                          : ioException.getMessage()))
               .setSeverity(Severity.FATAL)
               .setSQLState(SQLState.InternalError)
               .build();
@@ -322,7 +326,7 @@ public class ConnectionHandler extends Thread {
         this.handleError(pgException);
       } catch (Exception exception) {
         this.handleError(
-            PGException.newBuilder(exception.getMessage())
+            PGException.newBuilder(exception)
                 .setSeverity(Severity.FATAL)
                 .setSQLState(SQLState.InternalError)
                 .build());
@@ -396,7 +400,7 @@ public class ConnectionHandler extends Thread {
       message.send();
     } catch (IllegalArgumentException | IllegalStateException | EOFException fatalException) {
       this.handleError(
-          PGException.newBuilder(fatalException.getMessage())
+          PGException.newBuilder(fatalException)
               .setSeverity(Severity.FATAL)
               .setSQLState(SQLState.InternalError)
               .build());

--- a/src/main/java/com/google/cloud/spanner/pgadapter/error/PGException.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/error/PGException.java
@@ -54,6 +54,12 @@ public class PGException extends RuntimeException {
     }
   }
 
+  public static Builder newBuilder(Exception cause) {
+    Preconditions.checkNotNull(cause);
+    return new Builder(
+        cause.getMessage() == null ? cause.getClass().getName() : cause.getMessage());
+  }
+
   public static Builder newBuilder(String message) {
     return new Builder(Preconditions.checkNotNull(message));
   }

--- a/src/test/java/com/google/cloud/spanner/pgadapter/ConnectionHandlerTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/ConnectionHandlerTest.java
@@ -353,6 +353,41 @@ public class ConnectionHandlerTest {
   }
 
   @Test
+  public void testRestartConnectionWithSsl_SslSocketCreationFailureIsConvertedToPGException() {
+    ProxyServer server = mock(ProxyServer.class);
+    Socket socket = mock(Socket.class);
+    InetAddress address = mock(InetAddress.class);
+    when(socket.getInetAddress()).thenReturn(address);
+    ConnectionHandler connection =
+        new ConnectionHandler(server, socket) {
+          @Override
+          void createSSLSocket() throws IOException {
+            throw new IOException();
+          }
+        };
+    PGException exception = assertThrows(PGException.class, connection::restartConnectionWithSsl);
+    assertEquals("Failed to create SSL socket: java.io.IOException", exception.getMessage());
+  }
+
+  @Test
+  public void
+      testRestartConnectionWithSsl_SslSocketCreationFailureIsConvertedToPGExceptionWithMessage() {
+    ProxyServer server = mock(ProxyServer.class);
+    Socket socket = mock(Socket.class);
+    InetAddress address = mock(InetAddress.class);
+    when(socket.getInetAddress()).thenReturn(address);
+    ConnectionHandler connection =
+        new ConnectionHandler(server, socket) {
+          @Override
+          void createSSLSocket() throws IOException {
+            throw new IOException("test error");
+          }
+        };
+    PGException exception = assertThrows(PGException.class, connection::restartConnectionWithSsl);
+    assertEquals("Failed to create SSL socket: test error", exception.getMessage());
+  }
+
+  @Test
   public void testRestartConnectionWithSsl_SendsPGException() {
     ProxyServer server = mock(ProxyServer.class);
     Socket socket = mock(Socket.class);


### PR DESCRIPTION
Fixes the conversion from a generic Java exception to `PGException` for the cases where the underlying cause has no message.

Fixes #380 