### PR TITLE
fix: close SpannerPool at shutdown

### DIFF
--- a/src/main/java/com/google/cloud/spanner/pgadapter/ProxyServer.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/ProxyServer.java
@@ -19,6 +19,7 @@ import com.google.api.core.InternalApi;
 import com.google.cloud.spanner.ErrorCode;
 import com.google.cloud.spanner.SpannerException;
 import com.google.cloud.spanner.SpannerExceptionFactory;
+import com.google.cloud.spanner.connection.SpannerPool;
 import com.google.cloud.spanner.pgadapter.ConnectionHandler.QueryMode;
 import com.google.cloud.spanner.pgadapter.metadata.OptionsMetadata;
 import com.google.cloud.spanner.pgadapter.metadata.OptionsMetadata.TextFormat;
@@ -202,6 +203,10 @@ public class ProxyServer extends AbstractApiService {
     }
     for (ConnectionHandler handler : getConnectionHandlers()) {
       handler.terminate();
+    }
+    try {
+      SpannerPool.closeSpannerPool();
+    } catch (Throwable ignore) {
     }
     notifyStopped();
   }


### PR DESCRIPTION
The server did not close the Spanner pool when it was gracefully shut down. This caused gRPC channels to remain open when the server was shut down, which again could cause applications to shut down more slowly, as they would wait for the threads that managed those channels to shut down first.