### PR TITLE
perf: do not create a new parser for each column

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ target/
 *.class
 *.lst
 output.txt
+__pycache__
 
 src/test/golang/**/*.h
 src/test/golang/**/*.so

--- a/src/main/java/com/google/cloud/spanner/pgadapter/parsers/ArrayParser.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/parsers/ArrayParser.java
@@ -31,7 +31,7 @@ import java.util.stream.Collectors;
  * Translate wire protocol to array. Since arrays house any other specified types (including
  * potentially arrays), we use all parser types to parse each item within.
  */
-class ArrayParser extends Parser<List<?>> {
+public class ArrayParser extends Parser<List<?>> {
   private static final String STRING_TOGGLE = "\"";
   private static final String ARRAY_DELIMITER = ",";
   private static final String PG_ARRAY_OPEN = "{", PG_ARRAY_CLOSE = "}";
@@ -40,7 +40,7 @@ class ArrayParser extends Parser<List<?>> {
   private final Type arrayElementType;
   private final boolean isStringEquivalent;
 
-  ArrayParser(ResultSet item, int position) {
+  public ArrayParser(ResultSet item, int position) {
     if (item != null) {
       this.arrayElementType = item.getColumnType(position).getArrayElementType();
       if (this.arrayElementType.getCode() == Code.ARRAY) {

--- a/src/main/java/com/google/cloud/spanner/pgadapter/parsers/BinaryParser.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/parsers/BinaryParser.java
@@ -18,6 +18,7 @@ import com.google.api.core.InternalApi;
 import com.google.cloud.ByteArray;
 import com.google.cloud.spanner.ResultSet;
 import com.google.cloud.spanner.Statement;
+import com.google.cloud.spanner.pgadapter.ProxyServer.DataFormat;
 import com.google.cloud.spanner.pgadapter.error.PGExceptionFactory;
 import java.nio.charset.StandardCharsets;
 import javax.annotation.Nonnull;
@@ -77,6 +78,19 @@ public class BinaryParser extends Parser<ByteArray> {
   @Override
   protected byte[] binaryParse() {
     return this.item == null ? null : this.item.toByteArray();
+  }
+
+  public static byte[] convertToPG(ResultSet resultSet, int position, DataFormat format) {
+    switch (format) {
+      case SPANNER:
+      case POSTGRESQL_BINARY:
+        return resultSet.getBytes(position).toByteArray();
+      case POSTGRESQL_TEXT:
+        return ("\\x" + Utils.toHexString(resultSet.getBytes(position).toByteArray()))
+            .getBytes(StandardCharsets.UTF_8);
+      default:
+        throw new IllegalArgumentException("unknown data format: " + format);
+    }
   }
 
   @Override

--- a/src/main/java/com/google/cloud/spanner/pgadapter/parsers/BooleanParser.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/parsers/BooleanParser.java
@@ -43,7 +43,7 @@ public class BooleanParser extends Parser<Boolean> {
 
   static {
     ByteConverter.bool(TRUE_VALUE_BYTES_BINARY, 0, true);
-    ByteConverter.bool(FALSE_VALUE_BYTES_BINARY, 0, true);
+    ByteConverter.bool(FALSE_VALUE_BYTES_BINARY, 0, false);
   }
   // See https://www.postgresql.org/docs/current/datatype-boolean.html
   private static final Set<String> TRUE_VALUES =

--- a/src/main/java/com/google/cloud/spanner/pgadapter/parsers/NumericParser.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/parsers/NumericParser.java
@@ -29,6 +29,12 @@ import org.postgresql.util.ByteConverter;
 /** Translate from wire protocol to {@link Number}. */
 @InternalApi
 public class NumericParser extends Parser<String> {
+  private static final byte[] NAN = new byte[8];
+
+  static {
+    ByteConverter.int2(NAN, 4, (short) 0xC000);
+  }
+
   NumericParser(ResultSet item, int position) {
     this.item = item.isNull(position) ? null : item.getString(position);
   }
@@ -79,7 +85,7 @@ public class NumericParser extends Parser<String> {
 
   static byte[] convertToPG(@Nonnull String value) {
     if (value.equalsIgnoreCase("NaN")) {
-      return "NaN".getBytes(StandardCharsets.UTF_8);
+      return NAN;
     }
     try {
       return ByteConverter.numeric(new BigDecimal(value));

--- a/src/main/java/com/google/cloud/spanner/pgadapter/parsers/NumericParser.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/parsers/NumericParser.java
@@ -20,6 +20,7 @@ import com.google.cloud.spanner.ResultSet;
 import com.google.cloud.spanner.SpannerExceptionFactory;
 import com.google.cloud.spanner.Statement;
 import com.google.cloud.spanner.Value;
+import com.google.cloud.spanner.pgadapter.ProxyServer.DataFormat;
 import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
 import javax.annotation.Nonnull;
@@ -73,14 +74,30 @@ public class NumericParser extends Parser<String> {
     if (this.item == null) {
       return null;
     }
-    if (this.item.equalsIgnoreCase("NaN")) {
+    return convertToPG(this.item);
+  }
+
+  static byte[] convertToPG(@Nonnull String value) {
+    if (value.equalsIgnoreCase("NaN")) {
       return "NaN".getBytes(StandardCharsets.UTF_8);
     }
     try {
-      return ByteConverter.numeric(new BigDecimal(this.item));
+      return ByteConverter.numeric(new BigDecimal(value));
     } catch (NumberFormatException exception) {
       throw SpannerExceptionFactory.newSpannerException(
-          ErrorCode.INVALID_ARGUMENT, "Invalid numeric value: " + this.item);
+          ErrorCode.INVALID_ARGUMENT, "Invalid numeric value: " + value);
+    }
+  }
+
+  public static byte[] convertToPG(ResultSet resultSet, int position, DataFormat format) {
+    switch (format) {
+      case SPANNER:
+      case POSTGRESQL_TEXT:
+        return resultSet.getString(position).getBytes(StandardCharsets.UTF_8);
+      case POSTGRESQL_BINARY:
+        return convertToPG(resultSet.getString(position));
+      default:
+        throw new IllegalArgumentException("unknown data format: " + format);
     }
   }
 

--- a/src/main/java/com/google/cloud/spanner/pgadapter/parsers/StringParser.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/parsers/StringParser.java
@@ -53,6 +53,16 @@ public class StringParser extends Parser<String> {
     return this.item == null ? null : this.item.getBytes(StandardCharsets.UTF_8);
   }
 
+  public static byte[] convertToPG(ResultSet resultSet, int position) {
+    return resultSet.getString(position).getBytes(StandardCharsets.UTF_8);
+  }
+
+  public static byte[] binaryParse(ResultSet resultSet, int position) {
+    return resultSet.isNull(position)
+        ? null
+        : resultSet.getString(position).getBytes(StandardCharsets.UTF_8);
+  }
+
   @Override
   public void bind(Statement.Builder statementBuilder, String name) {
     statementBuilder.bind(name).to(this.item);

--- a/src/main/java/com/google/cloud/spanner/pgadapter/utils/Converter.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/utils/Converter.java
@@ -15,8 +15,18 @@
 package com.google.cloud.spanner.pgadapter.utils;
 
 import com.google.cloud.spanner.ResultSet;
+import com.google.cloud.spanner.Type;
 import com.google.cloud.spanner.pgadapter.ProxyServer.DataFormat;
-import com.google.cloud.spanner.pgadapter.parsers.Parser;
+import com.google.cloud.spanner.pgadapter.parsers.ArrayParser;
+import com.google.cloud.spanner.pgadapter.parsers.BinaryParser;
+import com.google.cloud.spanner.pgadapter.parsers.BooleanParser;
+import com.google.cloud.spanner.pgadapter.parsers.DateParser;
+import com.google.cloud.spanner.pgadapter.parsers.DoubleParser;
+import com.google.cloud.spanner.pgadapter.parsers.JsonbParser;
+import com.google.cloud.spanner.pgadapter.parsers.LongParser;
+import com.google.cloud.spanner.pgadapter.parsers.NumericParser;
+import com.google.cloud.spanner.pgadapter.parsers.StringParser;
+import com.google.cloud.spanner.pgadapter.parsers.TimestampParser;
 import com.google.common.base.Preconditions;
 
 /** Utility class for converting between generic PostgreSQL conversions. */
@@ -27,14 +37,40 @@ public class Converter {
    * may not contain a null value.
    *
    * @param result The {@link ResultSet} to read the data from.
-   * @param columnarIndex The columnar index.
+   * @param position The column index.
    * @param format The {@link DataFormat} format to use to encode the data.
    * @return a byte array containing the data in the specified format.
    */
-  public static byte[] parseData(ResultSet result, int columnarIndex, DataFormat format) {
-    Preconditions.checkArgument(
-        !result.isNull(columnarIndex), "Column may not contain a null value");
-    Parser<?> parser = Parser.create(result, result.getColumnType(columnarIndex), columnarIndex);
-    return parser.parse(format);
+  public static byte[] convertToPG(ResultSet result, int position, DataFormat format) {
+    Preconditions.checkArgument(!result.isNull(position), "Column may not contain a null value");
+    Type type = result.getColumnType(position);
+    switch (type.getCode()) {
+      case BOOL:
+        return BooleanParser.convertToPG(result, position, format);
+      case BYTES:
+        return BinaryParser.convertToPG(result, position, format);
+      case DATE:
+        return DateParser.convertToPG(result, position, format);
+      case FLOAT64:
+        return DoubleParser.convertToPG(result, position, format);
+      case INT64:
+        return LongParser.convertToPG(result, position, format);
+      case PG_NUMERIC:
+        return NumericParser.convertToPG(result, position, format);
+      case STRING:
+        return StringParser.convertToPG(result, position);
+      case TIMESTAMP:
+        return TimestampParser.convertToPG(result, position, format);
+      case PG_JSONB:
+        return JsonbParser.convertToPG(result, position, format);
+      case ARRAY:
+        ArrayParser arrayParser = new ArrayParser(result, position);
+        return arrayParser.parse(format);
+      case NUMERIC:
+      case JSON:
+      case STRUCT:
+      default:
+        throw new IllegalArgumentException("Illegal or unknown element type: " + type);
+    }
   }
 }

--- a/src/main/java/com/google/cloud/spanner/pgadapter/wireoutput/DataRowResponse.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/wireoutput/DataRowResponse.java
@@ -55,7 +55,7 @@ public class DataRowResponse extends WireOutput {
         columns.add(null);
       } else {
         DataFormat format = DataFormat.getDataFormat(column_index, statement, mode, options);
-        byte[] column = Converter.parseData(this.resultSet, column_index, format);
+        byte[] column = Converter.convertToPG(this.resultSet, column_index, format);
         length += column.length;
         columns.add(column);
       }

--- a/src/test/java/com/google/cloud/spanner/pgadapter/AbstractMockServerTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/AbstractMockServerTest.java
@@ -268,7 +268,7 @@ public abstract class AbstractMockServerTest {
   protected static MockSpannerServiceImpl mockSpanner;
   protected static MockDatabaseAdminImpl mockDatabaseAdmin;
   protected static MockInstanceAdminImpl mockInstanceAdmin;
-  private static Server spannerServer;
+  protected static Server spannerServer;
   protected static ProxyServer pgServer;
 
   protected List<WireMessage> getWireMessages() {

--- a/src/test/java/com/google/cloud/spanner/pgadapter/JdbcMockServerTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/JdbcMockServerTest.java
@@ -22,13 +22,19 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import com.google.cloud.ByteArray;
 import com.google.cloud.Date;
+import com.google.cloud.NoCredentials;
 import com.google.cloud.Timestamp;
+import com.google.cloud.spanner.DatabaseClient;
+import com.google.cloud.spanner.DatabaseId;
 import com.google.cloud.spanner.Dialect;
 import com.google.cloud.spanner.MockSpannerServiceImpl.SimulatedExecutionTime;
 import com.google.cloud.spanner.MockSpannerServiceImpl.StatementResult;
+import com.google.cloud.spanner.Spanner;
+import com.google.cloud.spanner.SpannerOptions;
 import com.google.cloud.spanner.Statement;
 import com.google.cloud.spanner.connection.RandomResultSetGenerator;
 import com.google.cloud.spanner.pgadapter.wireprotocol.ControlMessage.PreparedType;
@@ -46,6 +52,7 @@ import com.google.spanner.v1.ExecuteSqlRequest.QueryMode;
 import com.google.spanner.v1.Type;
 import com.google.spanner.v1.TypeAnnotationCode;
 import com.google.spanner.v1.TypeCode;
+import io.grpc.ManagedChannelBuilder;
 import io.grpc.Status;
 import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
@@ -1563,74 +1570,179 @@ public class JdbcMockServerTest extends AbstractMockServerTest {
 
   @Test
   public void testRandomResults() throws SQLException {
-    final int fetchSize = 3;
-    try (Connection connection = DriverManager.getConnection(createUrl())) {
-      connection.setAutoCommit(false);
-      try (PreparedStatement statement = connection.prepareStatement(SELECT_RANDOM.getSql())) {
-        statement.setFetchSize(fetchSize);
-        try (ResultSet resultSet = statement.executeQuery()) {
-          int rowCount = 0;
-          while (resultSet.next()) {
-            for (int col = 0; col < resultSet.getMetaData().getColumnCount(); col++) {
-              // TODO: Remove once we have a replacement for pg_type, as the JDBC driver will try to
-              //       read type information from the backend when it hits an 'unknown' type (jsonb
-              //       is not one of the types that the JDBC driver will load automatically).
-              if (col == 5 || col == 14) {
-                resultSet.getString(col + 1);
-              } else {
-                resultSet.getObject(col + 1);
+    for (boolean binary : new boolean[] {false, true}) {
+      // Also get the random results using the normal Spanner client to compare the results with
+      // what is returned by PGAdapter.
+      Spanner spanner =
+          SpannerOptions.newBuilder()
+              .setProjectId("p")
+              .setHost(String.format("http://localhost:%d", spannerServer.getPort()))
+              .setCredentials(NoCredentials.getInstance())
+              .setChannelConfigurator(ManagedChannelBuilder::usePlaintext)
+              .setClientLibToken("pg-adapter")
+              .build()
+              .getService();
+      DatabaseClient client = spanner.getDatabaseClient(DatabaseId.of("p", "i", "d"));
+      com.google.cloud.spanner.ResultSet spannerResult =
+          client.singleUse().executeQuery(SELECT_RANDOM);
+
+      String binaryTransferEnable =
+          "&binaryTransferEnable="
+              + ImmutableList.of(
+                      Oid.BOOL,
+                      Oid.BYTEA,
+                      Oid.VARCHAR,
+                      Oid.NUMERIC,
+                      Oid.FLOAT8,
+                      Oid.INT8,
+                      Oid.DATE,
+                      Oid.TIMESTAMPTZ)
+                  .stream()
+                  .map(String::valueOf)
+                  .collect(Collectors.joining(","));
+
+      final int fetchSize = 3;
+      try (Connection connection =
+          DriverManager.getConnection(createUrl() + binaryTransferEnable)) {
+        connection.setAutoCommit(false);
+        connection.unwrap(PGConnection.class).setPrepareThreshold(binary ? -1 : 5);
+        try (PreparedStatement statement = connection.prepareStatement(SELECT_RANDOM.getSql())) {
+          statement.setFetchSize(fetchSize);
+          try (ResultSet resultSet = statement.executeQuery()) {
+            int rowCount = 0;
+            while (resultSet.next()) {
+              assertTrue(spannerResult.next());
+              for (int col = 0; col < resultSet.getMetaData().getColumnCount(); col++) {
+                // TODO: Remove once we have a replacement for pg_type, as the JDBC driver will try
+                // to read type information from the backend when it hits an 'unknown' type (jsonb
+                // is not one of the types that the JDBC driver will load automatically).
+                if (col == 5 || col == 14) {
+                  resultSet.getString(col + 1);
+                } else {
+                  resultSet.getObject(col + 1);
+                }
               }
+              assertEqual(spannerResult, resultSet, binary);
+              rowCount++;
             }
-            rowCount++;
+            assertEquals(RANDOM_RESULTS_ROW_COUNT, rowCount);
           }
-          assertEquals(RANDOM_RESULTS_ROW_COUNT, rowCount);
         }
+        connection.commit();
       }
-      connection.commit();
+
+      // Close the resources used by the normal Spanner client.
+      spannerResult.close();
+      spanner.close();
+
+      // The ExecuteSql request should only be sent once to Cloud Spanner by PGAdapter.
+      // The normal Spanner client will also send it once to Spanner.
+      assertEquals(binary ? 3 : 2, mockSpanner.countRequestsOfType(ExecuteSqlRequest.class));
+      ExecuteSqlRequest executeRequest =
+          mockSpanner.getRequestsOfType(ExecuteSqlRequest.class).get(binary ? 2 : 1);
+      assertEquals(QueryMode.NORMAL, executeRequest.getQueryMode());
+      assertEquals(SELECT_RANDOM.getSql(), executeRequest.getSql());
+
+      // PGAdapter should receive 5 Execute messages:
+      // 1. BEGIN
+      // 2. Execute - fetch rows 1, 2
+      // 3. Execute - fetch rows 3, 4
+      // 4. Execute - fetch rows 5
+      // 5. COMMIT
+      if (pgServer != null) {
+        List<DescribeMessage> describeMessages = getWireMessagesOfType(DescribeMessage.class);
+        assertEquals(1, describeMessages.size());
+        DescribeMessage describeMessage = describeMessages.get(0);
+        assertEquals(
+            binary ? PreparedType.Statement : PreparedType.Portal, describeMessage.getType());
+
+        List<ExecuteMessage> executeMessages =
+            getWireMessagesOfType(ExecuteMessage.class).stream()
+                .filter(message -> !JDBC_STARTUP_STATEMENTS.contains(message.getSql()))
+                .collect(Collectors.toList());
+        int expectedExecuteMessageCount =
+            RANDOM_RESULTS_ROW_COUNT / fetchSize
+                + ((RANDOM_RESULTS_ROW_COUNT % fetchSize) > 0 ? 1 : 0)
+                + 2;
+        assertEquals(expectedExecuteMessageCount, executeMessages.size());
+        assertEquals("", executeMessages.get(0).getName());
+        for (ExecuteMessage executeMessage :
+            executeMessages.subList(1, executeMessages.size() - 1)) {
+          assertEquals(fetchSize, executeMessage.getMaxRows());
+        }
+        assertEquals("", executeMessages.get(executeMessages.size() - 1).getName());
+
+        List<ParseMessage> parseMessages =
+            getWireMessagesOfType(ParseMessage.class).stream()
+                .filter(message -> !JDBC_STARTUP_STATEMENTS.contains(message.getSql()))
+                .collect(Collectors.toList());
+        assertEquals(3, parseMessages.size());
+        assertEquals("BEGIN", parseMessages.get(0).getStatement().getSql());
+        assertEquals(SELECT_RANDOM.getSql(), parseMessages.get(1).getStatement().getSql());
+        assertEquals("COMMIT", parseMessages.get(2).getStatement().getSql());
+      }
+      mockSpanner.clearRequests();
+      pgServer.clearDebugMessages();
     }
-    // The ExecuteSql request should only be sent once to Cloud Spanner.
-    assertEquals(1, mockSpanner.countRequestsOfType(ExecuteSqlRequest.class));
-    ExecuteSqlRequest executeRequest =
-        mockSpanner.getRequestsOfType(ExecuteSqlRequest.class).get(0);
-    assertEquals(QueryMode.NORMAL, executeRequest.getQueryMode());
-    assertEquals(SELECT_RANDOM.getSql(), executeRequest.getSql());
+  }
 
-    // PGAdapter should receive 5 Execute messages:
-    // 1. BEGIN
-    // 2. Execute - fetch rows 1, 2
-    // 3. Execute - fetch rows 3, 4
-    // 4. Execute - fetch rows 5
-    // 5. COMMIT
-    if (pgServer != null) {
-      List<DescribeMessage> describeMessages = getWireMessagesOfType(DescribeMessage.class);
-      assertEquals(1, describeMessages.size());
-      DescribeMessage describeMessage = describeMessages.get(0);
-      assertEquals(PreparedType.Portal, describeMessage.getType());
-
-      List<ExecuteMessage> executeMessages =
-          getWireMessagesOfType(ExecuteMessage.class).stream()
-              .filter(message -> !JDBC_STARTUP_STATEMENTS.contains(message.getSql()))
-              .collect(Collectors.toList());
-      int expectedExecuteMessageCount =
-          RANDOM_RESULTS_ROW_COUNT / fetchSize
-              + ((RANDOM_RESULTS_ROW_COUNT % fetchSize) > 0 ? 1 : 0)
-              + 2;
-      assertEquals(expectedExecuteMessageCount, executeMessages.size());
-      assertEquals("", executeMessages.get(0).getName());
-      for (ExecuteMessage executeMessage : executeMessages.subList(1, executeMessages.size() - 1)) {
-        assertEquals(describeMessage.getName(), executeMessage.getName());
-        assertEquals(fetchSize, executeMessage.getMaxRows());
+  private void assertEqual(
+      com.google.cloud.spanner.ResultSet spannerResult, ResultSet pgResult, boolean binary)
+      throws SQLException {
+    assertEquals(spannerResult.getColumnCount(), pgResult.getMetaData().getColumnCount());
+    for (int col = 0; col < spannerResult.getColumnCount(); col++) {
+      if (spannerResult.isNull(col)) {
+        assertNull(pgResult.getObject(col + 1));
+        assertTrue(pgResult.wasNull());
+        continue;
       }
-      assertEquals("", executeMessages.get(executeMessages.size() - 1).getName());
 
-      List<ParseMessage> parseMessages =
-          getWireMessagesOfType(ParseMessage.class).stream()
-              .filter(message -> !JDBC_STARTUP_STATEMENTS.contains(message.getSql()))
-              .collect(Collectors.toList());
-      assertEquals(3, parseMessages.size());
-      assertEquals("BEGIN", parseMessages.get(0).getStatement().getSql());
-      assertEquals(SELECT_RANDOM.getSql(), parseMessages.get(1).getStatement().getSql());
-      assertEquals("COMMIT", parseMessages.get(2).getStatement().getSql());
+      switch (spannerResult.getColumnType(col).getCode()) {
+        case BOOL:
+          if (!binary) {
+            // Skip for binary for now, as there is a bug in the PG JDBC driver for decoding binary
+            // bool values.
+            assertEquals(spannerResult.getBoolean(col), pgResult.getBoolean(col + 1));
+          }
+          break;
+        case INT64:
+          assertEquals(spannerResult.getLong(col), pgResult.getLong(col + 1));
+          break;
+        case FLOAT64:
+          assertEquals(spannerResult.getDouble(col), pgResult.getDouble(col + 1), 0.0d);
+          break;
+        case PG_NUMERIC:
+        case STRING:
+          assertEquals(spannerResult.getString(col), pgResult.getString(col + 1));
+          break;
+        case BYTES:
+          assertArrayEquals(spannerResult.getBytes(col).toByteArray(), pgResult.getBytes(col + 1));
+          break;
+        case TIMESTAMP:
+          // Compare milliseconds, as PostgreSQL does not natively support nanosecond precision, and
+          // this is lost when using binary encoding.
+          assertEquals(
+              spannerResult.getTimestamp(col).toSqlTimestamp().getTime(),
+              pgResult.getTimestamp(col + 1).getTime());
+          break;
+        case DATE:
+          assertEquals(
+              LocalDate.of(
+                  spannerResult.getDate(col).getYear(),
+                  spannerResult.getDate(col).getMonth(),
+                  spannerResult.getDate(col).getDayOfMonth()),
+              pgResult.getDate(col + 1).toLocalDate());
+          break;
+        case PG_JSONB:
+          assertEquals(spannerResult.getPgJsonb(col), pgResult.getString(col + 1));
+          break;
+        case ARRAY:
+          break;
+        case NUMERIC:
+        case JSON:
+        case STRUCT:
+          fail("unsupported PG type: " + spannerResult.getColumnType(col));
+      }
     }
   }
 

--- a/src/test/java/com/google/cloud/spanner/pgadapter/parsers/ParserTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/parsers/ParserTest.java
@@ -411,12 +411,14 @@ public class ParserTest {
   @Test
   public void testNumericParsingNaN() {
     String value = "NaN";
+    byte[] byteResult = new byte[8];
+    ByteConverter.int2(byteResult, 4, (short) 0xC000);
 
     byte[] stringResult = {'N', 'a', 'N'};
 
     NumericParser parser = new NumericParser(value);
 
-    validate(parser, stringResult, stringResult, stringResult);
+    validate(parser, byteResult, stringResult, stringResult);
     assertEquals(value, parser.getItem());
     validateCreateText(stringResult, Oid.NUMERIC, value);
   }

--- a/src/test/java/com/google/cloud/spanner/pgadapter/parsers/TimestampParserTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/parsers/TimestampParserTest.java
@@ -22,9 +22,16 @@ import static org.junit.Assert.assertThrows;
 
 import com.google.cloud.Timestamp;
 import com.google.cloud.spanner.ErrorCode;
+import com.google.cloud.spanner.ResultSet;
+import com.google.cloud.spanner.ResultSets;
 import com.google.cloud.spanner.SpannerException;
+import com.google.cloud.spanner.Struct;
+import com.google.cloud.spanner.Type;
+import com.google.cloud.spanner.Type.StructField;
+import com.google.cloud.spanner.pgadapter.ProxyServer.DataFormat;
 import com.google.cloud.spanner.pgadapter.error.PGException;
 import com.google.cloud.spanner.pgadapter.parsers.Parser.FormatCode;
+import com.google.common.collect.ImmutableList;
 import java.nio.charset.StandardCharsets;
 import java.util.Random;
 import org.junit.Test;
@@ -64,6 +71,19 @@ public class TimestampParserTest {
                 FormatCode.TEXT)
             .spannerParse());
     assertNull(new TimestampParser(null).spannerParse());
+
+    ResultSet resultSet =
+        ResultSets.forRows(
+            Type.struct(StructField.of("ts", Type.timestamp())),
+            ImmutableList.of(
+                Struct.newBuilder()
+                    .set("ts")
+                    .to(Timestamp.parseTimestamp("2022-07-08T07:22:59.123456789Z"))
+                    .build()));
+    resultSet.next();
+    assertArrayEquals(
+        "2022-07-08T07:22:59.123456789Z".getBytes(StandardCharsets.UTF_8),
+        TimestampParser.convertToPG(resultSet, 0, DataFormat.SPANNER));
   }
 
   @Test


### PR DESCRIPTION
Convert a Spanner value directly to the PostgreSQL equivalent without creating a Parser object. This reduces the amount of memory that is allocated and must be garbage collected for each row that is sent to the PostgreSQL client.