### PR TITLE
build: remove unit tests from CI job

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,31 +21,6 @@ jobs:
           GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
         if: "${{ env.GCP_PROJECT_ID != '' }}"
         run: echo "::set-output name=defined::true"
-  units:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        java: [8, 11]
-    steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-java@v3
-      with:
-        java-version: ${{matrix.java}}
-        distribution: 'zulu'
-    - run: java -version
-    - uses: actions/setup-go@v3
-      with:
-        go-version: '^1.17.7'
-    - run: go version
-    - uses: actions/setup-python@v4
-      with:
-        python-version: '3.9'
-    - run: python --version
-    - run: pip install -r ./src/test/python/requirements.txt
-    - uses: actions/setup-node@v3
-      with:
-        node-version: 16
-    - run: .ci/run-with-credentials.sh units
 
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Remove unit tests from the CI job, as we are already running the unit tests in separate jobs.