### PR TITLE
perf: bundle Ready response with the rest

### DIFF
--- a/src/main/java/com/google/cloud/spanner/pgadapter/statements/ExtendedQueryProtocolHandler.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/statements/ExtendedQueryProtocolHandler.java
@@ -16,6 +16,7 @@ package com.google.cloud.spanner.pgadapter.statements;
 
 import com.google.cloud.spanner.pgadapter.ConnectionHandler;
 import com.google.cloud.spanner.pgadapter.error.PGExceptionFactory;
+import com.google.cloud.spanner.pgadapter.wireoutput.ReadyResponse;
 import com.google.cloud.spanner.pgadapter.wireprotocol.AbstractQueryProtocolMessage;
 import com.google.cloud.spanner.pgadapter.wireprotocol.SyncMessage;
 import com.google.common.annotations.VisibleForTesting;
@@ -86,8 +87,8 @@ public class ExtendedQueryProtocolHandler {
    * before sending the wire-protocol responses to the frontend. A flush does not commit the
    * implicit transaction (if any).
    *
-   * <p>This method will execute a {@link #sync()} if it determines that the next message in the
-   * buffer is a Sync message.
+   * <p>This method will execute a {@link #sync(boolean)} if it determines that the next message in
+   * the buffer is a Sync message.
    */
   public void flush() throws Exception {
     if (isExtendedProtocol()) {
@@ -98,7 +99,7 @@ public class ExtendedQueryProtocolHandler {
         // Do a sync instead of a flush, as the next message is a sync. This tells the backend
         // connection that it is safe to for example use a read-only transaction if the buffer only
         // contains queries.
-        sync();
+        sync(false);
       } else {
         internalFlush();
       }
@@ -117,13 +118,17 @@ public class ExtendedQueryProtocolHandler {
    * pending database statements are first executed, before sending the wire-protocol responses to
    * the frontend.
    */
-  public void sync() throws Exception {
+  public void sync(boolean includeReadyResponse) throws Exception {
     backendConnection.sync();
-    flushMessages();
+    flushMessages(includeReadyResponse);
   }
 
   /** Flushes the wire-protocol messages to the frontend. */
   private void flushMessages() throws Exception {
+    flushMessages(false);
+  }
+
+  private void flushMessages(boolean includeReadyResponse) throws Exception {
     try {
       for (AbstractQueryProtocolMessage message : messages) {
         message.flush();
@@ -133,6 +138,12 @@ public class ExtendedQueryProtocolHandler {
       }
       if (Thread.interrupted()) {
         throw PGExceptionFactory.newQueryCancelledException();
+      }
+      if (includeReadyResponse) {
+        new ReadyResponse(
+                connectionHandler.getConnectionMetadata().getOutputStream(),
+                getBackendConnection().getConnectionState().getReadyResponseStatus())
+            .send(false);
       }
     } finally {
       connectionHandler.getConnectionMetadata().getOutputStream().flush();

--- a/src/main/java/com/google/cloud/spanner/pgadapter/wireprotocol/SyncMessage.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/wireprotocol/SyncMessage.java
@@ -16,7 +16,6 @@ package com.google.cloud.spanner.pgadapter.wireprotocol;
 
 import com.google.api.core.InternalApi;
 import com.google.cloud.spanner.pgadapter.ConnectionHandler;
-import com.google.cloud.spanner.pgadapter.wireoutput.ReadyResponse;
 import java.text.MessageFormat;
 
 /**
@@ -38,15 +37,7 @@ public class SyncMessage extends ControlMessage {
 
   @Override
   protected void sendPayload() throws Exception {
-    connection.getExtendedQueryProtocolHandler().sync();
-    new ReadyResponse(
-            this.outputStream,
-            connection
-                .getExtendedQueryProtocolHandler()
-                .getBackendConnection()
-                .getConnectionState()
-                .getReadyResponseStatus())
-        .send();
+    connection.getExtendedQueryProtocolHandler().sync(true);
   }
 
   @Override

--- a/src/test/java/com/google/cloud/spanner/pgadapter/statements/ExtendedQueryProtocolHandlerTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/statements/ExtendedQueryProtocolHandlerTest.java
@@ -116,7 +116,7 @@ public class ExtendedQueryProtocolHandlerTest {
         ImmutableList.of(parseMessage, bindMessage, describeMessage, executeMessage),
         handler.getMessages());
 
-    handler.sync();
+    handler.sync(false);
 
     assertEquals(0, handler.getMessages().size());
     verify(backendConnection, never()).flush();
@@ -139,7 +139,7 @@ public class ExtendedQueryProtocolHandlerTest {
     handler.buffer(parseMessage);
 
     Thread.currentThread().interrupt();
-    PGException exception = assertThrows(PGException.class, handler::sync);
+    PGException exception = assertThrows(PGException.class, () -> handler.sync(false));
     assertEquals("Query cancelled", exception.getMessage());
     assertEquals(SQLState.QueryCanceled, exception.getSQLState());
   }

--- a/src/test/java/com/google/cloud/spanner/pgadapter/wireprotocol/ProtocolTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/wireprotocol/ProtocolTest.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doCallRealMethod;
@@ -156,7 +157,6 @@ public class ProtocolTest {
     when(connectionHandler.getExtendedQueryProtocolHandler())
         .thenReturn(extendedQueryProtocolHandler);
     when(extendedQueryProtocolHandler.getBackendConnection()).thenReturn(backendConnection);
-    when(backendConnection.getConnectionState()).thenReturn(ConnectionState.IDLE);
     when(connectionHandler.getStatement("")).thenReturn(intermediatePortalStatement);
     when(connectionHandler.getPortal("")).thenReturn(intermediatePortalStatement);
     when(connectionMetadata.getInputStream()).thenReturn(inputStream);
@@ -1098,13 +1098,14 @@ public class ProtocolTest {
     ByteArrayOutputStream result = new ByteArrayOutputStream();
     DataOutputStream outputStream = new DataOutputStream(result);
 
+    ExtendedQueryProtocolHandler extendedQueryProtocolHandler =
+        new ExtendedQueryProtocolHandler(connectionHandler, backendConnection);
     when(connectionHandler.getStatus()).thenReturn(ConnectionStatus.AUTHENTICATED);
     when(connectionHandler.getConnectionMetadata()).thenReturn(connectionMetadata);
     when(connectionMetadata.getInputStream()).thenReturn(inputStream);
     when(connectionMetadata.getOutputStream()).thenReturn(outputStream);
     when(connectionHandler.getExtendedQueryProtocolHandler())
         .thenReturn(extendedQueryProtocolHandler);
-    when(extendedQueryProtocolHandler.getBackendConnection()).thenReturn(backendConnection);
     when(backendConnection.getConnectionState()).thenReturn(ConnectionState.IDLE);
 
     WireMessage message = ControlMessage.create(connectionHandler);
@@ -1131,13 +1132,14 @@ public class ProtocolTest {
     ByteArrayOutputStream result = new ByteArrayOutputStream();
     DataOutputStream outputStream = new DataOutputStream(result);
 
+    ExtendedQueryProtocolHandler extendedQueryProtocolHandler =
+        new ExtendedQueryProtocolHandler(connectionHandler, backendConnection);
     when(connectionHandler.getStatus()).thenReturn(ConnectionStatus.AUTHENTICATED);
     when(connectionHandler.getConnectionMetadata()).thenReturn(connectionMetadata);
     when(connectionMetadata.getInputStream()).thenReturn(inputStream);
     when(connectionMetadata.getOutputStream()).thenReturn(outputStream);
     when(connectionHandler.getExtendedQueryProtocolHandler())
         .thenReturn(extendedQueryProtocolHandler);
-    when(extendedQueryProtocolHandler.getBackendConnection()).thenReturn(backendConnection);
     when(backendConnection.getConnectionState()).thenReturn(ConnectionState.TRANSACTION);
 
     WireMessage message = ControlMessage.create(connectionHandler);
@@ -1175,7 +1177,7 @@ public class ProtocolTest {
     message.send();
 
     verify(extendedQueryProtocolHandler).flush();
-    verify(extendedQueryProtocolHandler, never()).sync();
+    verify(extendedQueryProtocolHandler, never()).sync(anyBoolean());
   }
 
   @Test
@@ -1201,7 +1203,7 @@ public class ProtocolTest {
     message.send();
 
     verify(extendedQueryProtocolHandler).flush();
-    verify(extendedQueryProtocolHandler, never()).sync();
+    verify(extendedQueryProtocolHandler, never()).sync(anyBoolean());
   }
 
   @Test


### PR DESCRIPTION
Bundle the ReadyResponse with the rest of the response when we receive a Sync message. This reduces the number of network packages that are sent between the client and the server.