### PR TITLE
feat: allow unsupported OIDs as param types

### DIFF
--- a/src/main/java/com/google/cloud/spanner/pgadapter/parsers/Parser.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/parsers/Parser.java
@@ -97,9 +97,12 @@ public abstract class Parser<T> {
       case Oid.JSONB:
         return new JsonbParser(item, formatCode);
       case Oid.UNSPECIFIED:
-        return new UnspecifiedParser(item, formatCode);
       default:
-        throw new IllegalArgumentException("Unsupported parameter type: " + oidType);
+        // Use the UnspecifiedParser for unknown types. This will encode the parameter value as a
+        // string and send it to Spanner without any type information. This will ensure that clients
+        // that for example send char instead of varchar as the type code for a parameter would
+        // still work.
+        return new UnspecifiedParser(item, formatCode);
     }
   }
 

--- a/src/test/java/com/google/cloud/spanner/pgadapter/statements/StatementTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/statements/StatementTest.java
@@ -39,6 +39,7 @@ import com.google.cloud.spanner.ResultSet;
 import com.google.cloud.spanner.SpannerException;
 import com.google.cloud.spanner.SpannerExceptionFactory;
 import com.google.cloud.spanner.Statement;
+import com.google.cloud.spanner.Value;
 import com.google.cloud.spanner.connection.AbstractStatementParser;
 import com.google.cloud.spanner.connection.AbstractStatementParser.ParsedStatement;
 import com.google.cloud.spanner.connection.AbstractStatementParser.StatementType;
@@ -371,8 +372,10 @@ public class StatementTest {
 
     IntermediatePortalStatement portalStatement =
         intermediateStatement.createPortal("", parameters, new ArrayList<>(), new ArrayList<>());
-    assertThrows(
-        IllegalArgumentException.class, () -> portalStatement.bind(Statement.of(sqlStatement)));
+    Statement boundStatement = portalStatement.bind(Statement.of(sqlStatement));
+    assertEquals(
+        Value.untyped(com.google.protobuf.Value.newBuilder().setStringValue("{}").build()),
+        boundStatement.getParameters().get("p1"));
   }
 
   @Test


### PR DESCRIPTION
PGAdapter would refuse any parameter value that used an OID that was not currently known to PGAdapter. This meant that if an application used for example Oid.CHAR as the parameter type, PGAdapter would refuse it. This change allows those parameters and automatically encodes these as untyped parameter values using a string value when sending them to Cloud Spanner. This is not guaranteed to work for all types, but it will work for any type in Cloud Spanner that uses string encoding (meaning most of them).