### PR TITLE
test: ignore America/Resolute in random timezone tests

### DIFF
--- a/src/test/java/com/google/cloud/spanner/pgadapter/ITPsqlTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/ITPsqlTest.java
@@ -807,8 +807,10 @@ public class ITPsqlTest implements IntegrationTest {
           ZoneId.of("Asia/Amman"),
           // Iran observed DST in 1978. Not all databases agree on this.
           ZoneId.of("Asia/Tehran"),
-          // Rankin_Inlet did not observer DST in 1970-1979, but not all databases agree.
+          // Rankin_Inlet and Resolute did not observer DST in 1970-1979, but not all databases
+          // agree.
           ZoneId.of("America/Rankin_Inlet"),
+          ZoneId.of("America/Resolute"),
           // Pangnirtung did not observer DST in 1970-1979, but not all databases agree.
           ZoneId.of("America/Pangnirtung"),
           // Niue switched from -11:30 to -11 in 1978. Not all JDKs know that.


### PR DESCRIPTION
Fixes #744 