### PR TITLE
chore: add pg_enum to list of default table replacements

### DIFF
--- a/src/main/java/com/google/cloud/spanner/pgadapter/utils/ClientAutoDetector.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/utils/ClientAutoDetector.java
@@ -20,7 +20,6 @@ import com.google.cloud.spanner.pgadapter.ConnectionHandler;
 import com.google.cloud.spanner.pgadapter.error.PGException;
 import com.google.cloud.spanner.pgadapter.error.SQLState;
 import com.google.cloud.spanner.pgadapter.statements.PgCatalog.EmptyPgAttribute;
-import com.google.cloud.spanner.pgadapter.statements.PgCatalog.EmptyPgEnum;
 import com.google.cloud.spanner.pgadapter.statements.PgCatalog.PgCatalogTable;
 import com.google.cloud.spanner.pgadapter.statements.local.DjangoGetTableNamesStatement;
 import com.google.cloud.spanner.pgadapter.statements.local.ListDatabasesStatement;
@@ -184,16 +183,9 @@ public class ClientAutoDetector {
     NPGSQL {
       final ImmutableMap<String, String> tableReplacements =
           ImmutableMap.of(
-              "pg_catalog.pg_attribute",
-              "pg_attribute",
-              "pg_attribute",
-              "pg_attribute",
-              "pg_catalog.pg_enum",
-              "pg_enum",
-              "pg_enum",
-              "pg_enum");
+              "pg_catalog.pg_attribute", "pg_attribute", "pg_attribute", "pg_attribute");
       final ImmutableMap<String, PgCatalogTable> pgCatalogTables =
-          ImmutableMap.of("pg_attribute", new EmptyPgAttribute(), "pg_enum", new EmptyPgEnum());
+          ImmutableMap.of("pg_attribute", new EmptyPgAttribute());
 
       final ImmutableMap<Pattern, Supplier<String>> functionReplacements =
           ImmutableMap.of(

--- a/src/test/java/com/google/cloud/spanner/pgadapter/JdbcMockServerTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/JdbcMockServerTest.java
@@ -39,6 +39,7 @@ import com.google.cloud.spanner.SpannerOptions;
 import com.google.cloud.spanner.Statement;
 import com.google.cloud.spanner.connection.RandomResultSetGenerator;
 import com.google.cloud.spanner.pgadapter.error.SQLState;
+import com.google.cloud.spanner.pgadapter.statements.PgCatalog.EmptyPgEnum;
 import com.google.cloud.spanner.pgadapter.wireprotocol.ControlMessage.PreparedType;
 import com.google.cloud.spanner.pgadapter.wireprotocol.DescribeMessage;
 import com.google.cloud.spanner.pgadapter.wireprotocol.ExecuteMessage;
@@ -3291,6 +3292,28 @@ public class JdbcMockServerTest extends AbstractMockServerTest {
     CommitRequest commitRequest = mockSpanner.getRequestsOfType(CommitRequest.class).get(0);
     assertEquals(commitRequest.getTransactionId(), requests.get(1).getTransaction().getId());
     assertEquals(commitRequest.getTransactionId(), requests.get(3).getTransaction().getId());
+  }
+
+  @Test
+  public void testPgEnum() throws SQLException {
+    for (String sql :
+        new String[] {
+          "select * from pg_enum",
+          "select * from pg_catalog.pg_enum",
+          "select * from PG_CATALOG.PG_ENUM"
+        }) {
+      mockSpanner.putStatementResult(
+          StatementResult.query(
+              Statement.of("with " + new EmptyPgEnum().getTableExpression() + "\n" + sql),
+              SELECT1_RESULTSET));
+      try (Connection connection = DriverManager.getConnection(createUrl())) {
+        try (ResultSet resultSet = connection.createStatement().executeQuery(sql)) {
+          assertTrue(resultSet.next());
+          assertEquals(1L, resultSet.getLong(1));
+          assertFalse(resultSet.next());
+        }
+      }
+    }
   }
 
   @Test

--- a/src/test/java/com/google/cloud/spanner/pgadapter/statements/PgCatalogTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/statements/PgCatalogTest.java
@@ -14,6 +14,13 @@
 
 package com.google.cloud.spanner.pgadapter.statements;
 
+import static org.junit.Assert.assertSame;
+import static org.mockito.Mockito.mock;
+
+import com.google.cloud.spanner.Statement;
+import com.google.cloud.spanner.pgadapter.session.SessionState;
+import com.google.cloud.spanner.pgadapter.utils.ClientAutoDetector.WellKnownClient;
+import com.google.common.collect.ImmutableList;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -22,4 +29,11 @@ import org.junit.runners.JUnit4;
 public class PgCatalogTest {
   @Test
   public void testReplaceCatalogTables() {}
+
+  @Test
+  public void testAddCommonTableExpressions() {
+    Statement statement = Statement.of("select * from my_table");
+    PgCatalog catalog = new PgCatalog(mock(SessionState.class), WellKnownClient.UNSPECIFIED);
+    assertSame(statement, catalog.addCommonTableExpressions(statement, ImmutableList.of()));
+  }
 }


### PR DESCRIPTION
Adds pg_enum as one of the pg_catalog tables that is replaced by default for all clients.