### PR TITLE
fix: the JDBC reWriteBatchedInserts=true option could cause errors in DML batches

### DIFF
--- a/src/main/java/com/google/cloud/spanner/pgadapter/statements/BackendConnection.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/statements/BackendConnection.java
@@ -1194,6 +1194,9 @@ public class BackendConnection {
     int index = fromIndex;
     try {
       while (index < getStatementCount()) {
+        if (!bufferedStatements.get(index).isBatchingPossible()) {
+          break;
+        }
         StatementType statementType = getStatementType(index);
         if (canBeBatchedTogether(batchType, statementType)) {
           // Send DDL statements to the DdlExecutor instead of executing them directly on the

--- a/src/main/java/com/google/cloud/spanner/pgadapter/statements/BackendConnection.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/statements/BackendConnection.java
@@ -917,6 +917,9 @@ public class BackendConnection {
       connectionState = ConnectionState.ABORTED;
       sessionState.rollback();
       if (spannerConnection.isInTransaction()) {
+        if (spannerConnection.isDmlBatchActive()) {
+          spannerConnection.abortBatch();
+        }
         spannerConnection.setStatementTag(null);
         spannerConnection.execute(ROLLBACK);
       } else if (spannerConnection.isDdlBatchActive()) {
@@ -1242,6 +1245,9 @@ public class BackendConnection {
       Execute failedExecute = (Execute) bufferedStatements.get(fromIndex + counts.length);
       failedExecute.result.setException(batchUpdateException);
       throw batchUpdateException;
+    } catch (Throwable exception) {
+      bufferedStatements.get(fromIndex).result.setException(exception);
+      throw exception;
     }
     return index - fromIndex;
   }


### PR DESCRIPTION
The `reWriteBatchedInserts=true` JDBC option can cause the PG JDBC driver to execute a batch that contains different SQL statements, where one of the SQL statements in the middle of the batch must be described. The latter happens if the statement contains at least one untyped parameter. The JDBC driver sends all timestamp and date parameters as untyped, meaning that statements with parameters of those types could cause this problem. PGAdapter would then try to describe the statement as part of the batch, which is not possible, as ExecuteBatchDml does not support PLAN mode.

ExecuteBatchDml will normally throw a BatchUpdateException if something goes wrong in a batch. It is however possible that the entire batch fails, for example if the transaction has been aborted before the batch is sent and retrying the transaction fails because of concurrent modifications. Those errors would not be handled properly in PGAdapter and could cause PGAdapter to return the generic exception 'Statement result cannot be retrieved before flush/sync' instead of the actual underlying exception. This PR also adds error handling and tests for that possibility.