### PR TITLE
deps: pin the SQLAlchemy 2.x version used for tests

### DIFF
--- a/samples/python/sqlalchemy2-sample/requirements.txt
+++ b/samples/python/sqlalchemy2-sample/requirements.txt
@@ -1,3 +1,3 @@
 psycopg~=3.1.8
 pytz~=2022.1
-sqlalchemy~=2.0.1
+sqlalchemy==2.0.7

--- a/src/test/python/sqlalchemy2/requirements.txt
+++ b/src/test/python/sqlalchemy2/requirements.txt
@@ -1,3 +1,3 @@
 psycopg[binary]~=3.1.8
 pytz~=2022.1
-sqlalchemy~=2.0.1
+sqlalchemy==2.0.7


### PR DESCRIPTION
Pin the SQLAlchemy 2.x version used for testing to keep the behavior predictable.