### PR TITLE
fix: binary copy header should be included in first data message

### DIFF
--- a/src/main/java/com/google/cloud/spanner/pgadapter/metadata/OptionsMetadata.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/metadata/OptionsMetadata.java
@@ -674,8 +674,10 @@ public class OptionsMetadata {
         OPTION_DEBUG_MODE,
         "debug-mode",
         false,
-        "-- ONLY USE FOR DEBUGGING -- This option only intended for debugging. It will "
-            + "instruct the server to keep track of all messages it receives.");
+        "-- ONLY USE FOR INTERNAL DEBUGGING -- This option only intended for INTERNAL debugging. It will "
+            + "instruct the server to keep track of all messages it receives.\n"
+            + "You should not enable this option unless you want to debug PGAdapter.\n"
+            + "This option will NOT enable any additional LOGGING.");
 
     CommandLineParser parser = new DefaultParser();
     HelpFormatter help = new HelpFormatter();

--- a/src/main/java/com/google/cloud/spanner/pgadapter/metadata/OptionsMetadata.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/metadata/OptionsMetadata.java
@@ -674,10 +674,8 @@ public class OptionsMetadata {
         OPTION_DEBUG_MODE,
         "debug-mode",
         false,
-        "-- ONLY USE FOR INTERNAL DEBUGGING -- This option only intended for INTERNAL debugging. It will "
-            + "instruct the server to keep track of all messages it receives.\n"
-            + "You should not enable this option unless you want to debug PGAdapter.\n"
-            + "This option will NOT enable any additional LOGGING.");
+        "-- ONLY USE FOR DEBUGGING -- This option only intended for debugging. It will "
+            + "instruct the server to keep track of all messages it receives.");
 
     CommandLineParser parser = new DefaultParser();
     HelpFormatter help = new HelpFormatter();

--- a/src/main/java/com/google/cloud/spanner/pgadapter/statements/CopyStatement.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/statements/CopyStatement.java
@@ -24,6 +24,7 @@ import com.google.cloud.spanner.connection.AbstractStatementParser.ParsedStateme
 import com.google.cloud.spanner.connection.AbstractStatementParser.StatementType;
 import com.google.cloud.spanner.connection.AutocommitDmlMode;
 import com.google.cloud.spanner.pgadapter.ConnectionHandler;
+import com.google.cloud.spanner.pgadapter.ProxyServer.DataFormat;
 import com.google.cloud.spanner.pgadapter.error.PGException;
 import com.google.cloud.spanner.pgadapter.error.PGExceptionFactory;
 import com.google.cloud.spanner.pgadapter.error.SQLState;
@@ -80,7 +81,17 @@ public class CopyStatement extends IntermediatePortalStatement {
   public enum Format {
     CSV,
     TEXT,
-    BINARY,
+    BINARY {
+      @Override
+      public DataFormat getDataFormat() {
+        return DataFormat.POSTGRESQL_BINARY;
+      }
+    };
+
+    /** Returns the (default) data format that should be used for this copy format. */
+    public DataFormat getDataFormat() {
+      return DataFormat.POSTGRESQL_TEXT;
+    }
   }
 
   private static final String COLUMN_NAME = "column_name";

--- a/src/main/java/com/google/cloud/spanner/pgadapter/statements/CopyToStatement.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/statements/CopyToStatement.java
@@ -23,7 +23,6 @@ import com.google.cloud.spanner.connection.AbstractStatementParser.StatementType
 import com.google.cloud.spanner.connection.Connection;
 import com.google.cloud.spanner.connection.StatementResult;
 import com.google.cloud.spanner.pgadapter.ConnectionHandler;
-import com.google.cloud.spanner.pgadapter.ProxyServer.DataFormat;
 import com.google.cloud.spanner.pgadapter.error.PGExceptionFactory;
 import com.google.cloud.spanner.pgadapter.error.SQLState;
 import com.google.cloud.spanner.pgadapter.metadata.OptionsMetadata;
@@ -58,6 +57,7 @@ public class CopyToStatement extends IntermediatePortalStatement {
 
   private final ParsedCopyStatement parsedCopyStatement;
   private final CSVFormat csvFormat;
+  private boolean hasReturnedData;
 
   public CopyToStatement(
       ConnectionHandler connectionHandler,
@@ -220,22 +220,23 @@ public class CopyToStatement extends IntermediatePortalStatement {
 
   @Override
   public WireOutput[] createResultPrefix(ResultSet resultSet) {
-    return this.parsedCopyStatement.format == CopyStatement.Format.BINARY
-        ? new WireOutput[] {
-          new CopyOutResponse(
-              this.outputStream,
-              resultSet.getColumnCount(),
-              DataFormat.POSTGRESQL_BINARY.getCode()),
-          CopyDataResponse.createBinaryHeader(this.outputStream)
-        }
-        : new WireOutput[] {
-          new CopyOutResponse(
-              this.outputStream, resultSet.getColumnCount(), DataFormat.POSTGRESQL_TEXT.getCode())
-        };
+    return new WireOutput[] {
+      new CopyOutResponse(
+          this.outputStream,
+          resultSet.getColumnCount(),
+          this.parsedCopyStatement.format.getDataFormat().getCode())
+    };
   }
 
   @Override
   public CopyDataResponse createDataRowResponse(Converter converter) {
+    // Keep track of whether this COPY statement has returned at least one row. This is necessary to
+    // know whether we need to include the header in the current row and/or in the trailer.
+    // PostgreSQL includes the header in either the first data row or in the trailer if there are no
+    // rows. This is not specifically mentioned in the protocol description, but some clients assume
+    // this behavior. See
+    // https://github.com/npgsql/npgsql/blob/7f97dbad28c71b2202dd7bcccd05fc42a7de23c8/src/Npgsql/NpgsqlBinaryExporter.cs#L156
+    this.hasReturnedData = true;
     return parsedCopyStatement.format == CopyStatement.Format.BINARY
         ? createBinaryDataResponse(converter)
         : createDataResponse(converter.getResultSet());
@@ -245,7 +246,7 @@ public class CopyToStatement extends IntermediatePortalStatement {
   public WireOutput[] createResultSuffix() {
     return this.parsedCopyStatement.format == Format.BINARY
         ? new WireOutput[] {
-          CopyDataResponse.createBinaryTrailer(this.outputStream),
+          CopyDataResponse.createBinaryTrailer(this.outputStream, !hasReturnedData),
           new CopyDoneResponse(this.outputStream)
         }
         : new WireOutput[] {new CopyDoneResponse(this.outputStream)};

--- a/src/main/java/com/google/cloud/spanner/pgadapter/utils/BinaryCopyParser.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/utils/BinaryCopyParser.java
@@ -236,6 +236,14 @@ class BinaryCopyParser implements CopyInParser {
     }
 
     @Override
+    public boolean isNull(int columnIndex) {
+      Preconditions.checkArgument(
+          columnIndex >= 0 && columnIndex < numColumns(),
+          "columnIndex must be >= 0 && < numColumns");
+      return fields[columnIndex].data == null;
+    }
+
+    @Override
     public Value getValue(Type type, String columnName) {
       // The binary copy format does not include any column name headers or any type information.
       throw new UnsupportedOperationException();

--- a/src/main/java/com/google/cloud/spanner/pgadapter/utils/Converter.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/utils/Converter.java
@@ -16,6 +16,7 @@ package com.google.cloud.spanner.pgadapter.utils;
 
 import static com.google.cloud.spanner.pgadapter.statements.CopyToStatement.COPY_BINARY_HEADER;
 
+import com.google.api.core.InternalApi;
 import com.google.cloud.spanner.ResultSet;
 import com.google.cloud.spanner.Type;
 import com.google.cloud.spanner.pgadapter.ConnectionHandler.QueryMode;
@@ -40,6 +41,7 @@ import java.io.DataOutputStream;
 import java.io.IOException;
 
 /** Utility class for converting between generic PostgreSQL conversions. */
+@InternalApi
 public class Converter implements AutoCloseable {
   private final ByteArrayOutputStream buffer = new ByteArrayOutputStream(256);
   private final DataOutputStream outputStream = new DataOutputStream(buffer);
@@ -48,23 +50,15 @@ public class Converter implements AutoCloseable {
   private final OptionsMetadata options;
   private final ResultSet resultSet;
   private final SessionState sessionState;
-  private final boolean includeHeaderInFirstRow;
+  private final boolean includeBinaryCopyHeaderInFirstRow;
   private boolean firstRow = true;
 
   public Converter(
       IntermediateStatement statement,
       QueryMode mode,
       OptionsMetadata options,
-      ResultSet resultSet) {
-    this(statement, mode, options, resultSet, true);
-  }
-
-  public Converter(
-      IntermediateStatement statement,
-      QueryMode mode,
-      OptionsMetadata options,
       ResultSet resultSet,
-      boolean includeHeaderInFirstRow) {
+      boolean includeBinaryCopyHeaderInFirstRow) {
     this.statement = statement;
     this.mode = mode;
     this.options = options;
@@ -75,7 +69,7 @@ public class Converter implements AutoCloseable {
             .getExtendedQueryProtocolHandler()
             .getBackendConnection()
             .getSessionState();
-    this.includeHeaderInFirstRow = includeHeaderInFirstRow;
+    this.includeBinaryCopyHeaderInFirstRow = includeBinaryCopyHeaderInFirstRow;
   }
 
   @Override
@@ -97,10 +91,7 @@ public class Converter implements AutoCloseable {
               : DataFormat.POSTGRESQL_TEXT;
     }
     buffer.reset();
-    if (includeHeaderInFirstRow
-        && firstRow
-        && statement instanceof CopyToStatement
-        && ((CopyToStatement) statement).isBinary()) {
+    if (includeBinaryCopyHeaderInFirstRow && firstRow) {
       outputStream.write(COPY_BINARY_HEADER);
       outputStream.writeInt(0); // flags
       outputStream.writeInt(0); // header extension area length

--- a/src/main/java/com/google/cloud/spanner/pgadapter/utils/CopyRecord.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/utils/CopyRecord.java
@@ -34,6 +34,9 @@ public interface CopyRecord {
    */
   boolean hasColumnNames();
 
+  /** Returns true if the value of the given column is null. */
+  boolean isNull(int columnIndex);
+
   /**
    * Returns the value of the given column as a Cloud Spanner {@link Value} of the given type. This
    * method is used by a COPY ... FROM ... operation to convert a value to the type of the column

--- a/src/main/java/com/google/cloud/spanner/pgadapter/utils/CsvCopyParser.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/utils/CsvCopyParser.java
@@ -103,6 +103,11 @@ class CsvCopyParser implements CopyInParser {
     }
 
     @Override
+    public boolean isNull(int columnIndex) {
+      return record.get(columnIndex) == null;
+    }
+
+    @Override
     public Value getValue(Type type, String columnName) throws SpannerException {
       String recordValue = record.get(columnName);
       return getSpannerValue(sessionState, type, recordValue);

--- a/src/main/java/com/google/cloud/spanner/pgadapter/wireprotocol/ControlMessage.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/wireprotocol/ControlMessage.java
@@ -38,6 +38,7 @@ import com.google.cloud.spanner.pgadapter.error.SQLState;
 import com.google.cloud.spanner.pgadapter.error.Severity;
 import com.google.cloud.spanner.pgadapter.metadata.SendResultSetState;
 import com.google.cloud.spanner.pgadapter.statements.BackendConnection.PartitionQueryResult;
+import com.google.cloud.spanner.pgadapter.statements.CopyToStatement;
 import com.google.cloud.spanner.pgadapter.statements.IntermediateStatement;
 import com.google.cloud.spanner.pgadapter.utils.Converter;
 import com.google.cloud.spanner.pgadapter.wireoutput.CommandCompleteResponse;
@@ -444,7 +445,10 @@ public abstract class ControlMessage extends WireMessage {
               describedResult,
               mode,
               describedResult.getConnectionHandler().getServer().getOptions(),
-              resultSet);
+              resultSet,
+              includePrefix
+                  && describedResult instanceof CopyToStatement
+                  && ((CopyToStatement) describedResult).isBinary());
       this.batchReadOnlyTransaction = null;
       this.partition = null;
       this.maxRows = maxRows;

--- a/src/test/java/com/google/cloud/spanner/pgadapter/CopyOutMockServerTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/CopyOutMockServerTest.java
@@ -488,6 +488,47 @@ public class CopyOutMockServerTest extends AbstractMockServerTest {
   }
 
   @Test
+  public void testCopyOutBinaryEmptyPsql() throws Exception {
+    assumeTrue("This test requires psql", isPsqlAvailable());
+    mockSpanner.putStatementResult(
+        StatementResult.query(
+            Statement.of("select * from all_types"),
+            ALL_TYPES_RESULTSET.toBuilder().clearRows().build()));
+
+    ProcessBuilder builder = new ProcessBuilder();
+    builder.command(
+        "psql",
+        "-h",
+        (useDomainSocket ? "/tmp" : "localhost"),
+        "-p",
+        String.valueOf(pgServer.getLocalPort()),
+        "-c",
+        "copy all_types to stdout binary");
+    Process process = builder.start();
+    StringBuilder errorBuilder = new StringBuilder();
+    try (Scanner scanner = new Scanner(new InputStreamReader(process.getErrorStream()))) {
+      while (scanner.hasNextLine()) {
+        errorBuilder.append(scanner.nextLine()).append('\n');
+      }
+    }
+    PipedOutputStream pipedOutputStream = new PipedOutputStream();
+    PipedInputStream inputStream = new PipedInputStream(pipedOutputStream, 1 << 16);
+    SessionState sessionState = mock(SessionState.class);
+    CopyInParser copyParser =
+        CopyInParser.create(sessionState, Format.BINARY, null, inputStream, false);
+    int b;
+    while ((b = process.getInputStream().read()) != -1) {
+      pipedOutputStream.write(b);
+    }
+    int res = process.waitFor();
+    assertEquals("", errorBuilder.toString());
+    assertEquals(0, res);
+
+    Iterator<CopyRecord> iterator = copyParser.iterator();
+    assertFalse(iterator.hasNext());
+  }
+
+  @Test
   public void testCopyOutNullsBinaryPsql() throws Exception {
     assumeTrue("This test requires psql", isPsqlAvailable());
     mockSpanner.putStatementResult(
@@ -565,6 +606,38 @@ public class CopyOutMockServerTest extends AbstractMockServerTest {
   }
 
   @Test
+  public void testCopyOutPartitionedBinary() throws SQLException, IOException {
+    final int expectedRowCount = 100;
+    RandomResultSetGenerator randomResultSetGenerator =
+        new RandomResultSetGenerator(expectedRowCount, Dialect.POSTGRESQL);
+    com.google.spanner.v1.ResultSet resultSet = randomResultSetGenerator.generate();
+    mockSpanner.putStatementResult(
+        StatementResult.query(Statement.of("select * from random"), resultSet));
+
+    try (Connection connection = DriverManager.getConnection(createUrl())) {
+      CopyManager copyManager = new CopyManager(connection.unwrap(BaseConnection.class));
+      PipedOutputStream pipedOutputStream = new PipedOutputStream();
+      PipedInputStream inputStream = new PipedInputStream(pipedOutputStream, 1 << 20);
+      SessionState sessionState = mock(SessionState.class);
+      CopyInParser copyParser =
+          CopyInParser.create(sessionState, Format.BINARY, null, inputStream, false);
+      long rows = copyManager.copyOut("COPY random TO STDOUT (format binary)", pipedOutputStream);
+
+      assertEquals(expectedRowCount, rows);
+
+      Iterator<CopyRecord> iterator = copyParser.iterator();
+      int recordCount = 0;
+      while (iterator.hasNext()) {
+        recordCount++;
+        CopyRecord record = iterator.next();
+        int index = findIndex(resultSet, record);
+        assertNotEquals(String.format("Row %d not found: %s", recordCount, record), -1, index);
+      }
+      assertEquals(expectedRowCount, recordCount);
+    }
+  }
+
+  @Test
   public void testCopyOutPartitioned_NonExistingTable() throws SQLException {
     StatusRuntimeException exception =
         Status.NOT_FOUND.withDescription("Table my_table not found").asRuntimeException();
@@ -616,6 +689,47 @@ public class CopyOutMockServerTest extends AbstractMockServerTest {
           if (resultSet.getRows(index).getValues(colIndex).hasBoolValue()
               && !cols[colIndex].equals(
                   resultSet.getRows(index).getValues(colIndex).getBoolValue() ? "t" : "f")) {
+            valuesEqual = false;
+            break;
+          }
+        }
+      }
+      if (valuesEqual) {
+        return index;
+      }
+    }
+    return -1;
+  }
+
+  static int findIndex(com.google.spanner.v1.ResultSet resultSet, CopyRecord record) {
+    for (int index = 0; index < resultSet.getRowsCount(); index++) {
+      boolean nullValuesEqual = true;
+      for (int colIndex = 0; colIndex < record.numColumns(); colIndex++) {
+        if (record.isNull(colIndex)
+            != resultSet.getRows(index).getValues(colIndex).hasNullValue()) {
+          nullValuesEqual = false;
+          break;
+        }
+      }
+      if (!nullValuesEqual) {
+        continue;
+      }
+
+      boolean valuesEqual = true;
+      for (int colIndex = 0; colIndex < record.numColumns(); colIndex++) {
+        if (!resultSet.getRows(index).getValues(colIndex).hasNullValue()) {
+          if (resultSet.getMetadata().getRowType().getFields(colIndex).getType().getCode()
+                  == TypeCode.STRING
+              && !record
+                  .getValue(Type.string(), colIndex)
+                  .getString()
+                  .equals(resultSet.getRows(index).getValues(colIndex).getStringValue())) {
+            valuesEqual = false;
+            break;
+          }
+          if (resultSet.getRows(index).getValues(colIndex).hasBoolValue()
+              && record.getValue(Type.bool(), colIndex).getBool()
+                  != resultSet.getRows(index).getValues(colIndex).getBoolValue()) {
             valuesEqual = false;
             break;
           }

--- a/src/test/java/com/google/cloud/spanner/pgadapter/PsqlMockServerTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/PsqlMockServerTest.java
@@ -14,16 +14,23 @@
 
 package com.google.cloud.spanner.pgadapter;
 
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeTrue;
 
 import com.google.cloud.spanner.MockSpannerServiceImpl;
+import com.google.cloud.spanner.MockSpannerServiceImpl.StatementResult;
+import com.google.cloud.spanner.Statement;
+import com.google.cloud.spanner.pgadapter.statements.CopyToStatement;
 import com.google.cloud.spanner.pgadapter.wireprotocol.SSLMessage;
 import com.google.common.collect.ImmutableList;
+import com.google.common.io.ByteStreams;
 import com.google.spanner.admin.database.v1.UpdateDatabaseDdlRequest;
 import java.io.BufferedReader;
+import java.io.ByteArrayOutputStream;
+import java.io.DataOutputStream;
 import java.io.File;
 import java.io.InputStreamReader;
 import java.util.List;
@@ -140,5 +147,92 @@ public class PsqlMockServerTest extends AbstractMockServerTest {
 
     assertEquals(
         1L, pgServer.getDebugMessages().stream().filter(m -> m instanceof SSLMessage).count());
+  }
+
+  @Test
+  public void testCopyToBinaryPsql() throws Exception {
+    assumeTrue("This test requires psql to be installed", isPsqlAvailable());
+
+    ProcessBuilder builder = new ProcessBuilder();
+    String[] psqlCommand =
+        new String[] {
+          "psql",
+          "-h",
+          "localhost",
+          "-p",
+          String.valueOf(pgServer.getLocalPort()),
+          "-c",
+          "COPY (SELECT 1) TO STDOUT (FORMAT BINARY)"
+        };
+    builder.command(psqlCommand);
+    Process process = builder.start();
+    String errors;
+
+    try (BufferedReader errorReader =
+        new BufferedReader(new InputStreamReader(process.getErrorStream()))) {
+      errors = errorReader.lines().collect(Collectors.joining("\n"));
+    }
+    byte[] copyOutput = ByteStreams.toByteArray(process.getInputStream());
+
+    assertEquals("", errors);
+    int res = process.waitFor();
+    assertEquals(0, res);
+
+    ByteArrayOutputStream byteArrayOutputStream =
+        new ByteArrayOutputStream(CopyToStatement.COPY_BINARY_HEADER.length);
+    DataOutputStream expectedOutputStream = new DataOutputStream(byteArrayOutputStream);
+    expectedOutputStream.write(CopyToStatement.COPY_BINARY_HEADER);
+    expectedOutputStream.writeInt(0); // flags
+    expectedOutputStream.writeInt(0); // header extension area length
+    expectedOutputStream.writeShort(1); // Column count
+    expectedOutputStream.writeInt(8); // Value length
+    expectedOutputStream.writeLong(1L); // Column value
+    expectedOutputStream.writeShort(-1); // Column count == -1 means end of data.
+
+    assertArrayEquals(byteArrayOutputStream.toByteArray(), copyOutput);
+  }
+
+  @Test
+  public void testCopyToBinaryPsqlEmptyTable() throws Exception {
+    assumeTrue("This test requires psql to be installed", isPsqlAvailable());
+    mockSpanner.putStatementResult(
+        StatementResult.query(
+            Statement.of("select * from all_types"),
+            ALL_TYPES_RESULTSET.toBuilder().clearRows().build()));
+
+    ProcessBuilder builder = new ProcessBuilder();
+    String[] psqlCommand =
+        new String[] {
+          "psql",
+          "-h",
+          "localhost",
+          "-p",
+          String.valueOf(pgServer.getLocalPort()),
+          "-c",
+          "COPY all_types TO STDOUT (FORMAT BINARY)"
+        };
+    builder.command(psqlCommand);
+    Process process = builder.start();
+    String errors;
+
+    try (BufferedReader errorReader =
+        new BufferedReader(new InputStreamReader(process.getErrorStream()))) {
+      errors = errorReader.lines().collect(Collectors.joining("\n"));
+    }
+    byte[] copyOutput = ByteStreams.toByteArray(process.getInputStream());
+
+    assertEquals("", errors);
+    int res = process.waitFor();
+    assertEquals(0, res);
+
+    ByteArrayOutputStream byteArrayOutputStream =
+        new ByteArrayOutputStream(CopyToStatement.COPY_BINARY_HEADER.length);
+    DataOutputStream expectedOutputStream = new DataOutputStream(byteArrayOutputStream);
+    expectedOutputStream.write(CopyToStatement.COPY_BINARY_HEADER);
+    expectedOutputStream.writeInt(0); // flags
+    expectedOutputStream.writeInt(0); // header extension area length
+    expectedOutputStream.writeShort(-1); // Column count == -1 means end of data.
+
+    assertArrayEquals(byteArrayOutputStream.toByteArray(), copyOutput);
   }
 }


### PR DESCRIPTION
The PostgreSQL wire protocol requires that the binary copy header is sent before any data. It does however not specify whether it should be in a separate CopyData message, or whether it should be included in the first actual CopyData message. PGAdapter used to send the header in a separate message. This is accepted by most clients. PostgreSQL sends the header as part of the first data message, and some clients (npgsql) assume that this will always be the case.

This fix therefore changes the behavior of PGAdapter so it will always include the header with the first actual CopyData message, instead of sending it in a separate message. This also means that if the copy operation does not actually copy any data at all, the header will be included in the trailer message. This is also consistent with real PostgreSQL.