### PR TITLE
test: increase timeouts for npgsql tests

### DIFF
--- a/src/test/java/com/google/cloud/spanner/pgadapter/csharp/ITNpgsqlTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/csharp/ITNpgsqlTest.java
@@ -94,7 +94,8 @@ public class ITNpgsqlTest implements IntegrationTest {
 
   private String createConnectionString() {
     return String.format(
-        "Host=%s;Port=%d;Database=d;SSL Mode=Disable", host, testEnv.getServer().getLocalPort());
+        "Host=%s;Port=%d;Database=d;SSL Mode=Disable;Timeout=60;Command Timeout=60",
+        host, testEnv.getServer().getLocalPort());
   }
 
   @Before

--- a/src/test/java/com/google/cloud/spanner/pgadapter/csharp/NpgsqlMockServerTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/csharp/NpgsqlMockServerTest.java
@@ -82,7 +82,8 @@ public class NpgsqlMockServerTest extends AbstractNpgsqlMockServerTest {
 
   private String createConnectionString() {
     return String.format(
-        "Host=%s;Port=%d;Database=d;SSL Mode=Disable", host, pgServer.getLocalPort());
+        "Host=%s;Port=%d;Database=d;SSL Mode=Disable;Timeout=60;Command Timeout=60",
+        host, pgServer.getLocalPort());
   }
 
   @Test


### PR DESCRIPTION
The npgsql integration tests sometimes time out. This increases the timeout value for creating a new connection and for executing a command using npgsql.