### PR TITLE
deps: add dependabot for ecosystem tests and samples

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,11 +12,34 @@ updates:
     schedule:
       interval: "daily"
 
+  # ecosystem test packages
   - package-ecosystem: "nuget"
     directory: "/src/test/csharp/pgadapter_npgsql_tests"
     schedule:
       interval: "daily"
   - package-ecosystem: "gomod"
+    directory: "/src/test/golang/pgadapter_gorm_tests"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "gomod"
+    directory: "/src/test/golang/pgadapter_pgx_tests"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "npm"
+    directory: "/src/test/nodejs/node-postgres"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "npm"
+    directory: "/src/test/nodejs/typeorm/data-test"
+    schedule:
+      interval: "daily"
+
+  # ecosystem sample packages
+  - package-ecosystem: "gomod"
     directory: "/samples/golang/gorm"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "maven"
+    directory: "/samples/java/liquibase"
     schedule:
       interval: "daily"


### PR DESCRIPTION
Adds dependabot configuration for more samples and ecosystem tests. Python is not yet included in this, as they are not yet all moved to separate virtual environments.