### PR TITLE
feat: add setting for copy_commit_priority

### DIFF
--- a/src/main/java/com/google/cloud/spanner/pgadapter/session/CopySettings.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/session/CopySettings.java
@@ -14,6 +14,8 @@
 
 package com.google.cloud.spanner.pgadapter.session;
 
+import com.google.cloud.spanner.Options.RpcPriority;
+import java.util.Locale;
 import java.util.Map;
 
 public class CopySettings {
@@ -84,6 +86,19 @@ public class CopySettings {
   /** Returns the commit timeout for COPY operations in seconds. */
   public int getCommitTimeoutSeconds() {
     return sessionState.getIntegerSetting("spanner", "copy_commit_timeout", 300);
+  }
+
+  /** Returns the request priority for commits executed by COPY operations. */
+  public RpcPriority getCommitPriority() {
+    String setting =
+        sessionState
+            .getStringSetting("spanner", "copy_commit_priority", "medium")
+            .toUpperCase(Locale.ENGLISH);
+    try {
+      return RpcPriority.valueOf(setting);
+    } catch (IllegalArgumentException e) {
+      return RpcPriority.MEDIUM;
+    }
   }
 
   /** Returns the batch size to use for non-atomic COPY operations. */

--- a/src/main/java/com/google/cloud/spanner/pgadapter/session/SessionState.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/session/SessionState.java
@@ -271,6 +271,11 @@ public class SessionState {
     return null;
   }
 
+  String getStringSetting(String extension, String name, String defaultValue) {
+    PGSetting setting = internalGet(toKey(extension, name), false);
+    return setting != null ? setting.getSetting() : defaultValue;
+  }
+
   boolean getBoolSetting(String extension, String name, boolean defaultValue) {
     PGSetting setting = internalGet(toKey(extension, name), false);
     if (setting != null) {

--- a/src/main/java/com/google/cloud/spanner/pgadapter/utils/MutationWriter.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/utils/MutationWriter.java
@@ -23,6 +23,7 @@ import com.google.cloud.spanner.DatabaseClient;
 import com.google.cloud.spanner.ErrorCode;
 import com.google.cloud.spanner.Mutation;
 import com.google.cloud.spanner.Mutation.WriteBuilder;
+import com.google.cloud.spanner.Options;
 import com.google.cloud.spanner.SpannerException;
 import com.google.cloud.spanner.SpannerExceptionFactory;
 import com.google.cloud.spanner.SpannerOptions;
@@ -370,7 +371,10 @@ public class MutationWriter implements Callable<StatementResult>, Closeable {
                           SpannerCallContextTimeoutConfigurator.create()
                               .withCommitTimeout(
                                   Duration.ofSeconds(copySettings.getCommitTimeoutSeconds())));
-              context.run(() -> dbClient.write(immutableMutations));
+              context.run(
+                  () ->
+                      dbClient.writeWithOptions(
+                          immutableMutations, Options.priority(copySettings.getCommitPriority())));
               return null;
             });
     Futures.addCallback(

--- a/src/main/resources/com/google/cloud/spanner/pgadapter/session/pg_settings.txt
+++ b/src/main/resources/com/google/cloud/spanner/pgadapter/session/pg_settings.txt
@@ -346,6 +346,7 @@ zero_damaged_pages	off	\N	Developer Options	Continues processing past damaged pa
 spanner.copy_batch_size	5000	\N	COPY / Batch size for non-atomic COPY operations	The number of mutations to include in one batch when executing a non-atomic COPY operation.	\N	user	integer	default	\N	\N	\N	5000	5000	\N	\N	f
 spanner.copy_max_parallelism	128	\N	COPY / Max concurrent transactions for a non-atomic COPY operation	The maximum number of concurrent transactions for a non-atomic COPY operation.	\N	user	integer	default	\N	\N	\N	128	128	\N	\N	f
 spanner.copy_commit_timeout	300	\N	COPY / Timeout in seconds for commits for COPY operations	Timeout in seconds for commit requests for COPY operations.	\N	user	integer	default	\N	\N	\N	300	300	\N	\N	f
+spanner.copy_commit_priority	medium	\N	COPY / RPC priority for commits for COPY operations	RPC priority for commit requests for COPY operations.	\N	user	enum	default	\N	\N	{low,medium,high}	medium	medium	\N	\N	f
 spanner.copy_upsert	off	\N	COPY / Use Upsert instead of Insert for COPY	Use insert-or-update instead of insert for COPY operations.	\N	user	bool	default	\N	\N	\N	off	off	\N	\N	f
 spanner.copy_max_atomic_mutations	20000	\N	COPY / Max number of mutations for atomic COPY operations	The maximum number of mutations in an atomic COPY operation.	\N	internal	integer	default	\N	\N	\N	20000	20000	\N	\N	f
 spanner.copy_max_atomic_commit_size	100000000	\N	COPY / Max number of bytes in an atomic COPY operation	The maximum number of bytes in an atomic COPY operation.	\N	internal	integer	default	\N	\N	\N	100000000	100000000	\N	\N	f

--- a/src/test/java/com/google/cloud/spanner/pgadapter/CopyInMockServerTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/CopyInMockServerTest.java
@@ -40,6 +40,7 @@ import com.google.spanner.v1.CommitRequest;
 import com.google.spanner.v1.ExecuteSqlRequest;
 import com.google.spanner.v1.Mutation;
 import com.google.spanner.v1.Mutation.OperationCase;
+import com.google.spanner.v1.RequestOptions.Priority;
 import com.google.spanner.v1.ResultSetMetadata;
 import com.google.spanner.v1.RollbackRequest;
 import com.google.spanner.v1.StructType;
@@ -138,11 +139,28 @@ public class CopyInMockServerTest extends AbstractMockServerTest {
     assertEquals(1, commitRequests.size());
     CommitRequest commitRequest = commitRequests.get(0);
     assertEquals(1, commitRequest.getMutationsCount());
+    assertEquals(Priority.PRIORITY_MEDIUM, commitRequest.getRequestOptions().getPriority());
 
     Mutation mutation = commitRequest.getMutations(0);
     assertEquals(OperationCase.INSERT, mutation.getOperationCase());
     assertEquals(3, mutation.getInsert().getValuesCount());
     assertEquals(3, mutation.getInsert().getColumnsCount());
+  }
+
+  @Test
+  public void testCopyInWithPriority() throws SQLException, IOException {
+    setupCopyInformationSchemaResults();
+
+    try (Connection connection = DriverManager.getConnection(createUrl())) {
+      connection.createStatement().execute("set spanner.copy_commit_priority=low");
+      CopyManager copyManager = new CopyManager(connection.unwrap(BaseConnection.class));
+      copyManager.copyIn("COPY users FROM STDIN;", new StringReader("5\t5\t5\n"));
+    }
+
+    List<CommitRequest> commitRequests = mockSpanner.getRequestsOfType(CommitRequest.class);
+    assertEquals(1, commitRequests.size());
+    CommitRequest commitRequest = commitRequests.get(0);
+    assertEquals(Priority.PRIORITY_LOW, commitRequest.getRequestOptions().getPriority());
   }
 
   @Test

--- a/src/test/java/com/google/cloud/spanner/pgadapter/JdbcMockServerTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/JdbcMockServerTest.java
@@ -2359,7 +2359,7 @@ public class JdbcMockServerTest extends AbstractMockServerTest {
           }
           count++;
         }
-        assertEquals(357, count);
+        assertEquals(358, count);
       }
     }
   }

--- a/src/test/java/com/google/cloud/spanner/pgadapter/utils/MutationWriterTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/utils/MutationWriterTest.java
@@ -19,7 +19,9 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyIterable;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -151,7 +153,7 @@ public class MutationWriterTest {
                 .set("name")
                 .to("Two")
                 .build());
-    verify(databaseClient).write(expectedMutations);
+    verify(databaseClient).writeWithOptions(eq(expectedMutations), any());
   }
 
   @Test
@@ -238,7 +240,7 @@ public class MutationWriterTest {
       StatementResult updateCount = mutationWriter.call();
 
       assertEquals(5L, updateCount.getUpdateCount().longValue());
-      verify(databaseClient, times(3)).write(anyIterable());
+      verify(databaseClient, times(3)).writeWithOptions(anyIterable(), any());
     } finally {
       System.getProperties().remove("copy_in_mutation_limit");
     }
@@ -329,7 +331,7 @@ public class MutationWriterTest {
       // 4. The second batch contains 28 bytes. (3 - 'Three')
       // 5. The third batch contains 24 bytes. (4 - 'Four')
       // 6. the fourth batch contains 24 bytes. (5 - 'Five')
-      verify(databaseClient, times(4)).write(anyIterable());
+      verify(databaseClient, times(4)).writeWithOptions(anyIterable(), any());
     } finally {
       System.getProperties().remove("copy_in_commit_limit");
     }
@@ -399,7 +401,7 @@ public class MutationWriterTest {
                 .set("name")
                 .to("Five")
                 .build());
-    verify(databaseClient).write(expectedMutations);
+    verify(databaseClient).writeWithOptions(eq(expectedMutations), any());
 
     executor.shutdown();
   }


### PR DESCRIPTION
Adds the setting 'spanner.copy_commit_priority' that can be used to set the Rpc priority for Commit requests for COPY operations. The default is MEDIUM to be consistent with Dataflow.

Fixes b/254330479