### PR TITLE
chore: cleanup unused code

### DIFF
--- a/src/main/java/com/google/cloud/spanner/pgadapter/parsers/DateParser.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/parsers/DateParser.java
@@ -22,9 +22,7 @@ import com.google.cloud.spanner.SpannerExceptionFactory;
 import com.google.cloud.spanner.Statement;
 import com.google.cloud.spanner.pgadapter.ProxyServer.DataFormat;
 import com.google.cloud.spanner.pgadapter.error.PGExceptionFactory;
-import com.google.common.base.Preconditions;
 import java.nio.charset.StandardCharsets;
-import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.time.LocalDate;
 import javax.annotation.Nonnull;
@@ -85,25 +83,6 @@ public class DateParser extends Parser<Date> {
     LocalDate localDate = LocalDate.ofEpochDay(validateRange(days));
     return Date.fromYearMonthDay(
         localDate.getYear(), localDate.getMonthValue(), localDate.getDayOfMonth());
-  }
-
-  /**
-   * Checks whether the given text contains a date that can be parsed by PostgreSQL.
-   *
-   * @param value The value to check. May not be <code>null</code>.
-   * @return <code>true</code> if the text contains a valid date.
-   */
-  static boolean isDate(String value) {
-    Preconditions.checkNotNull(value);
-    for (SimpleDateFormat dateFormat : VALID_DATE_FORMATS) {
-      try {
-        dateFormat.parse(value);
-        return true;
-      } catch (ParseException e) {
-        // ignore and try the next
-      }
-    }
-    return false;
   }
 
   @Override

--- a/src/main/java/com/google/cloud/spanner/pgadapter/parsers/TimestampParser.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/parsers/TimestampParser.java
@@ -24,7 +24,6 @@ import com.google.cloud.spanner.pgadapter.ProxyServer.DataFormat;
 import com.google.cloud.spanner.pgadapter.error.PGExceptionFactory;
 import com.google.cloud.spanner.pgadapter.metadata.OptionsMetadata;
 import com.google.cloud.spanner.pgadapter.session.SessionState;
-import com.google.common.base.Preconditions;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.time.OffsetDateTime;
@@ -33,7 +32,6 @@ import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
 import java.time.temporal.ChronoField;
 import java.time.temporal.TemporalAccessor;
-import java.util.regex.Pattern;
 import javax.annotation.Nonnull;
 import org.postgresql.util.ByteConverter;
 
@@ -47,17 +45,6 @@ public class TimestampParser extends Parser<Timestamp> {
   private static final char EMPTY_SPACE = ' ';
   private static final String ZERO_TIMEZONE = "Z";
   private static final String PG_ZERO_TIMEZONE = "+00";
-
-  /** Regular expression for parsing timestamps. */
-  private static final String TIMESTAMP_REGEX =
-      // yyyy-MM-dd
-      "(\\d{4})-(\\d{2})-(\\d{2})"
-          // ' 'HH:mm:ss.milliseconds
-          + "( (\\d{2}):(\\d{2}):(\\d{2})(\\.\\d{1,9})?)"
-          // 'Z' or time zone shift HH:mm following '+' or '-'
-          + "([Zz]|([+-])(\\d{2})(:(\\d{2}))?)?";
-
-  private static final Pattern TIMESTAMP_PATTERN = Pattern.compile(TIMESTAMP_REGEX);
 
   private static final DateTimeFormatter TIMESTAMP_OUTPUT_FORMATTER =
       new DateTimeFormatterBuilder()
@@ -133,17 +120,6 @@ public class TimestampParser extends Parser<Timestamp> {
     } catch (Exception exception) {
       throw PGExceptionFactory.newPGException("Invalid timestamp value: " + value);
     }
-  }
-
-  /**
-   * Checks whether the given text contains a timestamp that can be parsed by PostgreSQL.
-   *
-   * @param value The value to check. May not be <code>null</code>.
-   * @return <code>true</code> if the text contains a valid timestamp.
-   */
-  static boolean isTimestamp(String value) {
-    Preconditions.checkNotNull(value);
-    return TIMESTAMP_PATTERN.matcher(toPGString(value)).matches();
   }
 
   @Override

--- a/src/test/java/com/google/cloud/spanner/pgadapter/parsers/ParserTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/parsers/ParserTest.java
@@ -17,10 +17,8 @@ package com.google.cloud.spanner.pgadapter.parsers;
 import static com.google.cloud.spanner.pgadapter.parsers.Parser.toOid;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -214,20 +212,6 @@ public class ParserTest {
   }
 
   @Test
-  public void testDateParsingDateValidityChecks() {
-    assertTrue(DateParser.isDate("1998-09-01 00:00"));
-    assertTrue(DateParser.isDate("1998-09-01 +00:00"));
-    assertTrue(DateParser.isDate("1998-09-01 -00:00"));
-    assertFalse(DateParser.isDate("This is not a date right?"));
-    assertFalse(DateParser.isDate("1998-09-01 *00:00"));
-    assertFalse(DateParser.isDate("1998-a-01 00:00"));
-    assertFalse(DateParser.isDate("1998-01-a 00:00"));
-    assertFalse(DateParser.isDate("1998-01-01 a:00"));
-    assertFalse(DateParser.isDate("1998-01-01 00:a"));
-    assertFalse(DateParser.isDate("1998-01 00:00"));
-  }
-
-  @Test
   public void testStringParsing() {
     String value = "This is a String.";
 
@@ -252,34 +236,6 @@ public class ParserTest {
 
     assertArrayEquals(byteResult, parsedValue.parse(DataFormat.POSTGRESQL_BINARY));
     validateCreateBinary(byteResult, Oid.TIMESTAMP, value);
-  }
-
-  @Test
-  public void testTimestampParsingTimestampValidityChecks() {
-    assertTrue(TimestampParser.isTimestamp("1998-09-01 00:00:00"));
-    assertTrue(TimestampParser.isTimestamp("1998-09-01 00:00:00.0"));
-    assertTrue(TimestampParser.isTimestamp("1998-09-01 00:00:00.000000000"));
-    assertTrue(TimestampParser.isTimestamp("1998-09-01 00:00:00.000000000Z"));
-    assertTrue(TimestampParser.isTimestamp("1998-09-01 00:00:00.000000000z"));
-    assertTrue(TimestampParser.isTimestamp("1998-09-01 00:00:00.000000000+00"));
-    assertTrue(TimestampParser.isTimestamp("1998-09-01 00:00:00.000000000+00:00"));
-    assertTrue(TimestampParser.isTimestamp("1998-09-01 00:00:00.000000000-00:00"));
-    assertFalse(TimestampParser.isTimestamp("This is not a timestamp right?"));
-    assertFalse(TimestampParser.isTimestamp("1998-09-01 00:00:00.000000000z00"));
-    assertFalse(TimestampParser.isTimestamp("1998-09-01 00:00:00.000000000z00:00"));
-    assertFalse(TimestampParser.isTimestamp("1998-09-01 00:00:00.000000000+"));
-    assertFalse(TimestampParser.isTimestamp("1998-09-01 00:00:00.000000000-"));
-    assertFalse(TimestampParser.isTimestamp("99999-09-01 00:00:00.000000000+00:00"));
-    assertFalse(TimestampParser.isTimestamp("aaaa-09-01 00:00:00.000000000+00:00"));
-    assertFalse(TimestampParser.isTimestamp("1998-aa-01 00:00:00.000000000+00:00"));
-    assertFalse(TimestampParser.isTimestamp("1998-09-aa 00:00:00.000000000+00:00"));
-    assertFalse(TimestampParser.isTimestamp("1998-09-01 aa:00:00.000000000+00:00"));
-    assertFalse(TimestampParser.isTimestamp("1998-09-01 00:aa:00.000000000+00:00"));
-    assertFalse(TimestampParser.isTimestamp("1998-09-01 00:00:aa.000000000+00:00"));
-    assertFalse(TimestampParser.isTimestamp("1998-09-01 00:00:00.a+00:00"));
-    assertFalse(TimestampParser.isTimestamp("1998-09-01 00:00:00.000000000+aa:00"));
-    assertFalse(TimestampParser.isTimestamp("1998-09-01 00:00:00.000000000+00:aa"));
-    assertFalse(TimestampParser.isTimestamp("1998-09-01 00:00:00.000000000*00:00"));
   }
 
   @Test


### PR DESCRIPTION
Removes unused code that was left over from a time when the type of a date/time parameter sometimes needed to be guessed. This is now implemented by internally executing a DescribeStatement step for statements that have at least one unspecified parameter.