### PR TITLE
test: skip the 'Factory' timezone in tests

### DIFF
--- a/src/test/java/com/google/cloud/spanner/pgadapter/ITPsqlTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/ITPsqlTest.java
@@ -536,7 +536,7 @@ public class ITPsqlTest implements IntegrationTest {
             pgConnection
                 .createStatement()
                 .executeQuery(
-                    "select count(*) from pg_timezone_names where not name like '%posix%'")) {
+                    "select count(*) from pg_timezone_names where not name like '%posix%' and not name like 'Factory'")) {
           assertTrue(resultSet.next());
           numTimezones = resultSet.getInt(1);
         }
@@ -547,7 +547,7 @@ public class ITPsqlTest implements IntegrationTest {
                   .createStatement()
                   .executeQuery(
                       String.format(
-                          "select name from pg_timezone_names where not name like '%%posix%%' offset %d limit 1",
+                          "select name from pg_timezone_names where not name like '%%posix%%' and not name like 'Factory' offset %d limit 1",
                           random.nextInt(numTimezones)))) {
             assertTrue(resultSet.next());
             timezone = resultSet.getString(1);


### PR DESCRIPTION
Ignore the 'Factory' timezone as it is not a recognized timezone in Java.

Fixes #583