### PR TITLE
fix: memory leak caused by ConnectionHandler not removed from map

### DIFF
--- a/src/main/java/com/google/cloud/spanner/pgadapter/ConnectionHandler.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/ConnectionHandler.java
@@ -431,6 +431,7 @@ public class ConnectionHandler extends Thread {
         this.spannerConnection.close();
       }
       this.status = ConnectionStatus.TERMINATED;
+      CONNECTION_HANDLERS.remove(this.connectionId);
     }
   }
 


### PR DESCRIPTION
PGAdapter keeps a map of ConnectionID / ConnectionHandler pairs to look these up in case a statement is cancelled. A ConnectionHandler was not removed from this map when the connection was closed, which could cause a slow memory leak if a large number of connections were opened and closed during the lifetime of PGAdapter.

Fixes #435 