### PR TITLE
perf: reduce conversion time for timestamptz, date and bytea

### DIFF
--- a/src/main/java/com/google/cloud/spanner/pgadapter/parsers/DateParser.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/parsers/DateParser.java
@@ -111,19 +111,19 @@ public class DateParser extends Parser<Date> {
     return this.item == null ? null : toString(this.item);
   }
 
-  private static String toString(Date date) {
+  static String toString(Date date) {
     int yearValue = date.getYear();
     int monthValue = date.getMonth();
     int dayValue = date.getDayOfMonth();
-    int absYear = Math.abs(yearValue);
     StringBuilder buf = new StringBuilder(10);
-    if (absYear < 1000) {
-      if (yearValue < 0) {
-        buf.append(yearValue - 10000).deleteCharAt(1);
-      } else {
-        buf.append(yearValue + 10000).deleteCharAt(0);
-      }
+    if (yearValue < 1000) {
+      // Note that Date cannot contain negative year numbers, so this value is always guaranteed to
+      // be between 1 and 999 (inclusive).
+      buf.append(yearValue + 10000).deleteCharAt(0);
     } else {
+      // Year values beyond 9999 are not supported by Cloud Spanner, but it is allowed by the Date
+      // class. The ISO specification requires year numbers that have more than 4 digits to have a
+      // plus or minus sign.
       if (yearValue > 9999) {
         buf.append('+');
       }

--- a/src/main/java/com/google/cloud/spanner/pgadapter/parsers/DateParser.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/parsers/DateParser.java
@@ -108,7 +108,32 @@ public class DateParser extends Parser<Date> {
 
   @Override
   public String stringParse() {
-    return this.item == null ? null : item.toString();
+    return this.item == null ? null : toString(this.item);
+  }
+
+  private static String toString(Date date) {
+    int yearValue = date.getYear();
+    int monthValue = date.getMonth();
+    int dayValue = date.getDayOfMonth();
+    int absYear = Math.abs(yearValue);
+    StringBuilder buf = new StringBuilder(10);
+    if (absYear < 1000) {
+      if (yearValue < 0) {
+        buf.append(yearValue - 10000).deleteCharAt(1);
+      } else {
+        buf.append(yearValue + 10000).deleteCharAt(0);
+      }
+    } else {
+      if (yearValue > 9999) {
+        buf.append('+');
+      }
+      buf.append(yearValue);
+    }
+    return buf.append(monthValue < 10 ? "-0" : "-")
+        .append(monthValue)
+        .append(dayValue < 10 ? "-0" : "-")
+        .append(dayValue)
+        .toString();
   }
 
   @Override
@@ -130,7 +155,7 @@ public class DateParser extends Parser<Date> {
     switch (format) {
       case SPANNER:
       case POSTGRESQL_TEXT:
-        return resultSet.getDate(position).toString().getBytes(StandardCharsets.UTF_8);
+        return toString(resultSet.getDate(position)).getBytes(StandardCharsets.UTF_8);
       case POSTGRESQL_BINARY:
         return convertToPG(resultSet.getDate(position));
       default:

--- a/src/main/java/com/google/cloud/spanner/pgadapter/session/SessionState.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/session/SessionState.java
@@ -253,7 +253,9 @@ public class SessionState {
     currentSettings.put(key, newSetting);
   }
 
-  private void clearCachedValues() {}
+  private void clearCachedValues() {
+    cachedZoneId = null;
+  }
 
   /** Returns the current value of the specified setting. */
   public PGSetting get(String extension, String name) {

--- a/src/test/java/com/google/cloud/spanner/pgadapter/EmulatedPsqlMockServerTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/EmulatedPsqlMockServerTest.java
@@ -26,6 +26,8 @@ import com.google.cloud.spanner.Statement;
 import com.google.cloud.spanner.pgadapter.error.PGException;
 import com.google.cloud.spanner.pgadapter.statements.IntermediateStatement;
 import com.google.common.collect.ImmutableList;
+import com.google.protobuf.ListValue;
+import com.google.protobuf.Value;
 import com.google.rpc.ResourceInfo;
 import com.google.spanner.admin.database.v1.Database;
 import com.google.spanner.admin.database.v1.DatabaseDialect;
@@ -37,6 +39,7 @@ import com.google.spanner.v1.DatabaseName;
 import com.google.spanner.v1.ExecuteBatchDmlRequest;
 import com.google.spanner.v1.ExecuteSqlRequest;
 import com.google.spanner.v1.SessionName;
+import com.google.spanner.v1.TypeCode;
 import io.grpc.Metadata;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
@@ -304,6 +307,51 @@ public class EmulatedPsqlMockServerTest extends AbstractMockServerTest {
       assertEquals(
           "ERROR: prepared statement my_prepared_statement does not exist",
           sqlException.getMessage());
+    }
+  }
+
+  @Test
+  public void testTimezone() throws SQLException {
+    String sql = "select ts from foo";
+    mockSpanner.putStatementResult(
+        StatementResult.query(
+            Statement.of(sql),
+            com.google.spanner.v1.ResultSet.newBuilder()
+                .setMetadata(createMetadata(ImmutableList.of(TypeCode.TIMESTAMP)))
+                .addRows(
+                    ListValue.newBuilder()
+                        .addValues(
+                            Value.newBuilder()
+                                .setStringValue("2023-01-06T11:49:15.123456789Z")
+                                .build())
+                        .build())
+                .build()));
+
+    try (Connection connection = DriverManager.getConnection(createUrl("my-db"))) {
+      connection.createStatement().execute("set time zone cet");
+      try (ResultSet resultSet = connection.createStatement().executeQuery(sql)) {
+        while (resultSet.next()) {
+          assertEquals("2023-01-06 12:49:15.123456+01", resultSet.getString(1));
+        }
+      }
+      connection.createStatement().execute("set time zone ist");
+      try (ResultSet resultSet = connection.createStatement().executeQuery(sql)) {
+        while (resultSet.next()) {
+          assertEquals("2023-01-06 17:19:15.123456+05:30", resultSet.getString(1));
+        }
+      }
+      connection.createStatement().execute("set time zone 'America/Los_Angeles'");
+      try (ResultSet resultSet = connection.createStatement().executeQuery(sql)) {
+        while (resultSet.next()) {
+          assertEquals("2023-01-06 03:49:15.123456-08", resultSet.getString(1));
+        }
+      }
+      connection.createStatement().execute("set time zone -12");
+      try (ResultSet resultSet = connection.createStatement().executeQuery(sql)) {
+        while (resultSet.next()) {
+          assertEquals("2023-01-05 23:49:15.123456-12", resultSet.getString(1));
+        }
+      }
     }
   }
 

--- a/src/test/java/com/google/cloud/spanner/pgadapter/JdbcMockServerTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/JdbcMockServerTest.java
@@ -42,6 +42,7 @@ import com.google.cloud.spanner.pgadapter.wireprotocol.ControlMessage.PreparedTy
 import com.google.cloud.spanner.pgadapter.wireprotocol.DescribeMessage;
 import com.google.cloud.spanner.pgadapter.wireprotocol.ExecuteMessage;
 import com.google.cloud.spanner.pgadapter.wireprotocol.ParseMessage;
+import com.google.common.base.Stopwatch;
 import com.google.common.collect.ImmutableList;
 import com.google.protobuf.ListValue;
 import com.google.protobuf.Value;
@@ -77,9 +78,11 @@ import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.temporal.ChronoUnit;
 import java.util.*;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -3366,6 +3369,29 @@ public class JdbcMockServerTest extends AbstractMockServerTest {
             .count());
     assertEquals(1, mockSpanner.countRequestsOfType(ExecuteSqlRequest.class));
     assertEquals(0, mockSpanner.countRequestsOfType(CommitRequest.class));
+  }
+
+  @Ignore("Only used for manual performance testing")
+  @Test
+  public void testBasePerformance() throws SQLException {
+    final int numRuns = 1000;
+    String sql = "select * from random_benchmark";
+    RandomResultSetGenerator generator = new RandomResultSetGenerator(10, Dialect.POSTGRESQL);
+    for (int run = 0; run < numRuns; run++) {
+      mockSpanner.putStatementResult(
+          StatementResult.query(Statement.of(sql + run), generator.generate()));
+    }
+    try (Connection connection = DriverManager.getConnection(createUrl())) {
+      Stopwatch watch = Stopwatch.createStarted();
+      for (int run = 0; run < numRuns; run++) {
+        try (ResultSet resultSet = connection.createStatement().executeQuery(sql + run)) {
+          while (resultSet.next()) {
+            // ignore
+          }
+        }
+      }
+      System.out.printf("Elapsed: %dms\n", watch.elapsed(TimeUnit.MILLISECONDS));
+    }
   }
 
   private void verifySettingIsNull(Connection connection, String setting) throws SQLException {

--- a/src/test/java/com/google/cloud/spanner/pgadapter/parsers/DateParserTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/parsers/DateParserTest.java
@@ -49,4 +49,13 @@ public class DateParserTest {
         PGException.class,
         () -> new DateParser("2022".getBytes(StandardCharsets.UTF_8), FormatCode.TEXT));
   }
+
+  @Test
+  public void testToString() {
+    assertEquals("2023-01-06", DateParser.toString(Date.fromYearMonthDay(2023, 1, 6)));
+    assertEquals("0900-01-06", DateParser.toString(Date.fromYearMonthDay(900, 1, 6)));
+    assertEquals("0016-02-28", DateParser.toString(Date.fromYearMonthDay(16, 2, 28)));
+    assertEquals("0001-01-01", DateParser.toString(Date.fromYearMonthDay(1, 1, 1)));
+    assertEquals("+10000-01-01", DateParser.toString(Date.fromYearMonthDay(10000, 1, 1)));
+  }
 }


### PR DESCRIPTION
Reduces the time needed to convert data of type timestamptz, date and bytea from Cloud Spanner wire-format to PostgreSQL (text) wire format.