### PR TITLE
test: update psycopg3 savepoint documentation

### DIFF
--- a/src/test/java/com/google/cloud/spanner/pgadapter/python/psycopg3/Psycopg3MockServerTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/python/psycopg3/Psycopg3MockServerTest.java
@@ -1368,7 +1368,6 @@ public class Psycopg3MockServerTest extends AbstractMockServerTest {
   }
 
   @Test
-  @Ignore("Nested transactions are not yet supported")
   public void testNestedTransaction() throws Exception {
     String sql = "SELECT * FROM all_types WHERE col_bigint=$1";
     mockSpanner.putStatementResult(
@@ -1389,7 +1388,34 @@ public class Psycopg3MockServerTest extends AbstractMockServerTest {
             + "col_timestamptz: 2022-02-16 13:18:02.123456+00:00\n"
             + "col_date: 2022-03-29\n"
             + "col_string: test\n"
-            + "col_jsonb: {'key': 'value'}\n",
+            + "col_jsonb: {'key': 'value'}\n"
+            + "col_array_bigint: [1, None, 2]\n"
+            + "col_array_bool: [True, None, False]\n"
+            + "col_array_bytea: [b'bytes1', None, b'bytes2']\n"
+            + "col_array_float8: [3.14, None, -99.99]\n"
+            + "col_array_int: [-100, None, -200]\n"
+            + "col_array_numeric: [Decimal('6.626'), None, Decimal('-3.14')]\n"
+            + "col_array_timestamptz: [datetime.datetime(2022, 2, 16, 16, 18, 2, 123456, tzinfo=<UTC>), None, datetime.datetime(2000, 1, 1, 0, 0, tzinfo=<UTC>)]\n"
+            + "col_array_date: [datetime.date(2023, 2, 20), None, datetime.date(2000, 1, 1)]\n"
+            + "col_array_string: ['string1', None, 'string2']\n"
+            + "col_array_jsonb: [{'key': 'value1'}, None, {'key': 'value2'}]\n",
+        result);
+  }
+
+  @Test
+  public void testRollbackNestedTransaction() throws Exception {
+    String sql = "SELECT * FROM all_types WHERE col_bigint=$1";
+    mockSpanner.putStatementResult(
+        StatementResult.query(
+            Statement.of(sql), ALL_TYPES_RESULTSET.toBuilder().clearRows().build()));
+    mockSpanner.putStatementResult(
+        StatementResult.query(
+            Statement.newBuilder(sql).bind("p1").to(1L).build(), ALL_TYPES_RESULTSET));
+
+    String result = execute("rollback_nested_transaction");
+    assertEquals(
+        "Nested transaction failed with error: Test rollback of savepoint\n"
+            + "Outer transaction failed with error: current transaction is aborted, commands ignored until end of transaction block\n",
         result);
   }
 

--- a/src/test/python/psycopg3/psycopg3_tests.py
+++ b/src/test/python/psycopg3/psycopg3_tests.py
@@ -19,7 +19,8 @@ from decimal import Decimal
 
 import pytz
 import psycopg
-from psycopg import Copy
+from psycopg import Copy, Rollback
+from psycopg.errors import InFailedSqlTransaction
 from psycopg.types.json import Jsonb
 
 
@@ -496,8 +497,6 @@ def named_cursor(conn_string: str):
       print_all_types(row)
 
 
-# This method is currently not being used, as nested transactions are not yet
-# supported.
 def nested_transaction(conn_string: str):
   with psycopg.connect(conn_string) as conn:
     with conn.transaction() as tx1:
@@ -505,6 +504,30 @@ def nested_transaction(conn_string: str):
         row = conn.execute(
           "SELECT * FROM all_types WHERE col_bigint=%s", (1,)).fetchone()
         print_all_types(row)
+
+
+def rollback_nested_transaction(conn_string: str):
+  with psycopg.connect(conn_string) as conn:
+    with conn.transaction():
+      try:
+        with conn.transaction():
+          conn.execute(
+              "SELECT * FROM all_types WHERE col_bigint=%s", (1,)).fetchone()
+          raise ValueError("Test rollback of savepoint")
+        print("Nested transaction succeeded")
+      except ValueError as e:
+        # We should come here, as the inner transaction always raises an error.
+        print("Nested transaction failed with error:", e)
+      # Note that the outer transaction is now invalid, because the
+      # ROLLBACK TO SAVEPOINT statement failed. psycopg3 swallows that error,
+      # which means that we will only know that something went wrong if we try
+      # to use the outer transaction again.
+      try:
+        conn.execute(
+            "SELECT * FROM all_types WHERE col_bigint=%s", (1,)).fetchone()
+      except InFailedSqlTransaction as e:
+        print("Outer transaction failed with error:", e)
+        raise Rollback()
 
 
 def create_batch_insert_values(batch_size: int):


### PR DESCRIPTION
Adds tests and documentation for what happens when using a `SAVEPOINT` with `psycopg3`.