### PR TITLE
fix: add support for getting arrays using npgsql

### DIFF
--- a/src/main/java/com/google/cloud/spanner/pgadapter/utils/ClientAutoDetector.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/utils/ClientAutoDetector.java
@@ -198,8 +198,15 @@ public class ClientAutoDetector {
       final ImmutableMap<Pattern, Supplier<String>> functionReplacements =
           ImmutableMap.of(
               Pattern.compile("elemproc\\.oid = elemtyp\\.typreceive"),
-                  Suppliers.ofInstance("false"),
-              Pattern.compile("proc\\.oid = typ\\.typreceive"), Suppliers.ofInstance("false"));
+              Suppliers.ofInstance("false"),
+              Pattern.compile("proc\\.oid = typ\\.typreceive"),
+              Suppliers.ofInstance("false"),
+              Pattern.compile("WHEN proc\\.proname='array_recv' THEN typ\\.typelem"),
+              Suppliers.ofInstance("WHEN substr(typ.typname, 1, 1)='_' THEN typ.typelem"),
+              Pattern.compile(
+                  "WHEN proc\\.proname='array_recv' THEN 'a' ELSE typ\\.typtype END AS typtype"),
+              Suppliers.ofInstance(
+                  "WHEN substr(typ.typname, 1, 1)='_' THEN 'a' ELSE typ.typtype END AS typtype"));
 
       @Override
       boolean isClient(List<String> orderedParameterKeys, Map<String, String> parameters) {

--- a/src/test/csharp/pgadapter_npgsql_tests/npgsql_tests/NpgsqlTest.cs
+++ b/src/test/csharp/pgadapter_npgsql_tests/npgsql_tests/NpgsqlTest.cs
@@ -115,6 +115,29 @@ public class NpgsqlTest
         Console.WriteLine("Success");
     }
 
+    public void TestSelectArray()
+    {
+        using var connection = new NpgsqlConnection(ConnectionString);
+        connection.Open();
+
+        using var cmd = new NpgsqlCommand("SELECT '{1,2}'::bigint[] as c", connection);
+        using (var reader = cmd.ExecuteReader())
+        {
+            while (reader.Read())
+            {
+                var got = reader.GetFieldValue<long?[]>(0);
+                if (got.Length == 2 && got[0] == 1L && got[1] == 2L)
+                {
+                    continue;
+                }
+                
+                Console.WriteLine($"Value mismatch: Got {got}, Want: (1,2)");
+                return;
+            }
+        }
+        Console.WriteLine("Success");
+    }
+
     public void TestQueryWithParameter()
     {
         using var connection = new NpgsqlConnection(ConnectionString);

--- a/src/test/java/com/google/cloud/spanner/pgadapter/csharp/AbstractNpgsqlMockServerTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/csharp/AbstractNpgsqlMockServerTest.java
@@ -155,9 +155,9 @@ public abstract class AbstractNpgsqlMockServerTest extends AbstractMockServerTes
               + "        CASE WHEN elemproc.proname='array_recv' THEN 'a' ELSE elemtyp.typtype END AS elemtyptype\n"
               + "    FROM (\n"
               + "        SELECT typ.oid, typnamespace, typname, typrelid, typnotnull, relkind, typelem AS elemoid,\n"
-              + "            CASE WHEN proc.proname='array_recv' THEN 'a' ELSE typ.typtype END AS typtype,\n"
+              + "            CASE WHEN substr(typ.typname, 1, 1)='_' THEN 'a' ELSE typ.typtype END AS typtype,\n"
               + "            CASE\n"
-              + "                WHEN proc.proname='array_recv' THEN typ.typelem\n"
+              + "                WHEN substr(typ.typname, 1, 1)='_' THEN typ.typelem\n"
               + "                WHEN typ.typtype='r' THEN rngsubtype\n"
               + "                WHEN typ.typtype='m' THEN (SELECT rngtypid FROM pg_range WHERE rngmultitypid = typ.oid)\n"
               + "                WHEN typ.typtype='d' THEN typ.typbasetype\n"
@@ -361,6 +361,142 @@ public abstract class AbstractNpgsqlMockServerTest extends AbstractMockServerTes
                   .addValues(Value.newBuilder().setStringValue("b").build())
                   .addValues(Value.newBuilder().setBoolValue(false).build())
                   .addValues(Value.newBuilder().setNullValue(NullValue.NULL_VALUE).build())
+                  .build())
+          .addRows(
+              ListValue.newBuilder()
+                  .addValues(Value.newBuilder().setStringValue("pg_catalog").build())
+                  .addValues(
+                      Value.newBuilder().setStringValue(String.valueOf(Oid.INT2_ARRAY)).build())
+                  .addValues(Value.newBuilder().setStringValue("_int2").build())
+                  .addValues(Value.newBuilder().setStringValue("a").build())
+                  .addValues(Value.newBuilder().setBoolValue(false).build())
+                  .addValues(Value.newBuilder().setStringValue(String.valueOf(Oid.INT2)).build())
+                  .build())
+          .addRows(
+              ListValue.newBuilder()
+                  .addValues(Value.newBuilder().setStringValue("pg_catalog").build())
+                  .addValues(
+                      Value.newBuilder().setStringValue(String.valueOf(Oid.INT4_ARRAY)).build())
+                  .addValues(Value.newBuilder().setStringValue("_int4").build())
+                  .addValues(Value.newBuilder().setStringValue("a").build())
+                  .addValues(Value.newBuilder().setBoolValue(false).build())
+                  .addValues(Value.newBuilder().setStringValue(String.valueOf(Oid.INT4)).build())
+                  .build())
+          .addRows(
+              ListValue.newBuilder()
+                  .addValues(Value.newBuilder().setStringValue("pg_catalog").build())
+                  .addValues(
+                      Value.newBuilder().setStringValue(String.valueOf(Oid.INT8_ARRAY)).build())
+                  .addValues(Value.newBuilder().setStringValue("_int8").build())
+                  .addValues(Value.newBuilder().setStringValue("a").build())
+                  .addValues(Value.newBuilder().setBoolValue(false).build())
+                  .addValues(Value.newBuilder().setStringValue(String.valueOf(Oid.INT8)).build())
+                  .build())
+          .addRows(
+              ListValue.newBuilder()
+                  .addValues(Value.newBuilder().setStringValue("pg_catalog").build())
+                  .addValues(
+                      Value.newBuilder().setStringValue(String.valueOf(Oid.FLOAT8_ARRAY)).build())
+                  .addValues(Value.newBuilder().setStringValue("_float8").build())
+                  .addValues(Value.newBuilder().setStringValue("a").build())
+                  .addValues(Value.newBuilder().setBoolValue(false).build())
+                  .addValues(Value.newBuilder().setStringValue(String.valueOf(Oid.FLOAT8)).build())
+                  .build())
+          .addRows(
+              ListValue.newBuilder()
+                  .addValues(Value.newBuilder().setStringValue("pg_catalog").build())
+                  .addValues(
+                      Value.newBuilder().setStringValue(String.valueOf(Oid.NUMERIC_ARRAY)).build())
+                  .addValues(Value.newBuilder().setStringValue("_numeric").build())
+                  .addValues(Value.newBuilder().setStringValue("a").build())
+                  .addValues(Value.newBuilder().setBoolValue(false).build())
+                  .addValues(Value.newBuilder().setStringValue(String.valueOf(Oid.NUMERIC)).build())
+                  .build())
+          .addRows(
+              ListValue.newBuilder()
+                  .addValues(Value.newBuilder().setStringValue("pg_catalog").build())
+                  .addValues(
+                      Value.newBuilder().setStringValue(String.valueOf(Oid.TEXT_ARRAY)).build())
+                  .addValues(Value.newBuilder().setStringValue("_text").build())
+                  .addValues(Value.newBuilder().setStringValue("a").build())
+                  .addValues(Value.newBuilder().setBoolValue(false).build())
+                  .addValues(Value.newBuilder().setStringValue(String.valueOf(Oid.TEXT)).build())
+                  .build())
+          .addRows(
+              ListValue.newBuilder()
+                  .addValues(Value.newBuilder().setStringValue("pg_catalog").build())
+                  .addValues(
+                      Value.newBuilder().setStringValue(String.valueOf(Oid.VARCHAR_ARRAY)).build())
+                  .addValues(Value.newBuilder().setStringValue("_varchar").build())
+                  .addValues(Value.newBuilder().setStringValue("a").build())
+                  .addValues(Value.newBuilder().setBoolValue(false).build())
+                  .addValues(Value.newBuilder().setStringValue(String.valueOf(Oid.VARCHAR)).build())
+                  .build())
+          .addRows(
+              ListValue.newBuilder()
+                  .addValues(Value.newBuilder().setStringValue("pg_catalog").build())
+                  .addValues(
+                      Value.newBuilder().setStringValue(String.valueOf(Oid.JSONB_ARRAY)).build())
+                  .addValues(Value.newBuilder().setStringValue("_jsonb").build())
+                  .addValues(Value.newBuilder().setStringValue("a").build())
+                  .addValues(Value.newBuilder().setBoolValue(false).build())
+                  .addValues(Value.newBuilder().setStringValue(String.valueOf(Oid.JSONB)).build())
+                  .build())
+          .addRows(
+              ListValue.newBuilder()
+                  .addValues(Value.newBuilder().setStringValue("pg_catalog").build())
+                  .addValues(
+                      Value.newBuilder()
+                          .setStringValue(String.valueOf(Oid.TIMESTAMP_ARRAY))
+                          .build())
+                  .addValues(Value.newBuilder().setStringValue("_timestamp").build())
+                  .addValues(Value.newBuilder().setStringValue("a").build())
+                  .addValues(Value.newBuilder().setBoolValue(false).build())
+                  .addValues(
+                      Value.newBuilder().setStringValue(String.valueOf(Oid.TIMESTAMP)).build())
+                  .build())
+          .addRows(
+              ListValue.newBuilder()
+                  .addValues(Value.newBuilder().setStringValue("pg_catalog").build())
+                  .addValues(
+                      Value.newBuilder()
+                          .setStringValue(String.valueOf(Oid.TIMESTAMPTZ_ARRAY))
+                          .build())
+                  .addValues(Value.newBuilder().setStringValue("_timestamptz").build())
+                  .addValues(Value.newBuilder().setStringValue("a").build())
+                  .addValues(Value.newBuilder().setBoolValue(false).build())
+                  .addValues(
+                      Value.newBuilder().setStringValue(String.valueOf(Oid.TIMESTAMPTZ)).build())
+                  .build())
+          .addRows(
+              ListValue.newBuilder()
+                  .addValues(Value.newBuilder().setStringValue("pg_catalog").build())
+                  .addValues(
+                      Value.newBuilder().setStringValue(String.valueOf(Oid.DATE_ARRAY)).build())
+                  .addValues(Value.newBuilder().setStringValue("_date").build())
+                  .addValues(Value.newBuilder().setStringValue("a").build())
+                  .addValues(Value.newBuilder().setBoolValue(false).build())
+                  .addValues(Value.newBuilder().setStringValue(String.valueOf(Oid.DATE)).build())
+                  .build())
+          .addRows(
+              ListValue.newBuilder()
+                  .addValues(Value.newBuilder().setStringValue("pg_catalog").build())
+                  .addValues(
+                      Value.newBuilder().setStringValue(String.valueOf(Oid.BOOL_ARRAY)).build())
+                  .addValues(Value.newBuilder().setStringValue("_bool").build())
+                  .addValues(Value.newBuilder().setStringValue("a").build())
+                  .addValues(Value.newBuilder().setBoolValue(false).build())
+                  .addValues(Value.newBuilder().setStringValue(String.valueOf(Oid.BOOL)).build())
+                  .build())
+          .addRows(
+              ListValue.newBuilder()
+                  .addValues(Value.newBuilder().setStringValue("pg_catalog").build())
+                  .addValues(
+                      Value.newBuilder().setStringValue(String.valueOf(Oid.BYTEA_ARRAY)).build())
+                  .addValues(Value.newBuilder().setStringValue("_bytea").build())
+                  .addValues(Value.newBuilder().setStringValue("a").build())
+                  .addValues(Value.newBuilder().setBoolValue(false).build())
+                  .addValues(Value.newBuilder().setStringValue(String.valueOf(Oid.BYTEA)).build())
                   .build())
           .setMetadata(SELECT_TYPES_METADATA)
           .build();

--- a/src/test/java/com/google/cloud/spanner/pgadapter/csharp/ITNpgsqlTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/csharp/ITNpgsqlTest.java
@@ -148,6 +148,12 @@ public class ITNpgsqlTest implements IntegrationTest {
   }
 
   @Test
+  public void testSelectArray() throws IOException, InterruptedException {
+    String result = execute("TestSelectArray", createConnectionString());
+    assertEquals("Success\n", result);
+  }
+
+  @Test
   public void testQueryAllDataTypes() throws IOException, InterruptedException {
     String result = execute("TestQueryAllDataTypes", createConnectionString());
     assertEquals("Success\n", result);


### PR DESCRIPTION
Getting columns with an array type failed when using Npgsql, as Npgsql then tries to execute a pg_catalog query that is not fully supported on Cloud Spanner. This PR introduces a query translation for that.