### PR TITLE
fix: enable gracefully stopping Docker container

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -2,7 +2,7 @@
 #                                     BUILD                                    #
 ################################################################################
 
-FROM maven:3.8.4-eclipse-temurin-17-alpine AS build
+FROM maven:3.8.6-eclipse-temurin-17 AS build
 
 # Copy over build files to docker image.
 COPY LICENSE ./

--- a/build/startup.sh
+++ b/build/startup.sh
@@ -15,4 +15,4 @@ done
 cd /home/pgadapter
 COMMAND="java ${JAVA_ARGUMENTS} -jar pgadapter.jar ${ARGUMENTS}"
 echo $COMMAND
-eval " $COMMAND"
+exec $COMMAND


### PR DESCRIPTION
The pre-built Docker image had two minor problems:
1. It could not be built on M1 Macs, because the internal build container used an '-alpine' image, which do not support the M1 architecture.
2. Docker containers based on this image could not be gracefully stopped because these used `eval` instead of `exec`. This again means that PGAdapter itself was started as a subprocess in the container, and the sigterm signal is not propagated to any subprocess inside the container.

Fixes #552 #553