### PR TITLE
chore: allow client-detection to skip the first N messages

### DIFF
--- a/src/main/java/com/google/cloud/spanner/pgadapter/ConnectionHandler.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/ConnectionHandler.java
@@ -756,6 +756,13 @@ public class ConnectionHandler extends Thread {
    */
   public void maybeDetermineWellKnownClient(ParseMessage parseMessage) {
     if (!this.hasDeterminedClientUsingQuery) {
+      // We skip up to 10 Parse messages before forcing the connection to detect a client (or not).
+      // This is a safety measure against clients that might send a very large number of Parse
+      // messages with client-side statements directly after connecting. This could in worst case
+      // cause PGAdapter to buffer an unreasonable number of messages. The number 10 was randomly
+      // chosen as a reasonable number of statements that should be enough. It can safely be
+      // increased if we encounter clients that send more than 10 client-side statements before
+      // sending anything that we can use to automatically recognize them.
       if (parseMessage.getStatement().getStatementType() == StatementType.CLIENT_SIDE
           && skippedAutoDetectParseMessages.size() < 10) {
         skippedAutoDetectParseMessages.add(parseMessage);

--- a/src/main/java/com/google/cloud/spanner/pgadapter/ConnectionHandler.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/ConnectionHandler.java
@@ -73,6 +73,7 @@ import java.time.Duration;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedList;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -793,6 +794,16 @@ public class ConnectionHandler extends Thread {
       // the list of settings. Just ignore this situation, as the only consequence is that the
       // 'application_name' setting has not been set.
     }
+  }
+
+  @VisibleForTesting
+  List<ParseMessage> getSkippedAutoDetectParseMessages() {
+    return this.skippedAutoDetectParseMessages;
+  }
+
+  @VisibleForTesting
+  boolean isHasDeterminedClientUsingQuery() {
+    return this.hasDeterminedClientUsingQuery;
   }
 
   /** Status of a {@link ConnectionHandler} */

--- a/src/main/java/com/google/cloud/spanner/pgadapter/utils/ClientAutoDetector.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/utils/ClientAutoDetector.java
@@ -175,7 +175,7 @@ public class ClientAutoDetector {
       }
 
       @Override
-      boolean isClient(ParseMessage parseMessage) {
+      boolean isClient(List<ParseMessage> skippedParseMessages, ParseMessage parseMessage) {
         // pgx uses a relatively unique naming scheme for prepared statements (and uses prepared
         // statements for everything by default).
         return parseMessage.getName() != null && parseMessage.getName().startsWith("lrupsc_");
@@ -208,7 +208,7 @@ public class ClientAutoDetector {
       }
 
       @Override
-      boolean isClient(List<Statement> statements) {
+      boolean isClient(List<ParseMessage> skippedParseMessages, List<Statement> statements) {
         // The npgsql client always starts with sending a query that contains multiple statements
         // and that starts with the following prefix.
         return statements.size() == 1
@@ -245,14 +245,14 @@ public class ClientAutoDetector {
       }
 
       @Override
-      boolean isClient(List<Statement> statements) {
+      boolean isClient(List<ParseMessage> skippedParseMessages, List<Statement> statements) {
         // Use UNSPECIFIED as default to prevent null checks everywhere and to ease the use of any
         // defaults defined in this enum.
         return true;
       }
 
       @Override
-      boolean isClient(ParseMessage parseMessage) {
+      boolean isClient(List<ParseMessage> skippedParseMessages, ParseMessage parseMessage) {
         // Use UNSPECIFIED as default to prevent null checks everywhere and to ease the use of any
         // defaults defined in this enum.
         return true;
@@ -265,11 +265,11 @@ public class ClientAutoDetector {
     @VisibleForTesting
     public void reset() {}
 
-    boolean isClient(List<Statement> statements) {
+    boolean isClient(List<ParseMessage> skippedParseMessages, List<Statement> statements) {
       return false;
     }
 
-    boolean isClient(ParseMessage parseMessage) {
+    boolean isClient(List<ParseMessage> skippedParseMessages, ParseMessage parseMessage) {
       return false;
     }
 
@@ -332,9 +332,10 @@ public class ClientAutoDetector {
    * Returns the {@link WellKnownClient} that the detector thinks is connected to PGAdapter based on
    * the given list of SQL statements that have been executed.
    */
-  public static @Nonnull WellKnownClient detectClient(List<Statement> statements) {
+  public static @Nonnull WellKnownClient detectClient(
+      List<ParseMessage> skippedParseMessages, List<Statement> statements) {
     for (WellKnownClient client : WellKnownClient.values()) {
-      if (client.isClient(statements)) {
+      if (client.isClient(skippedParseMessages, statements)) {
         return client;
       }
     }
@@ -346,9 +347,10 @@ public class ClientAutoDetector {
    * Returns the {@link WellKnownClient} that the detector thinks is connected to PGAdapter based on
    * the Parse message that has been received.
    */
-  public static @Nonnull WellKnownClient detectClient(ParseMessage parseMessage) {
+  public static @Nonnull WellKnownClient detectClient(
+      List<ParseMessage> skippedParseMessages, ParseMessage parseMessage) {
     for (WellKnownClient client : WellKnownClient.values()) {
-      if (client.isClient(parseMessage)) {
+      if (client.isClient(skippedParseMessages, parseMessage)) {
         return client;
       }
     }

--- a/src/test/java/com/google/cloud/spanner/pgadapter/ConnectionHandlerTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/ConnectionHandlerTest.java
@@ -27,6 +27,7 @@ import static org.mockito.Mockito.when;
 import com.google.cloud.spanner.ErrorCode;
 import com.google.cloud.spanner.SpannerExceptionFactory;
 import com.google.cloud.spanner.Statement;
+import com.google.cloud.spanner.connection.AbstractStatementParser.StatementType;
 import com.google.cloud.spanner.connection.Connection;
 import com.google.cloud.spanner.pgadapter.ConnectionHandler.ConnectionStatus;
 import com.google.cloud.spanner.pgadapter.error.PGException;
@@ -38,7 +39,9 @@ import com.google.cloud.spanner.pgadapter.metadata.OptionsMetadata.SslMode;
 import com.google.cloud.spanner.pgadapter.statements.IntermediatePortalStatement;
 import com.google.cloud.spanner.pgadapter.statements.IntermediatePreparedStatement;
 import com.google.cloud.spanner.pgadapter.utils.ClientAutoDetector.WellKnownClient;
+import com.google.cloud.spanner.pgadapter.wireprotocol.ParseMessage;
 import com.google.cloud.spanner.pgadapter.wireprotocol.WireMessage;
+import com.google.common.collect.ImmutableList;
 import java.io.ByteArrayOutputStream;
 import java.io.DataOutputStream;
 import java.io.EOFException;
@@ -591,5 +594,65 @@ public class ConnectionHandlerTest {
                 + "SELECT ns.nspname, t.oid, t.typname, t.typtype, t.typnotnull, t.elemtypoid\n"));
 
     assertEquals(WellKnownClient.UNSPECIFIED, connectionHandler.getWellKnownClient());
+  }
+
+  @Test
+  public void testMaybeDetermineWellKnownClient_skipsClientSideStatements() {
+    OptionsMetadata options = mock(OptionsMetadata.class);
+    ProxyServer server = mock(ProxyServer.class);
+    when(server.getOptions()).thenReturn(options);
+    Socket socket = mock(Socket.class);
+    InetAddress address = mock(InetAddress.class);
+    when(socket.getInetAddress()).thenReturn(address);
+    ConnectionHandler connectionHandler = new ConnectionHandler(server, socket);
+
+    when(options.shouldAutoDetectClient()).thenReturn(true);
+    connectionHandler.setWellKnownClient(WellKnownClient.UNSPECIFIED);
+
+    ParseMessage parseMessage = mock(ParseMessage.class);
+    IntermediatePreparedStatement statement = mock(IntermediatePreparedStatement.class);
+    when(statement.getStatementType()).thenReturn(StatementType.CLIENT_SIDE);
+    when(parseMessage.getStatement()).thenReturn(statement);
+
+    connectionHandler.maybeDetermineWellKnownClient(parseMessage);
+
+    assertEquals(WellKnownClient.UNSPECIFIED, connectionHandler.getWellKnownClient());
+    assertFalse(connectionHandler.isHasDeterminedClientUsingQuery());
+    assertEquals(
+        ImmutableList.of(parseMessage), connectionHandler.getSkippedAutoDetectParseMessages());
+  }
+
+  @Test
+  public void testMaybeDetermineWellKnownClient_stopsSkippingParseMessagesAfter10Messages() {
+    OptionsMetadata options = mock(OptionsMetadata.class);
+    ProxyServer server = mock(ProxyServer.class);
+    when(server.getOptions()).thenReturn(options);
+    Socket socket = mock(Socket.class);
+    InetAddress address = mock(InetAddress.class);
+    when(socket.getInetAddress()).thenReturn(address);
+    ConnectionHandler connectionHandler = new ConnectionHandler(server, socket);
+
+    when(options.shouldAutoDetectClient()).thenReturn(true);
+    connectionHandler.setWellKnownClient(WellKnownClient.UNSPECIFIED);
+
+    ParseMessage parseMessage = mock(ParseMessage.class);
+    IntermediatePreparedStatement statement = mock(IntermediatePreparedStatement.class);
+    when(statement.getStatementType()).thenReturn(StatementType.CLIENT_SIDE);
+    when(parseMessage.getStatement()).thenReturn(statement);
+
+    for (int i = 0; i < 10; i++) {
+      connectionHandler.maybeDetermineWellKnownClient(parseMessage);
+    }
+
+    assertEquals(WellKnownClient.UNSPECIFIED, connectionHandler.getWellKnownClient());
+    assertFalse(connectionHandler.isHasDeterminedClientUsingQuery());
+    assertEquals(10, connectionHandler.getSkippedAutoDetectParseMessages().size());
+
+    // This should cause the connection to stop buffering Parse messages and just set the client to
+    // UNSPECIFIED.
+    connectionHandler.maybeDetermineWellKnownClient(parseMessage);
+
+    assertTrue(connectionHandler.isHasDeterminedClientUsingQuery());
+    assertTrue(connectionHandler.getSkippedAutoDetectParseMessages().isEmpty());
   }
 }

--- a/src/test/java/com/google/cloud/spanner/pgadapter/utils/ClientAutoDetectorTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/utils/ClientAutoDetectorTest.java
@@ -309,6 +309,7 @@ public class ClientAutoDetectorTest {
     assertEquals(
         WellKnownClient.NPGSQL,
         ClientAutoDetector.detectClient(
+            ImmutableList.of(),
             ImmutableList.of(
                 Statement.of(
                     "SELECT version();\n"
@@ -316,10 +317,12 @@ public class ClientAutoDetectorTest {
                         + "SELECT ns.nspname, t.oid, t.typname, t.typtype, t.typnotnull, t.elemtypoid\n"))));
     assertEquals(
         WellKnownClient.UNSPECIFIED,
-        ClientAutoDetector.detectClient(ImmutableList.of(Statement.of("SELECT version()"))));
+        ClientAutoDetector.detectClient(
+            ImmutableList.of(), ImmutableList.of(Statement.of("SELECT version()"))));
     assertEquals(
         WellKnownClient.UNSPECIFIED,
         ClientAutoDetector.detectClient(
+            ImmutableList.of(),
             ImmutableList.of(
                 Statement.of(
                     "SELECT version();\n"


### PR DESCRIPTION
Some clients might need to skip the first N Parse messages that we receive before doing the actual client detection. This is for example the case if the client first executes a number of very generic statements, like BEGIN or SHOW ISOLATION LEVEL.