### PR TITLE
fix: add pg_sequence and pg_sequences views

### DIFF
--- a/src/main/java/com/google/cloud/spanner/pgadapter/statements/PgCatalog.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/statements/PgCatalog.java
@@ -57,6 +57,16 @@ public class PgCatalog {
           .put(new TableOrIndexName("pg_catalog", "pg_type"), new TableOrIndexName(null, "pg_type"))
           .put(new TableOrIndexName(null, "pg_type"), new TableOrIndexName(null, "pg_type"))
           .put(
+              new TableOrIndexName("pg_catalog", "pg_sequence"),
+              new TableOrIndexName(null, "pg_sequence"))
+          .put(new TableOrIndexName(null, "pg_sequence"), new TableOrIndexName(null, "pg_sequence"))
+          .put(
+              new TableOrIndexName("pg_catalog", "pg_sequences"),
+              new TableOrIndexName(null, "pg_sequences"))
+          .put(
+              new TableOrIndexName(null, "pg_sequences"),
+              new TableOrIndexName(null, "pg_sequences"))
+          .put(
               new TableOrIndexName("pg_catalog", "pg_settings"),
               new TableOrIndexName(null, "pg_settings"))
           .put(new TableOrIndexName(null, "pg_settings"), new TableOrIndexName(null, "pg_settings"))
@@ -83,7 +93,9 @@ public class PgCatalog {
           new TableOrIndexName(null, "pg_class"), new PgClass(),
           new TableOrIndexName(null, "pg_proc"), new PgProc(),
           new TableOrIndexName(null, "pg_range"), new PgRange(),
-          new TableOrIndexName(null, "pg_type"), new PgType());
+          new TableOrIndexName(null, "pg_type"), new PgType(),
+          new TableOrIndexName(null, "pg_sequence"), new PgSequence(),
+          new TableOrIndexName(null, "pg_sequences"), new PgSequences());
   private final SessionState sessionState;
 
   public PgCatalog(@Nonnull SessionState sessionState, @Nonnull WellKnownClient wellKnownClient) {
@@ -470,6 +482,36 @@ public class PgCatalog {
     @Override
     public String getTableExpression() {
       return PG_ENUM_CTE;
+    }
+  }
+
+  private static class PgSequences implements PgCatalogTable {
+    private static final String PG_SEQUENCES_CTE =
+        "pg_sequences as (\n"
+            + "select * from ("
+            + "select ''::varchar as schemaname, ''::varchar as sequencename, ''::varchar as sequenceowner, "
+            + "0::bigint as data_type, 0::bigint as start_value, 0::bigint as min_value, 0::bigint as max_value, "
+            + "0::bigint as increment_by, false::bool as cycle, 0::bigint as cache_size, 0::bigint as last_value\n"
+            + ") seq where false)";
+
+    @Override
+    public String getTableExpression() {
+      return PG_SEQUENCES_CTE;
+    }
+  }
+
+  private static class PgSequence implements PgCatalogTable {
+    private static final String PG_SEQUENCE_CTE =
+        "pg_sequence as (\n"
+            + "select * from ("
+            + "select 0::bigint as seqrelid, 0::bigint as seqtypid, 0::bigint as seqstart, "
+            + "0::bigint as seqincrement, 0::bigint as seqmax, 0::bigint as seqmin, 0::bigint as seqcache, "
+            + "false::bool as seqcycle\n"
+            + ") seq where false)";
+
+    @Override
+    public String getTableExpression() {
+      return PG_SEQUENCE_CTE;
     }
   }
 }

--- a/src/test/java/com/google/cloud/spanner/pgadapter/ITJdbcTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/ITJdbcTest.java
@@ -17,6 +17,7 @@ package com.google.cloud.spanner.pgadapter;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
@@ -202,6 +203,23 @@ public class ITJdbcTest implements IntegrationTest {
         assertTrue(resultSet.next());
         assertEquals("public", resultSet.getString(1));
         assertFalse(resultSet.next());
+      }
+    }
+  }
+
+  @Test
+  public void testPgCatalogViews() throws SQLException {
+    for (String view : new String[] {"pg_sequence", "pg_sequences"}) {
+      for (String prefix : new String[] {"", "pg_catalog."}) {
+        try (Connection connection = DriverManager.getConnection(getConnectionUrl())) {
+          try (ResultSet resultSet =
+              connection.createStatement().executeQuery("SELECT * FROM " + prefix + view)) {
+            while (resultSet.next()) {
+              assertNotNull(resultSet.getMetaData());
+              assertNotEquals(0, resultSet.getMetaData().getColumnCount());
+            }
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
There was no replacement for the pg_sequence and pg_sequences views in pg_catalog. These are added as empty views in this fix.