### PR TITLE
fix: show statements failed in pgx

### DIFF
--- a/src/main/java/com/google/cloud/spanner/pgadapter/ConnectionHandler.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/ConnectionHandler.java
@@ -754,19 +754,25 @@ public class ConnectionHandler extends Thread {
   }
 
   private void maybeSetApplicationName() {
-    if (this.wellKnownClient != WellKnownClient.UNSPECIFIED
-        && getExtendedQueryProtocolHandler() != null
-        && Strings.isNullOrEmpty(
-            getExtendedQueryProtocolHandler()
-                .getBackendConnection()
-                .getSessionState()
-                .get(null, "application_name")
-                .getSetting())) {
-      getExtendedQueryProtocolHandler()
-          .getBackendConnection()
-          .getSessionState()
-          .set(null, "application_name", wellKnownClient.name().toLowerCase(Locale.ENGLISH));
-      getExtendedQueryProtocolHandler().getBackendConnection().getSessionState().commit();
+    try {
+      if (this.wellKnownClient != WellKnownClient.UNSPECIFIED
+          && getExtendedQueryProtocolHandler() != null
+          && Strings.isNullOrEmpty(
+              getExtendedQueryProtocolHandler()
+                  .getBackendConnection()
+                  .getSessionState()
+                  .get(null, "application_name")
+                  .getSetting())) {
+        getExtendedQueryProtocolHandler()
+            .getBackendConnection()
+            .getSessionState()
+            .set(null, "application_name", wellKnownClient.name().toLowerCase(Locale.ENGLISH));
+        getExtendedQueryProtocolHandler().getBackendConnection().getSessionState().commit();
+      }
+    } catch (Throwable ignore) {
+      // Safeguard against a theoretical situation that 'application_name' has been removed from
+      // the list of settings. Just ignore this situation, as the only consequence is that the
+      // 'application_name' setting has not been set.
     }
   }
 

--- a/src/main/java/com/google/cloud/spanner/pgadapter/ConnectionHandler.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/ConnectionHandler.java
@@ -52,9 +52,11 @@ import com.google.cloud.spanner.pgadapter.wireoutput.ErrorResponse;
 import com.google.cloud.spanner.pgadapter.wireoutput.ReadyResponse;
 import com.google.cloud.spanner.pgadapter.wireoutput.TerminateResponse;
 import com.google.cloud.spanner.pgadapter.wireprotocol.BootstrapMessage;
+import com.google.cloud.spanner.pgadapter.wireprotocol.ParseMessage;
 import com.google.cloud.spanner.pgadapter.wireprotocol.SSLMessage;
 import com.google.cloud.spanner.pgadapter.wireprotocol.WireMessage;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Strings;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.collect.ImmutableList;
@@ -69,6 +71,7 @@ import java.text.MessageFormat;
 import java.time.Duration;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Properties;
@@ -704,6 +707,14 @@ public class ConnectionHandler extends Thread {
 
   public void setWellKnownClient(WellKnownClient wellKnownClient) {
     this.wellKnownClient = wellKnownClient;
+    if (this.wellKnownClient != WellKnownClient.UNSPECIFIED) {
+      logger.log(
+          Level.INFO,
+          () ->
+              String.format(
+                  "Well-known client %s detected for connection %d.",
+                  this.wellKnownClient, getConnectionId()));
+    }
   }
 
   /**
@@ -713,21 +724,50 @@ public class ConnectionHandler extends Thread {
    * executed.
    */
   public void maybeDetermineWellKnownClient(Statement statement) {
-    if (!this.hasDeterminedClientUsingQuery
-        && this.wellKnownClient == WellKnownClient.UNSPECIFIED
-        && getServer().getOptions().shouldAutoDetectClient()) {
-      this.wellKnownClient = ClientAutoDetector.detectClient(ImmutableList.of(statement));
-      if (this.wellKnownClient != WellKnownClient.UNSPECIFIED) {
-        logger.log(
-            Level.INFO,
-            () ->
-                String.format(
-                    "Well-known client %s detected for connection %d.",
-                    this.wellKnownClient, getConnectionId()));
+    if (!this.hasDeterminedClientUsingQuery) {
+      if (this.wellKnownClient == WellKnownClient.UNSPECIFIED
+          && getServer().getOptions().shouldAutoDetectClient()) {
+        setWellKnownClient(ClientAutoDetector.detectClient(ImmutableList.of(statement)));
       }
+      maybeSetApplicationName();
     }
     // Make sure that we only try to detect the client once.
     this.hasDeterminedClientUsingQuery = true;
+  }
+
+  /**
+   * This is called by the extended query protocol {@link
+   * com.google.cloud.spanner.pgadapter.wireprotocol.ParseMessage} to give the connection the
+   * opportunity to determine the client that is connected based on the data in the (first) parse
+   * messages.
+   */
+  public void maybeDetermineWellKnownClient(ParseMessage parseMessage) {
+    if (!this.hasDeterminedClientUsingQuery) {
+      if (this.wellKnownClient == WellKnownClient.UNSPECIFIED
+          && getServer().getOptions().shouldAutoDetectClient()) {
+        setWellKnownClient(ClientAutoDetector.detectClient(parseMessage));
+      }
+      maybeSetApplicationName();
+    }
+    // Make sure that we only try to detect the client once.
+    this.hasDeterminedClientUsingQuery = true;
+  }
+
+  private void maybeSetApplicationName() {
+    if (this.wellKnownClient != WellKnownClient.UNSPECIFIED
+        && getExtendedQueryProtocolHandler() != null
+        && Strings.isNullOrEmpty(
+            getExtendedQueryProtocolHandler()
+                .getBackendConnection()
+                .getSessionState()
+                .get(null, "application_name")
+                .getSetting())) {
+      getExtendedQueryProtocolHandler()
+          .getBackendConnection()
+          .getSessionState()
+          .set(null, "application_name", wellKnownClient.name().toLowerCase(Locale.ENGLISH));
+      getExtendedQueryProtocolHandler().getBackendConnection().getSessionState().commit();
+    }
   }
 
   /** Status of a {@link ConnectionHandler} */

--- a/src/main/java/com/google/cloud/spanner/pgadapter/ProxyServer.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/ProxyServer.java
@@ -358,7 +358,7 @@ public class ProxyServer extends AbstractApiService {
     return String.format("ProxyServer[port: %d]", getLocalPort());
   }
 
-  ConcurrentLinkedQueue<WireMessage> getDebugMessages() {
+  public ConcurrentLinkedQueue<WireMessage> getDebugMessages() {
     return debugMessages;
   }
 

--- a/src/main/java/com/google/cloud/spanner/pgadapter/statements/BackendConnection.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/statements/BackendConnection.java
@@ -30,7 +30,6 @@ import com.google.cloud.spanner.Partition;
 import com.google.cloud.spanner.PartitionOptions;
 import com.google.cloud.spanner.ReadContext.QueryAnalyzeMode;
 import com.google.cloud.spanner.ResultSet;
-import com.google.cloud.spanner.ResultSets;
 import com.google.cloud.spanner.Spanner;
 import com.google.cloud.spanner.SpannerBatchUpdateException;
 import com.google.cloud.spanner.SpannerException;
@@ -1313,7 +1312,7 @@ public class BackendConnection {
 
     @Override
     public ResultSet getResultSet() {
-      return ResultSets.forRows(
+      return ClientSideResultSet.forRows(
           Type.struct(StructField.of("partition", Type.bytes())),
           partitions.stream()
               .map(

--- a/src/main/java/com/google/cloud/spanner/pgadapter/statements/ClientSideResultSet.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/statements/ClientSideResultSet.java
@@ -1,0 +1,54 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.cloud.spanner.pgadapter.statements;
+
+import com.google.api.core.InternalApi;
+import com.google.cloud.spanner.ForwardingResultSet;
+import com.google.cloud.spanner.ResultSet;
+import com.google.cloud.spanner.ResultSets;
+import com.google.cloud.spanner.Struct;
+import com.google.cloud.spanner.Type;
+import com.google.spanner.v1.ResultSetMetadata;
+import com.google.spanner.v1.ResultSetStats;
+
+/** Wrapper class for query results that are handled directly in PGAdapter. */
+@InternalApi
+public class ClientSideResultSet extends ForwardingResultSet {
+  public static ResultSet forRows(Type type, Iterable<Struct> rows) {
+    return new ClientSideResultSet(ResultSets.forRows(type, rows), type);
+  }
+
+  private final Type type;
+
+  private ClientSideResultSet(ResultSet delegate, Type type) {
+    super(delegate);
+    this.type = type;
+  }
+
+  @Override
+  public Type getType() {
+    return type;
+  }
+
+  @Override
+  public ResultSetStats getStats() {
+    return ResultSetStats.getDefaultInstance();
+  }
+
+  @Override
+  public ResultSetMetadata getMetadata() {
+    return ResultSetMetadata.getDefaultInstance();
+  }
+}

--- a/src/main/java/com/google/cloud/spanner/pgadapter/statements/SessionStatementParser.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/statements/SessionStatementParser.java
@@ -17,7 +17,6 @@ package com.google.cloud.spanner.pgadapter.statements;
 import com.google.api.client.util.Strings;
 import com.google.api.core.InternalApi;
 import com.google.cloud.spanner.ErrorCode;
-import com.google.cloud.spanner.ResultSets;
 import com.google.cloud.spanner.SpannerExceptionFactory;
 import com.google.cloud.spanner.Struct;
 import com.google.cloud.spanner.Type;
@@ -186,7 +185,7 @@ public class SessionStatementParser {
     public StatementResult execute(SessionState sessionState) {
       if (name != null) {
         return new QueryResult(
-            ResultSets.forRows(
+            ClientSideResultSet.forRows(
                 Type.struct(StructField.of(getKey(), Type.string())),
                 ImmutableList.of(
                     Struct.newBuilder()
@@ -195,7 +194,7 @@ public class SessionStatementParser {
                         .build())));
       }
       return new QueryResult(
-          ResultSets.forRows(
+          ClientSideResultSet.forRows(
               Type.struct(
                   StructField.of("name", Type.string()),
                   StructField.of("setting", Type.string()),

--- a/src/main/java/com/google/cloud/spanner/pgadapter/statements/local/DjangoGetTableNamesStatement.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/statements/local/DjangoGetTableNamesStatement.java
@@ -16,12 +16,12 @@ package com.google.cloud.spanner.pgadapter.statements.local;
 
 import com.google.api.core.InternalApi;
 import com.google.cloud.spanner.ResultSet;
-import com.google.cloud.spanner.ResultSets;
 import com.google.cloud.spanner.Type;
 import com.google.cloud.spanner.Type.StructField;
 import com.google.cloud.spanner.connection.StatementResult;
 import com.google.cloud.spanner.pgadapter.statements.BackendConnection;
 import com.google.cloud.spanner.pgadapter.statements.BackendConnection.QueryResult;
+import com.google.cloud.spanner.pgadapter.statements.ClientSideResultSet;
 import com.google.common.collect.ImmutableList;
 
 /*
@@ -60,7 +60,7 @@ public class DjangoGetTableNamesStatement implements LocalStatement {
   @Override
   public StatementResult execute(BackendConnection backendConnection) {
     ResultSet resultSet =
-        ResultSets.forRows(
+        ClientSideResultSet.forRows(
             Type.struct(
                 StructField.of("relname", Type.string()), StructField.of("case", Type.string())),
             ImmutableList.of());

--- a/src/main/java/com/google/cloud/spanner/pgadapter/statements/local/ListDatabasesStatement.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/statements/local/ListDatabasesStatement.java
@@ -20,7 +20,6 @@ import com.google.cloud.spanner.DatabaseAdminClient;
 import com.google.cloud.spanner.Dialect;
 import com.google.cloud.spanner.InstanceId;
 import com.google.cloud.spanner.ResultSet;
-import com.google.cloud.spanner.ResultSets;
 import com.google.cloud.spanner.Spanner;
 import com.google.cloud.spanner.Struct;
 import com.google.cloud.spanner.Type;
@@ -31,6 +30,7 @@ import com.google.cloud.spanner.connection.StatementResult;
 import com.google.cloud.spanner.pgadapter.ConnectionHandler;
 import com.google.cloud.spanner.pgadapter.statements.BackendConnection;
 import com.google.cloud.spanner.pgadapter.statements.BackendConnection.QueryResult;
+import com.google.cloud.spanner.pgadapter.statements.ClientSideResultSet;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import java.util.Comparator;
@@ -74,7 +74,7 @@ public class ListDatabasesStatement implements LocalStatement {
     InstanceId defaultInstanceId =
         connectionHandler.getServer().getOptions().getDefaultInstanceId();
     ResultSet resultSet =
-        ResultSets.forRows(
+        ClientSideResultSet.forRows(
             Type.struct(
                 StructField.of("Name", Type.string()),
                 StructField.of("Owner", Type.string()),

--- a/src/main/java/com/google/cloud/spanner/pgadapter/statements/local/SelectCurrentCatalogStatement.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/statements/local/SelectCurrentCatalogStatement.java
@@ -16,13 +16,13 @@ package com.google.cloud.spanner.pgadapter.statements.local;
 
 import com.google.api.core.InternalApi;
 import com.google.cloud.spanner.ResultSet;
-import com.google.cloud.spanner.ResultSets;
 import com.google.cloud.spanner.Struct;
 import com.google.cloud.spanner.Type;
 import com.google.cloud.spanner.Type.StructField;
 import com.google.cloud.spanner.connection.StatementResult;
 import com.google.cloud.spanner.pgadapter.statements.BackendConnection;
 import com.google.cloud.spanner.pgadapter.statements.BackendConnection.QueryResult;
+import com.google.cloud.spanner.pgadapter.statements.ClientSideResultSet;
 import com.google.common.collect.ImmutableList;
 
 @InternalApi
@@ -52,7 +52,7 @@ public class SelectCurrentCatalogStatement implements LocalStatement {
   @Override
   public StatementResult execute(BackendConnection backendConnection) {
     ResultSet resultSet =
-        ResultSets.forRows(
+        ClientSideResultSet.forRows(
             Type.struct(StructField.of("current_catalog", Type.string())),
             ImmutableList.of(
                 Struct.newBuilder()

--- a/src/main/java/com/google/cloud/spanner/pgadapter/statements/local/SelectCurrentDatabaseStatement.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/statements/local/SelectCurrentDatabaseStatement.java
@@ -16,13 +16,13 @@ package com.google.cloud.spanner.pgadapter.statements.local;
 
 import com.google.api.core.InternalApi;
 import com.google.cloud.spanner.ResultSet;
-import com.google.cloud.spanner.ResultSets;
 import com.google.cloud.spanner.Struct;
 import com.google.cloud.spanner.Type;
 import com.google.cloud.spanner.Type.StructField;
 import com.google.cloud.spanner.connection.StatementResult;
 import com.google.cloud.spanner.pgadapter.statements.BackendConnection;
 import com.google.cloud.spanner.pgadapter.statements.BackendConnection.QueryResult;
+import com.google.cloud.spanner.pgadapter.statements.ClientSideResultSet;
 import com.google.common.collect.ImmutableList;
 
 @InternalApi
@@ -53,7 +53,7 @@ public class SelectCurrentDatabaseStatement implements LocalStatement {
   @Override
   public StatementResult execute(BackendConnection backendConnection) {
     ResultSet resultSet =
-        ResultSets.forRows(
+        ClientSideResultSet.forRows(
             Type.struct(StructField.of("current_database", Type.string())),
             ImmutableList.of(
                 Struct.newBuilder()

--- a/src/main/java/com/google/cloud/spanner/pgadapter/statements/local/SelectCurrentSchemaStatement.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/statements/local/SelectCurrentSchemaStatement.java
@@ -16,13 +16,13 @@ package com.google.cloud.spanner.pgadapter.statements.local;
 
 import com.google.api.core.InternalApi;
 import com.google.cloud.spanner.ResultSet;
-import com.google.cloud.spanner.ResultSets;
 import com.google.cloud.spanner.Struct;
 import com.google.cloud.spanner.Type;
 import com.google.cloud.spanner.Type.StructField;
 import com.google.cloud.spanner.connection.StatementResult;
 import com.google.cloud.spanner.pgadapter.statements.BackendConnection;
 import com.google.cloud.spanner.pgadapter.statements.BackendConnection.QueryResult;
+import com.google.cloud.spanner.pgadapter.statements.ClientSideResultSet;
 import com.google.common.collect.ImmutableList;
 
 @InternalApi
@@ -50,7 +50,7 @@ public class SelectCurrentSchemaStatement implements LocalStatement {
   @Override
   public StatementResult execute(BackendConnection backendConnection) {
     ResultSet resultSet =
-        ResultSets.forRows(
+        ClientSideResultSet.forRows(
             Type.struct(StructField.of("current_schema", Type.string())),
             ImmutableList.of(
                 Struct.newBuilder()

--- a/src/main/java/com/google/cloud/spanner/pgadapter/statements/local/SelectVersionStatement.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/statements/local/SelectVersionStatement.java
@@ -16,13 +16,13 @@ package com.google.cloud.spanner.pgadapter.statements.local;
 
 import com.google.api.core.InternalApi;
 import com.google.cloud.spanner.ResultSet;
-import com.google.cloud.spanner.ResultSets;
 import com.google.cloud.spanner.Struct;
 import com.google.cloud.spanner.Type;
 import com.google.cloud.spanner.Type.StructField;
 import com.google.cloud.spanner.connection.StatementResult;
 import com.google.cloud.spanner.pgadapter.statements.BackendConnection;
 import com.google.cloud.spanner.pgadapter.statements.BackendConnection.QueryResult;
+import com.google.cloud.spanner.pgadapter.statements.ClientSideResultSet;
 import com.google.common.collect.ImmutableList;
 
 @InternalApi
@@ -64,7 +64,7 @@ public class SelectVersionStatement implements LocalStatement {
   @Override
   public StatementResult execute(BackendConnection backendConnection) {
     ResultSet resultSet =
-        ResultSets.forRows(
+        ClientSideResultSet.forRows(
             Type.struct(StructField.of("version", Type.string())),
             ImmutableList.of(
                 Struct.newBuilder()

--- a/src/main/java/com/google/cloud/spanner/pgadapter/wireprotocol/ParseMessage.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/wireprotocol/ParseMessage.java
@@ -64,6 +64,7 @@ public class ParseMessage extends AbstractQueryProtocolMessage {
     }
     this.statement =
         createStatement(connection, name, parsedStatement, originalStatement, parameterDataTypes);
+    connection.maybeDetermineWellKnownClient(this);
   }
 
   /**

--- a/src/main/java/com/google/cloud/spanner/pgadapter/wireprotocol/StartupMessage.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/wireprotocol/StartupMessage.java
@@ -26,7 +26,6 @@ import java.io.IOException;
 import java.text.MessageFormat;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.annotation.Nullable;
 
@@ -53,14 +52,6 @@ public class StartupMessage extends BootstrapMessage {
       WellKnownClient wellKnownClient =
           ClientAutoDetector.detectClient(this.parseParameterKeys(rawParameters), this.parameters);
       connection.setWellKnownClient(wellKnownClient);
-      if (wellKnownClient != WellKnownClient.UNSPECIFIED) {
-        logger.log(
-            Level.INFO,
-            () ->
-                String.format(
-                    "Well-known client %s detected for connection %d.",
-                    wellKnownClient, connection.getConnectionId()));
-      }
     } else {
       connection.setWellKnownClient(WellKnownClient.UNSPECIFIED);
     }

--- a/src/test/csharp/pgadapter_npgsql_tests/npgsql_tests/NpgsqlTest.cs
+++ b/src/test/csharp/pgadapter_npgsql_tests/npgsql_tests/NpgsqlTest.cs
@@ -60,6 +60,22 @@ public class NpgsqlTest
         }
     }
 
+    public void TestShowApplicationName()
+    {
+        using var connection = new NpgsqlConnection(ConnectionString);
+        connection.Open();
+
+        using var cmd = new NpgsqlCommand("show application_name", connection);
+        using (var reader = cmd.ExecuteReader())
+        {
+            while (reader.Read())
+            {
+                var applicationName = reader.GetString(0);
+                Console.WriteLine($"{applicationName}");
+            }
+        }
+    }
+
     public void TestSelect1()
     {
         using var connection = new NpgsqlConnection(ConnectionString);

--- a/src/test/golang/pgadapter_pgx_tests/pgx.go
+++ b/src/test/golang/pgadapter_pgx_tests/pgx.go
@@ -80,6 +80,27 @@ func TestSelect1(connString string) *C.char {
 	return nil
 }
 
+//export TestShowApplicationName
+func TestShowApplicationName(connString string) *C.char {
+	ctx := context.Background()
+	conn, err := pgx.Connect(ctx, connString)
+	if err != nil {
+		return C.CString(err.Error())
+	}
+	defer conn.Close(ctx)
+
+	var value string
+	err = conn.QueryRow(ctx, "show application_name").Scan(&value)
+	if err != nil {
+		return C.CString(err.Error())
+	}
+	if g, w := value, "pgx"; g != w {
+		return C.CString(fmt.Sprintf("value mismatch\n Got: %v\nWant: %v", g, w))
+	}
+
+	return nil
+}
+
 //export TestQueryWithParameter
 func TestQueryWithParameter(connString string) *C.char {
 	ctx := context.Background()

--- a/src/test/java/com/google/cloud/spanner/pgadapter/EmulatedPsqlMockServerTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/EmulatedPsqlMockServerTest.java
@@ -196,6 +196,18 @@ public class EmulatedPsqlMockServerTest extends AbstractMockServerTest {
   }
 
   @Test
+  public void testShowApplicationName() throws SQLException {
+    try (Connection connection = DriverManager.getConnection(createUrl("my-db"))) {
+      try (ResultSet resultSet =
+          connection.createStatement().executeQuery("show application_name")) {
+        assertTrue(resultSet.next());
+        assertEquals("psql", resultSet.getString(1));
+        assertFalse(resultSet.next());
+      }
+    }
+  }
+
+  @Test
   public void testConnectToNonExistingInstance() {
     try {
       mockSpanner.setExecuteStreamingSqlExecutionTime(

--- a/src/test/java/com/google/cloud/spanner/pgadapter/csharp/NpgsqlMockServerTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/csharp/NpgsqlMockServerTest.java
@@ -72,6 +72,12 @@ public class NpgsqlMockServerTest extends AbstractNpgsqlMockServerTest {
   }
 
   @Test
+  public void testShowApplicationName() throws IOException, InterruptedException {
+    String result = execute("TestShowApplicationName", createConnectionString());
+    assertEquals("npgsql\n", result);
+  }
+
+  @Test
   public void testSelect1() throws IOException, InterruptedException {
     String result = execute("TestSelect1", createConnectionString());
     assertEquals("Success\n", result);

--- a/src/test/java/com/google/cloud/spanner/pgadapter/golang/PgxMockServerTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/golang/PgxMockServerTest.java
@@ -159,6 +159,16 @@ public class PgxMockServerTest extends AbstractMockServerTest {
   }
 
   @Test
+  public void testShowApplicationName() {
+    String res = pgxTest.TestShowApplicationName(createConnString());
+
+    assertNull(res);
+
+    // This should all be handled in PGAdapter.
+    assertEquals(0, mockSpanner.countRequestsOfType(ExecuteSqlRequest.class));
+  }
+
+  @Test
   public void testQueryWithParameter() {
     String sql = "SELECT * FROM FOO WHERE BAR=$1";
     Statement statement = Statement.newBuilder(sql).bind("p1").to("baz").build();

--- a/src/test/java/com/google/cloud/spanner/pgadapter/golang/PgxTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/golang/PgxTest.java
@@ -23,6 +23,8 @@ public interface PgxTest extends Library {
 
   String TestSelect1(GoString connString);
 
+  String TestShowApplicationName(GoString connString);
+
   String TestQueryWithParameter(GoString connString);
 
   String TestQueryAllDataTypes(GoString connString, int oid, int format);


### PR DESCRIPTION
SHOW variable_name statements failed in pgx, because pgx tries to describe all statements (including SHOW). This failed as these statements do not have any metadata, as they are not returned by the backend.

This fix also adds automatic detection of the pgx driver based on the first Parse message that we receive. pgx uses a very specific name for the prepared statements that it creates that can be used for (relatively) safe detection.