### PR TITLE
feat: support more than 50 query parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,8 +264,6 @@ Other `psql` meta-commands are __not__ supported.
 ## Limitations
 
 PGAdapter has the following known limitations at this moment:
-- Server side [prepared statements](https://www.postgresql.org/docs/current/sql-prepare.html) are limited to at most 50 parameters.
-- SSL connections are not supported.
 - Only [password authentication](https://www.postgresql.org/docs/current/auth-password.html) using
   the `password` method is supported. All other authentication methods are not supported.
 - The COPY protocol only supports COPY TO|FROM STDOUT|STDIN [BINARY]. COPY TO|FROM <FILE|PROGRAM> is not supported.

--- a/docs/jdbc.md
+++ b/docs/jdbc.md
@@ -106,7 +106,3 @@ try (java.sql.Statement statement = connection.createStatement()) {
 ```
 
 ## Limitations
-- Server side [prepared statements](https://www.postgresql.org/docs/current/sql-prepare.html) are limited to at most 50 parameters.
-  Note: This is not the same as `java.sql.PreparedStatement`. A `java.sql.PreparedStatement` will only use
-  a server side prepared statement if it has been executed more at least `prepareThreshold` times.
-  See https://jdbc.postgresql.org/documentation/server-prepare/#activation for more information.

--- a/docs/node-postgres.md
+++ b/docs/node-postgres.md
@@ -116,4 +116,3 @@ console.log(res);
 ```
 
 ## Limitations
-- [Prepared statements](https://www.postgresql.org/docs/current/sql-prepare.html) are limited to at most 50 parameters.

--- a/docs/pgx.md
+++ b/docs/pgx.md
@@ -104,6 +104,3 @@ res := conn.SendBatch(context.Background(), batch)
 ```
 
 ## Limitations
-- Server side [prepared statements](https://www.postgresql.org/docs/current/sql-prepare.html) are limited to at most 50 parameters.
-  `pgx` uses server side prepared statements for all parameterized statements in extended query mode.
-  You can use the [simple query protocol](https://pkg.go.dev/github.com/jackc/pgx/v4#QuerySimpleProtocol) to work around this limitation.

--- a/samples/golang/gorm/README.md
+++ b/samples/golang/gorm/README.md
@@ -162,14 +162,3 @@ db, err := gorm.Open(postgres.Open(connectionString), &gorm.Config{
 ### Locking
 Locking clauses, like `clause.Locking{Strength: "UPDATE"}`, are not supported. These are generally speaking also not
 required, as Cloud Spanner uses isolation level `serializable` for read/write transactions.
-
-### Large CreateInBatches
-The `CreateInBatches` function will generate an insert statement in the following form:
-
-```sql
-INSERT INTO my_table (col1, col2, col3)
-VALUES ($1, $2, $3), ($4, $5, $6), ($7, $8, $9), ..., ($x, $y, $z)
-```
-
-PGAdapter currently does not support prepared statements with more than 50 parameters. Either reduce the number of rows
-that are inserted in one batch or use the `SimpleQueryMode` to work around this limitation.


### PR DESCRIPTION
Remove the limitation that a query can have at most 50 parameters.