### PR TITLE
fix: empty copy from stdin statements could be unresponsive

### DIFF
--- a/src/main/java/com/google/cloud/spanner/pgadapter/utils/MutationWriter.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/utils/MutationWriter.java
@@ -66,6 +66,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.LinkedBlockingDeque;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.annotation.Nonnull;
@@ -109,6 +110,8 @@ public class MutationWriter implements Callable<StatementResult>, Closeable {
   private final CSVFormat csvFormat;
   private final boolean hasHeader;
   private final CountDownLatch pipeCreatedLatch = new CountDownLatch(1);
+  private final CountDownLatch dataReceivedLatch = new CountDownLatch(1);
+  private final AtomicLong bytesReceived = new AtomicLong();
   private final PipedOutputStream payload = new PipedOutputStream();
   private final AtomicBoolean commit = new AtomicBoolean(false);
   private final AtomicBoolean rollback = new AtomicBoolean(false);
@@ -164,6 +167,8 @@ public class MutationWriter implements Callable<StatementResult>, Closeable {
     }
     try {
       pipeCreatedLatch.await();
+      bytesReceived.addAndGet(payload.length);
+      dataReceivedLatch.countDown();
       this.payload.write(payload);
     } catch (InterruptedException | InterruptedIOException interruptedIOException) {
       // The IO operation was interrupted. This indicates that the user wants to cancel the COPY
@@ -204,6 +209,7 @@ public class MutationWriter implements Callable<StatementResult>, Closeable {
   public void close() throws IOException {
     this.payload.close();
     this.closedLatch.countDown();
+    this.dataReceivedLatch.countDown();
   }
 
   @Override
@@ -228,13 +234,17 @@ public class MutationWriter implements Callable<StatementResult>, Closeable {
     // before finishing, to ensure that all data has been written before we signal that we are done.
     List<ApiFuture<Void>> allCommitFutures = new ArrayList<>();
     try {
+      // Wait until we know whether we actually will receive any data. It could be that it is an
+      // empty copy operation, and we should then end early.
+      dataReceivedLatch.await();
+
       Iterator<CopyRecord> iterator = parser.iterator();
       List<Mutation> mutations = new ArrayList<>();
       long currentBufferByteSize = 0L;
       // Note: iterator.hasNext() blocks if there is not enough data in the pipeline to construct a
       // complete record. It returns false if the stream has been closed and all records have been
       // returned.
-      while (!rollback.get() && iterator.hasNext()) {
+      while (bytesReceived.get() > 0L && !rollback.get() && iterator.hasNext()) {
         CopyRecord record = iterator.next();
         if (record.numColumns() != this.tableColumns.keySet().size()) {
           throw PGExceptionFactory.newPGException(

--- a/src/test/java/com/google/cloud/spanner/pgadapter/CopyInMockServerTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/CopyInMockServerTest.java
@@ -50,6 +50,7 @@ import com.google.spanner.v1.Type;
 import com.google.spanner.v1.TypeCode;
 import io.grpc.Status;
 import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
@@ -383,6 +384,19 @@ public class CopyInMockServerTest extends AbstractMockServerTest {
               "copy all_types from stdin;",
               new FileInputStream("./src/test/resources/all_types_data_small.txt"));
       assertEquals(100L, copyCount);
+    }
+  }
+
+  @Test
+  public void testCopyIn_Empty() throws SQLException, IOException {
+    setupCopyInformationSchemaResults();
+
+    try (Connection connection = DriverManager.getConnection(createUrl())) {
+      PGConnection pgConnection = connection.unwrap(PGConnection.class);
+      CopyManager copyManager = pgConnection.getCopyAPI();
+      long copyCount =
+          copyManager.copyIn("copy all_types from stdin;", new ByteArrayInputStream(new byte[0]));
+      assertEquals(0L, copyCount);
     }
   }
 


### PR DESCRIPTION
`COPY my_table FROM STDIN` statements could hang forever. This would happen if the `CopyDone` message would not be received and handled quickly enough, and PGAdapter would already have proceeded to try to decode the incoming data stream. This fix ensures that PGAdapter will wait with starting to try to decode the incoming data stream until it actually knows that it will receive some data, or until a CopyDone message has been received (in the latter case the COPY operation will automatically stop).