### PR TITLE
fix: support end-of-data record in COPY

### DIFF
--- a/src/main/java/com/google/cloud/spanner/pgadapter/utils/BinaryCopyParser.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/utils/BinaryCopyParser.java
@@ -231,6 +231,11 @@ class BinaryCopyParser implements CopyInParser {
     }
 
     @Override
+    public boolean isEndRecord() {
+      return false;
+    }
+
+    @Override
     public boolean hasColumnNames() {
       return false;
     }

--- a/src/main/java/com/google/cloud/spanner/pgadapter/utils/CopyRecord.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/utils/CopyRecord.java
@@ -28,6 +28,9 @@ public interface CopyRecord {
   /** Returns the number of columns in the record. */
   int numColumns();
 
+  /** Returns true if this record is the PG end record (\.). */
+  boolean isEndRecord();
+
   /**
    * Returns true if the copy record has column names. The {@link #getValue(Type, String)} method
    * can only be used for records that have column names.

--- a/src/main/java/com/google/cloud/spanner/pgadapter/utils/CsvCopyParser.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/utils/CsvCopyParser.java
@@ -33,6 +33,7 @@ import java.io.Reader;
 import java.nio.charset.StandardCharsets;
 import java.time.format.DateTimeParseException;
 import java.util.Iterator;
+import java.util.Objects;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.apache.commons.codec.binary.Hex;
@@ -95,6 +96,15 @@ class CsvCopyParser implements CopyInParser {
     @Override
     public int numColumns() {
       return record.size();
+    }
+
+    @Override
+    public boolean isEndRecord() {
+      // End of data can be represented by a single line containing just backslash-period (\.). An
+      // end-of-data marker is not necessary when reading from a file, since the end of file serves
+      // perfectly well; it is needed only when copying data to or from client applications using
+      // pre-3.0 client protocol.
+      return record.size() == 1 && Objects.equals("\\.", record.get(0));
     }
 
     @Override

--- a/src/main/java/com/google/cloud/spanner/pgadapter/utils/MutationWriter.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/utils/MutationWriter.java
@@ -236,6 +236,9 @@ public class MutationWriter implements Callable<StatementResult>, Closeable {
       // returned.
       while (!rollback.get() && iterator.hasNext()) {
         CopyRecord record = iterator.next();
+        if (record.isEndRecord()) {
+          break;
+        }
         if (record.numColumns() != this.tableColumns.keySet().size()) {
           throw PGExceptionFactory.newPGException(
               "Invalid COPY data: Row length mismatched. Expected "

--- a/src/test/java/com/google/cloud/spanner/pgadapter/CopyInMockServerTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/CopyInMockServerTest.java
@@ -149,6 +149,27 @@ public class CopyInMockServerTest extends AbstractMockServerTest {
   }
 
   @Test
+  public void testEndRecord() throws SQLException, IOException {
+    setupCopyInformationSchemaResults();
+
+    try (Connection connection = DriverManager.getConnection(createUrl())) {
+      CopyManager copyManager = new CopyManager(connection.unwrap(BaseConnection.class));
+      copyManager.copyIn("COPY users FROM STDIN;", new StringReader("5\t5\t5\n\\.\n7\t7\t7\n"));
+    }
+
+    List<CommitRequest> commitRequests = mockSpanner.getRequestsOfType(CommitRequest.class);
+    assertEquals(1, commitRequests.size());
+    CommitRequest commitRequest = commitRequests.get(0);
+    assertEquals(1, commitRequest.getMutationsCount());
+
+    Mutation mutation = commitRequest.getMutations(0);
+    assertEquals(OperationCase.INSERT, mutation.getOperationCase());
+    // We should only receive 1 row, as there is an end record in the middle of the stream.
+    assertEquals(1, mutation.getInsert().getValuesCount());
+    assertEquals(3, mutation.getInsert().getColumnsCount());
+  }
+
+  @Test
   public void testCopyUpsert() throws SQLException, IOException {
     setupCopyInformationSchemaResults();
 

--- a/src/test/java/com/google/cloud/spanner/pgadapter/utils/CsvCopyParserTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/utils/CsvCopyParserTest.java
@@ -43,7 +43,6 @@ public class CsvCopyParserTest {
 
   @Test
   public void testCanCreateIterator() throws IOException {
-
     CsvCopyParser parser =
         new CsvCopyParser(
             mock(SessionState.class),


### PR DESCRIPTION
Adds support for the end-of-data record in the COPY protocol. This record is normally not used anymore, but some older client might send it (like `pgbench`).