### PR TITLE
chore: skip pg_catalog replacements for client-side statements

### DIFF
--- a/src/main/java/com/google/cloud/spanner/pgadapter/statements/BackendConnection.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/statements/BackendConnection.java
@@ -260,7 +260,8 @@ public class BackendConnection {
         } else {
           // Potentially replace pg_catalog table references with common table expressions.
           updatedStatement =
-              sessionState.isReplacePgCatalogTables()
+              parsedStatement.getType() != StatementType.CLIENT_SIDE
+                      && sessionState.isReplacePgCatalogTables()
                   ? pgCatalog.get().replacePgCatalogTables(statement)
                   : statement;
           updatedStatement = bindStatement(updatedStatement);


### PR DESCRIPTION
Minor performance fix: Skip trying to replace pg_catalog tables in client-side statements, as these will never contain any references to pg_catalog anyways.