### PR TITLE
chore: skip auto-describe when there are no param values

### DIFF
--- a/src/main/java/com/google/cloud/spanner/pgadapter/wireprotocol/BindMessage.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/wireprotocol/BindMessage.java
@@ -19,6 +19,7 @@ import com.google.cloud.spanner.pgadapter.ConnectionHandler;
 import com.google.cloud.spanner.pgadapter.statements.BackendConnection;
 import com.google.cloud.spanner.pgadapter.statements.IntermediatePreparedStatement;
 import com.google.cloud.spanner.pgadapter.wireoutput.BindCompleteResponse;
+import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import java.text.MessageFormat;
 import java.util.Arrays;
@@ -67,12 +68,12 @@ public class BindMessage extends AbstractQueryProtocolMessage {
     this.statementName = statementName;
     this.formatCodes = ImmutableList.of();
     this.resultFormatCodes = ImmutableList.of();
-    this.parameters = parameters;
+    this.parameters = Preconditions.checkNotNull(parameters);
     this.statement = connection.getStatement(statementName);
   }
 
-  private boolean hasParameterValues() {
-    return this.parameters != null && this.parameters.length > 0;
+  boolean hasParameterValues() {
+    return this.parameters.length > 0;
   }
 
   @Override

--- a/src/main/java/com/google/cloud/spanner/pgadapter/wireprotocol/BindMessage.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/wireprotocol/BindMessage.java
@@ -71,9 +71,13 @@ public class BindMessage extends AbstractQueryProtocolMessage {
     this.statement = connection.getStatement(statementName);
   }
 
+  private boolean hasParameterValues() {
+    return this.parameters != null && this.parameters.length > 0;
+  }
+
   @Override
   void buffer(BackendConnection backendConnection) {
-    if (isExtendedProtocol() && !this.statement.isDescribed()) {
+    if (isExtendedProtocol() && hasParameterValues() && !this.statement.isDescribed()) {
       try {
         // Make sure all parameters have been described, so we always send typed parameters to Cloud
         // Spanner.

--- a/src/test/java/com/google/cloud/spanner/pgadapter/wireprotocol/ProtocolTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/wireprotocol/ProtocolTest.java
@@ -19,6 +19,7 @@ import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -648,6 +649,7 @@ public class ProtocolTest {
     assertEquals(expectedFormatCodes, ((BindMessage) message).getFormatCodes());
     assertEquals(expectedFormatCodes, ((BindMessage) message).getResultFormatCodes());
     assertEquals("select * from foo", ((BindMessage) message).getSql());
+    assertTrue(((BindMessage) message).hasParameterValues());
 
     when(intermediatePreparedStatement.bind(
             ArgumentMatchers.anyString(),


### PR DESCRIPTION
We can skip the auto-describe method completely when there are no parameter values. This saves a little parsing of the SQL string for simple statements like `BEGIN` or `SELECT 1`.

Fixes #459