### PR TITLE
test: add test for error in transaction for gorm

### DIFF
--- a/src/test/java/com/google/cloud/spanner/pgadapter/golang/GormTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/golang/GormTest.java
@@ -41,5 +41,7 @@ public interface GormTest extends Library {
 
   String TestNestedTransaction(GoString connString);
 
+  String TestErrorInTransaction(GoString connString);
+
   String TestReadOnlyTransaction(GoString connString);
 }


### PR DESCRIPTION
Adds a test for error handling in a read/write transaction in gorm.