### PR TITLE
docs: add psycopg3 sample with embedded PGAdapter

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -43,3 +43,7 @@ updates:
     directory: "/samples/java/liquibase"
     schedule:
       interval: "daily"
+  - package-ecosystem: "pip"
+    directory: "/samples/python/psycopg3"
+    schedule:
+      interval: "daily"

--- a/docs/psycopg3.md
+++ b/docs/psycopg3.md
@@ -2,6 +2,12 @@
 
 PGAdapter has experimental support for the [Python psycopg3 driver](https://www.psycopg.org/psycopg3/docs/index.html).
 
+## Sample Application
+
+See this [sample application using psycopg3](../samples/python/psycopg3) for a Python sample
+application that embeds and starts PGAdapter automatically, and then connects to PGAdapter using
+`psycopg3`.
+
 ## Usage
 
 First start PGAdapter:

--- a/samples/python/psycopg3/README.md
+++ b/samples/python/psycopg3/README.md
@@ -1,0 +1,14 @@
+# psycopg3 sample
+
+This sample application shows how to connect to Cloud Spanner through PGAdapter using
+the standard `psycopg3` PostgreSQL driver. PGAdapter is automatically started in a Docker
+container by the sample application.
+
+Run the sample with the following command:
+
+```shell
+python psycopg3_sample-py \
+    -p my-project \
+    -i my-instance \
+    -i my-database
+```

--- a/samples/python/psycopg3/pgadapter.py
+++ b/samples/python/psycopg3/pgadapter.py
@@ -1,0 +1,111 @@
+# Copyright 2023 Google LLC All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Utility for starting and stopping PGAdapter in an embedded container
+
+Defines functions for starting and stopping PGAdapter in an embedded Docker
+container. Requires that Docker is installed on the local system.
+"""
+
+import io
+import json
+import os
+import socket
+import time
+import google.auth
+import google.oauth2.credentials
+import google.oauth2.service_account
+from testcontainers.core.container import DockerContainer
+from testcontainers.core.waiting_utils import wait_for_logs
+
+
+def start_pgadapter(project: str,
+                    instance: str,
+                    credentials: str = None) -> (DockerContainer, str):
+  """Starts PGAdapter in an embedded Docker container
+
+  Starts PGAdapter in an embedded Docker container and returns the TCP port
+  number where PGAdapter is listening for incoming connections. You can Use any
+  standard PostgreSQL driver to connect to this port.
+
+  Parameters
+  ----------
+  project : str
+      The Google Cloud project that PGAdapter should connect to.
+  instance : str
+      The Cloud Spanner instance that PGAdapter should connect to.
+  credentials : str or None
+      The credentials file that PGAdapter should use. If None, then this
+      function will try to load the default credentials from the environment.
+
+  Returns
+  -------
+  container, port : tuple[DockerContainer, str]
+      The Docker container running PGAdapter and
+      the port where PGAdapter is listening. Connect to this port on localhost
+      with a standard PostgreSQL driver to connect to Cloud Spanner.
+  """
+
+  # Start PGAdapter in a Docker container
+  container = DockerContainer("gcr.io/cloud-spanner-pg-adapter/pgadapter") \
+    .with_exposed_ports(5432) \
+    .with_command("   -p " + project
+                  + " -i " + instance
+                  + " -x -c /credentials.json")
+  container.start()
+  # Determine the credentials that should be used by PGAdapter and write these
+  # to a file in the container.
+  credentials_info = _determine_credentials(credentials)
+  container.exec("sh -c 'cat <<EOT >> /credentials.json\n"
+                 + json.dumps(credentials_info, indent=0)
+                 + "\nEOT'")
+  # Wait until PGAdapter has started and is listening on the exposed port.
+  wait_for_logs(container, "PostgreSQL version:")
+  port = container.get_exposed_port("5432")
+  _wait_for_port(port=int(port))
+  return container, port
+
+
+def _determine_credentials(credentials: str):
+  if credentials is None:
+    explicit_file = os.environ.get("GOOGLE_APPLICATION_CREDENTIALS")
+  else:
+    explicit_file = credentials
+  if explicit_file is None:
+    credentials, _ = google.auth.default()
+    if type(credentials).__name__ == \
+       google.oauth2.credentials.Credentials.__name__:
+      info = json.loads(credentials.to_json())
+      info["type"] = "authorized_user"
+    else:
+      raise ValueError("GOOGLE_APPLICATION_CREDENTIALS has not been set "
+                       "and no explicit credentials were supplied")
+  else:
+    with io.open(explicit_file, "r") as file_obj:
+      info = json.load(file_obj)
+  return info
+
+
+def _wait_for_port(port: int, poll_interval: float = 0.1, timeout: float = 5.0):
+  start = time.time()
+  while True:
+    try:
+      with socket.create_connection(("localhost", port), timeout=timeout):
+        break
+    except OSError:
+      duration = time.time() - start
+      if timeout and duration > timeout:
+        raise TimeoutError("container did not listen on port {} in {} seconds"
+                           .format(port, timeout))
+      time.sleep(poll_interval)

--- a/samples/python/psycopg3/psycopg3_sample.py
+++ b/samples/python/psycopg3/psycopg3_sample.py
@@ -1,0 +1,58 @@
+# Copyright 2023 Google LLC All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Sample for connecting to PGAdapter with psycopg3
+
+This sample application shows how to connect to PGAdapter and Cloud Spanner
+using the PostgreSQL psycopg3 driver. The sample starts PGAdapter in an embedded
+Docker container and then connects through this container to Cloud Spanner.
+
+This sample requires Docker to be installed on the local environment.
+
+Usage:
+  python psycopg3_sample.py -p my-project -i my-instance -d my-database
+"""
+
+import argparse
+import psycopg
+from pgadapter import start_pgadapter
+
+
+parser = argparse.ArgumentParser(
+  prog='PGAdapter psycopg3 sample',
+  description='Sample application for using psycopg3 with PGAdapter')
+parser.add_argument('-p', '--project', default="my-project", help="The Google Cloud project containing the Cloud Spanner instance that PGAdapter should connect to.")
+parser.add_argument('-i', '--instance', default="my-instance", help="The Cloud Spanner instance that PGAdapter should connect to.")
+parser.add_argument('-d', '--database', default="my-database", help="The Cloud Spanner database that psycopg3 should connect to.")
+parser.add_argument('-c', '--credentials', required=False, help="The credentials file that PGAdapter should use to connect to Cloud Spanner. If None, then the sample application will try to use the default credentials in the environment.")
+args = parser.parse_args()
+
+# Start PGAdapter in an embedded container.
+container, port = start_pgadapter(args.project, args.instance, args.credentials)
+try:
+  print("PGAdapter running on port ", port, "\n")
+
+  # Connect to Cloud Spanner using psycopg3 by connecting to PGAdapter that is
+  # running in the embedded container.
+  with psycopg.connect("host=localhost port={port} "
+                       "dbname={database} "
+                       "sslmode=disable"
+                       .format(port=port, database=args.database)) as conn:
+    conn.autocommit = True
+    with conn.cursor() as cur:
+      cur.execute("select 'Hello world!' as hello")
+      print("Greeting from Cloud Spanner PostgreSQL:", cur.fetchone()[0], "\n")
+finally:
+  if container is not None:
+    container.stop()

--- a/samples/python/psycopg3/requirements.txt
+++ b/samples/python/psycopg3/requirements.txt
@@ -1,0 +1,3 @@
+psycopg~=3.1.8
+testcontainers~=3.7.1
+google~=3.0.0


### PR DESCRIPTION
Adds a small sample application that shows how to connect to PGAdapter using `psycopg3`. This sample application automatically starts PGAdapter as an embedded test container.