### PR TITLE
fix: empty partitions could skip binary copy header

### DIFF
--- a/src/main/java/com/google/cloud/spanner/pgadapter/statements/BackendConnection.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/statements/BackendConnection.java
@@ -372,7 +372,7 @@ public class BackendConnection {
     }
   }
 
-  private static final int MAX_PARTITIONS =
+  public static final int MAX_PARTITIONS =
       Math.max(16, 2 * Runtime.getRuntime().availableProcessors());
 
   private final class CopyOut extends BufferedStatement<StatementResult> {
@@ -401,9 +401,14 @@ public class BackendConnection {
               // No need for the extra complexity of a partitioned query.
               result.set(spannerConnection.execute(statement));
             } else {
+              // Get the metadata of the query, so we can include that in the result.
+              ResultSet metadataResultSet =
+                  spannerConnection.analyzeQuery(statement, QueryAnalyzeMode.PLAN);
               result.set(
                   new PartitionQueryResult(
-                      batchReadOnlyTransaction.getBatchTransactionId(), partitions));
+                      batchReadOnlyTransaction.getBatchTransactionId(),
+                      partitions,
+                      metadataResultSet));
             }
           } catch (SpannerException spannerException) {
             // The query might not be suitable for partitioning. Just try with a normal query.
@@ -1262,10 +1267,15 @@ public class BackendConnection {
   public static final class PartitionQueryResult implements StatementResult {
     private final BatchTransactionId batchTransactionId;
     private final List<Partition> partitions;
+    private final ResultSet metadataResultSet;
 
-    public PartitionQueryResult(BatchTransactionId batchTransactionId, List<Partition> partitions) {
+    public PartitionQueryResult(
+        BatchTransactionId batchTransactionId,
+        List<Partition> partitions,
+        ResultSet metadataResultSet) {
       this.batchTransactionId = batchTransactionId;
       this.partitions = partitions;
+      this.metadataResultSet = metadataResultSet;
     }
 
     public BatchTransactionId getBatchTransactionId() {
@@ -1274,6 +1284,10 @@ public class BackendConnection {
 
     public List<Partition> getPartitions() {
       return partitions;
+    }
+
+    public ResultSet getMetadataResultSet() {
+      return metadataResultSet;
     }
 
     @Override

--- a/src/main/java/com/google/cloud/spanner/pgadapter/utils/Converter.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/utils/Converter.java
@@ -50,7 +50,7 @@ public class Converter implements AutoCloseable {
   private final OptionsMetadata options;
   private final ResultSet resultSet;
   private final SessionState sessionState;
-  private final boolean includeBinaryCopyHeaderInFirstRow;
+  private boolean includeBinaryCopyHeaderInFirstRow;
   private boolean firstRow = true;
 
   public Converter(
@@ -70,6 +70,15 @@ public class Converter implements AutoCloseable {
             .getBackendConnection()
             .getSessionState();
     this.includeBinaryCopyHeaderInFirstRow = includeBinaryCopyHeaderInFirstRow;
+  }
+
+  public Converter includeBinaryCopyHeader() {
+    this.includeBinaryCopyHeaderInFirstRow = true;
+    return this;
+  }
+
+  public boolean isIncludeBinaryCopyHeaderInFirstRow() {
+    return this.includeBinaryCopyHeaderInFirstRow;
   }
 
   @Override


### PR DESCRIPTION
Binary COPY TO STDOUT statements could fail if it used a partitioned query that contained one or more empty partitions. The binary copy header would be included for the first partition, but if that partition happened to return 0 rows, the copy statement would never send a binary copy header. This again would cause all other partitions never to be processed and sent, because they would wait for the first partition to send the header before starting to send data.

This is now fixed by:
1. Include the binary header with the first partition that actually sends data.
2. Include the binary header with the trailer if no partition sent any data.