### PR TITLE
deps: bump node-postgres to 8.9.0

### DIFF
--- a/src/test/java/com/google/cloud/spanner/pgadapter/nodejs/NodePostgresMockServerTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/nodejs/NodePostgresMockServerTest.java
@@ -206,10 +206,9 @@ public class NodePostgresMockServerTest extends AbstractMockServerTest {
     ExecuteSqlRequest executeRequest = executeSqlRequests.get(1);
     assertEquals(sql, executeRequest.getSql());
     assertEquals(1, executeRequest.getParamTypesCount());
-    // TODO: Enable when node-postgres 8.9 has been released.
-    //    assertTrue(executeRequest.getTransaction().hasBegin());
-    //    assertTrue(executeRequest.getTransaction().getBegin().hasReadWrite());
-    //    assertEquals(2, mockSpanner.countRequestsOfType(CommitRequest.class));
+    assertTrue(executeRequest.getTransaction().hasBegin());
+    assertTrue(executeRequest.getTransaction().getBegin().hasReadWrite());
+    assertEquals(2, mockSpanner.countRequestsOfType(CommitRequest.class));
   }
 
   @Test
@@ -282,10 +281,9 @@ public class NodePostgresMockServerTest extends AbstractMockServerTest {
     ExecuteSqlRequest executeRequest = executeSqlRequests.get(1);
     assertEquals(sql, executeRequest.getSql());
     assertEquals(10, executeRequest.getParamTypesCount());
-    // TODO: Enable once node-postgres 8.9 is released.
-    //    assertTrue(executeRequest.getTransaction().hasBegin());
-    //    assertTrue(executeRequest.getTransaction().getBegin().hasReadWrite());
-    //    assertEquals(2, mockSpanner.countRequestsOfType(CommitRequest.class));
+    assertTrue(executeRequest.getTransaction().hasBegin());
+    assertTrue(executeRequest.getTransaction().getBegin().hasReadWrite());
+    assertEquals(2, mockSpanner.countRequestsOfType(CommitRequest.class));
   }
 
   @Test
@@ -448,10 +446,9 @@ public class NodePostgresMockServerTest extends AbstractMockServerTest {
     ExecuteSqlRequest executeRequest = executeSqlRequests.get(1);
     assertEquals(sql, executeRequest.getSql());
     assertEquals(10, executeRequest.getParamTypesCount());
-    // TODO: Enable once node-postgres 8.9 is released.
-    //    assertTrue(executeRequest.getTransaction().hasBegin());
-    //    assertTrue(executeRequest.getTransaction().getBegin().hasReadWrite());
-    //    assertEquals(3, mockSpanner.countRequestsOfType(CommitRequest.class));
+    assertTrue(executeRequest.getTransaction().hasBegin());
+    assertTrue(executeRequest.getTransaction().getBegin().hasReadWrite());
+    assertEquals(3, mockSpanner.countRequestsOfType(CommitRequest.class));
   }
 
   @Test

--- a/src/test/java/com/google/cloud/spanner/pgadapter/nodejs/TypeORMMockServerTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/nodejs/TypeORMMockServerTest.java
@@ -16,7 +16,6 @@ package com.google.cloud.spanner.pgadapter.nodejs;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 import com.google.cloud.ByteArray;
 import com.google.cloud.Date;
@@ -132,34 +131,16 @@ public class TypeORMMockServerTest extends AbstractMockServerTest {
     assertEquals(2, executeSqlRequests.size());
     ExecuteSqlRequest describeRequest = executeSqlRequests.get(0);
     ExecuteSqlRequest executeRequest = executeSqlRequests.get(1);
-    // The TypeORM PostgreSQL driver sends both a Flush and a Sync message. The Flush message does
-    // a look-ahead to determine if the next message is a Sync, and if it is, executes a Sync on the
-    // backend connection. This is a lot more efficient, as it means that we can use a read-only
-    // transaction for transactions that only contains queries.
-    // There is however no guarantee that the server will see the Sync message in time to do this
-    // optimization, so in some cases the single query will be using a read/write transaction, as we
-    // don't know what might be following the current query.
-    // This behavior in node-postgres has been fixed in
-    // https://github.com/brianc/node-postgres/pull/2842,
-    // but has not yet been released.
-    int commitRequestCount = mockSpanner.countRequestsOfType(CommitRequest.class);
-    if (commitRequestCount == 0) {
-      assertEquals(1, mockSpanner.countRequestsOfType(BeginTransactionRequest.class));
-      assertTrue(
-          mockSpanner
-              .getRequestsOfType(BeginTransactionRequest.class)
-              .get(0)
-              .getOptions()
-              .hasReadOnly());
-      assertTrue(describeRequest.getTransaction().hasId());
-      assertTrue(executeRequest.getTransaction().hasId());
-    } else if (commitRequestCount == 1) {
-      assertTrue(describeRequest.getTransaction().hasBegin());
-      assertTrue(describeRequest.getTransaction().getBegin().hasReadWrite());
-      assertTrue(executeRequest.getTransaction().hasId());
-    } else {
-      fail("Invalid commit count: " + commitRequestCount);
-    }
+    assertEquals(0, mockSpanner.countRequestsOfType(CommitRequest.class));
+    assertEquals(1, mockSpanner.countRequestsOfType(BeginTransactionRequest.class));
+    assertTrue(
+        mockSpanner
+            .getRequestsOfType(BeginTransactionRequest.class)
+            .get(0)
+            .getOptions()
+            .hasReadOnly());
+    assertTrue(describeRequest.getTransaction().hasId());
+    assertTrue(executeRequest.getTransaction().hasId());
   }
 
   @Test
@@ -261,7 +242,6 @@ public class TypeORMMockServerTest extends AbstractMockServerTest {
     // Creating the user will use a read/write transaction. The query that checks whether the record
     // already exists will however not use that transaction, as each statement is executed in
     // auto-commit mode.
-    int expectedCommitCount = 0;
     List<ExecuteSqlRequest> checkExistsRequests =
         mockSpanner.getRequestsOfType(ExecuteSqlRequest.class).stream()
             .filter(request -> request.getSql().equals(existsSql))
@@ -271,9 +251,6 @@ public class TypeORMMockServerTest extends AbstractMockServerTest {
     ExecuteSqlRequest executeCheckExistsRequest = checkExistsRequests.get(1);
     assertEquals(QueryMode.PLAN, describeCheckExistsRequest.getQueryMode());
     assertEquals(QueryMode.NORMAL, executeCheckExistsRequest.getQueryMode());
-    if (describeCheckExistsRequest.getTransaction().hasBegin()) {
-      expectedCommitCount++;
-    }
 
     List<ExecuteSqlRequest> insertRequests =
         mockSpanner.getRequestsOfType(ExecuteSqlRequest.class).stream()
@@ -287,7 +264,6 @@ public class TypeORMMockServerTest extends AbstractMockServerTest {
     ExecuteSqlRequest executeInsertRequest = insertRequests.get(1);
     assertEquals(QueryMode.NORMAL, executeInsertRequest.getQueryMode());
     assertTrue(executeInsertRequest.getTransaction().hasId());
-    expectedCommitCount++;
 
     // Loading the user after having saved it will be done in a single-use read-only transaction.
     List<ExecuteSqlRequest> loadRequests =
@@ -299,10 +275,7 @@ public class TypeORMMockServerTest extends AbstractMockServerTest {
     assertEquals(QueryMode.PLAN, describeLoadRequest.getQueryMode());
     ExecuteSqlRequest executeLoadRequest = loadRequests.get(1);
     assertEquals(QueryMode.NORMAL, executeLoadRequest.getQueryMode());
-    if (describeLoadRequest.getTransaction().hasBegin()) {
-      expectedCommitCount++;
-    }
-    assertEquals(expectedCommitCount, mockSpanner.countRequestsOfType(CommitRequest.class));
+    assertEquals(1, mockSpanner.countRequestsOfType(CommitRequest.class));
   }
 
   @Test
@@ -410,7 +383,6 @@ public class TypeORMMockServerTest extends AbstractMockServerTest {
     // Updating the user will use a read/write transaction. The query that checks whether the record
     // already exists will however not use that transaction, as each statement is executed in
     // auto-commit mode.
-    int expectedCommitCount = 0;
     List<ExecuteSqlRequest> loadRequests =
         mockSpanner.getRequestsOfType(ExecuteSqlRequest.class).stream()
             .filter(request -> request.getSql().equals(loadSql))
@@ -420,9 +392,6 @@ public class TypeORMMockServerTest extends AbstractMockServerTest {
     assertEquals(QueryMode.PLAN, describeLoadRequest.getQueryMode());
     ExecuteSqlRequest executeLoadRequest = loadRequests.get(1);
     assertEquals(QueryMode.NORMAL, executeLoadRequest.getQueryMode());
-    if (describeLoadRequest.getTransaction().hasBegin()) {
-      expectedCommitCount++;
-    }
 
     List<ExecuteSqlRequest> checkExistsRequests =
         mockSpanner.getRequestsOfType(ExecuteSqlRequest.class).stream()
@@ -433,9 +402,6 @@ public class TypeORMMockServerTest extends AbstractMockServerTest {
     assertEquals(QueryMode.PLAN, describeCheckExistsRequest.getQueryMode());
     ExecuteSqlRequest executeCheckExistsRequest = checkExistsRequests.get(1);
     assertEquals(QueryMode.NORMAL, executeCheckExistsRequest.getQueryMode());
-    if (describeCheckExistsRequest.getTransaction().hasBegin()) {
-      expectedCommitCount++;
-    }
 
     List<ExecuteSqlRequest> updateRequests =
         mockSpanner.getRequestsOfType(ExecuteSqlRequest.class).stream()
@@ -447,9 +413,8 @@ public class TypeORMMockServerTest extends AbstractMockServerTest {
     assertTrue(describeUpdateRequest.getTransaction().hasBegin());
     assertTrue(describeUpdateRequest.getTransaction().getBegin().hasReadWrite());
     assertTrue(executeUpdateRequest.getTransaction().hasId());
-    expectedCommitCount++;
 
-    assertEquals(expectedCommitCount, mockSpanner.countRequestsOfType(CommitRequest.class));
+    assertEquals(1, mockSpanner.countRequestsOfType(CommitRequest.class));
   }
 
   @Test
@@ -540,7 +505,6 @@ public class TypeORMMockServerTest extends AbstractMockServerTest {
     // Deleting the user will use a read/write transaction. The query that checks whether the record
     // already exists will however not use that transaction, as each statement is executed in
     // auto-commit mode.
-    int expectedCommitCount = 0;
     List<ExecuteSqlRequest> loadRequests =
         mockSpanner.getRequestsOfType(ExecuteSqlRequest.class).stream()
             .filter(request -> request.getSql().equals(loadSql))
@@ -550,9 +514,6 @@ public class TypeORMMockServerTest extends AbstractMockServerTest {
     assertEquals(QueryMode.PLAN, describeLoadRequest.getQueryMode());
     ExecuteSqlRequest executeLoadRequest = loadRequests.get(1);
     assertEquals(QueryMode.NORMAL, executeLoadRequest.getQueryMode());
-    if (describeLoadRequest.getTransaction().hasBegin()) {
-      expectedCommitCount++;
-    }
 
     List<ExecuteSqlRequest> checkExistsRequests =
         mockSpanner.getRequestsOfType(ExecuteSqlRequest.class).stream()
@@ -563,9 +524,6 @@ public class TypeORMMockServerTest extends AbstractMockServerTest {
     assertEquals(QueryMode.PLAN, describeCheckExistsRequest.getQueryMode());
     ExecuteSqlRequest executeCheckExistsRequest = checkExistsRequests.get(1);
     assertEquals(QueryMode.NORMAL, executeCheckExistsRequest.getQueryMode());
-    if (describeCheckExistsRequest.getTransaction().hasBegin()) {
-      expectedCommitCount++;
-    }
 
     List<ExecuteSqlRequest> deleteRequests =
         mockSpanner.getRequestsOfType(ExecuteSqlRequest.class).stream()
@@ -578,9 +536,8 @@ public class TypeORMMockServerTest extends AbstractMockServerTest {
     assertEquals(QueryMode.NORMAL, executeDeleteRequest.getQueryMode());
     assertTrue(describeDeleteRequest.getTransaction().hasBegin());
     assertTrue(describeDeleteRequest.getTransaction().getBegin().hasReadWrite());
-    expectedCommitCount++;
 
-    assertEquals(expectedCommitCount, mockSpanner.countRequestsOfType(CommitRequest.class));
+    assertEquals(1, mockSpanner.countRequestsOfType(CommitRequest.class));
   }
 
   @Test
@@ -633,7 +590,6 @@ public class TypeORMMockServerTest extends AbstractMockServerTest {
             + "}\n",
         output);
 
-    int expectedCommitCount = 0;
     List<ExecuteSqlRequest> executeSqlRequests =
         mockSpanner.getRequestsOfType(ExecuteSqlRequest.class).stream()
             .filter(request -> request.getSql().equals(sql))
@@ -643,10 +599,7 @@ public class TypeORMMockServerTest extends AbstractMockServerTest {
     assertEquals(QueryMode.PLAN, describeRequest.getQueryMode());
     ExecuteSqlRequest executeRequest = executeSqlRequests.get(1);
     assertEquals(QueryMode.NORMAL, executeRequest.getQueryMode());
-    if (describeRequest.getTransaction().hasBegin()) {
-      expectedCommitCount++;
-    }
-    assertEquals(expectedCommitCount, mockSpanner.countRequestsOfType(CommitRequest.class));
+    assertEquals(0, mockSpanner.countRequestsOfType(CommitRequest.class));
   }
 
   @Test
@@ -846,8 +799,7 @@ public class TypeORMMockServerTest extends AbstractMockServerTest {
 
     // We get two commit requests, because the statement is auto-described the first time the update
     // is executed. The auto-describe also runs in autocommit mode.
-    // TODO: Enable when node-postgres 8.9 has been released.
-    //    assertEquals(2, mockSpanner.countRequestsOfType(CommitRequest.class));
+    assertEquals(2, mockSpanner.countRequestsOfType(CommitRequest.class));
     assertEquals(4, mockSpanner.countRequestsOfType(ExecuteSqlRequest.class));
     ExecuteSqlRequest updateRequest = mockSpanner.getRequestsOfType(ExecuteSqlRequest.class).get(3);
     assertEquals(updateSql, updateRequest.getSql());

--- a/src/test/nodejs/node-postgres/package.json
+++ b/src/test/nodejs/node-postgres/package.json
@@ -9,7 +9,7 @@
     "typescript": "4.5.2"
   },
   "dependencies": {
-    "pg": "^8.8.0",
+    "pg": "^8.9.0",
     "pg-copy-streams": "^6.0.4",
     "reflect-metadata": "^0.1.13",
     "yargs": "^17.5.1"

--- a/src/test/nodejs/typeorm/data-test/package.json
+++ b/src/test/nodejs/typeorm/data-test/package.json
@@ -9,9 +9,9 @@
       "typescript": "4.5.2"
    },
    "dependencies": {
-      "typeorm": "0.3.7",
+      "typeorm": "0.3.12",
       "reflect-metadata": "^0.1.13",
-      "pg": "^8.4.0",
+      "pg": "^8.9.0",
       "yargs": "^17.5.1"
    },
    "scripts": {


### PR DESCRIPTION
Bump the tested version of node-postgres to 8.9.0. This version contains an important performance optimization that helps PGAdapter execute statements coming from node-postgres more efficiently, as node-postgres no longer sends both a flush and sync message.