### PR TITLE
fix: latency benchmark should use random local port

### DIFF
--- a/benchmarks/latency-comparison/java/src/main/java/com/google/cloud/spanner/pgadapter/latency/LatencyBenchmark.java
+++ b/benchmarks/latency-comparison/java/src/main/java/com/google/cloud/spanner/pgadapter/latency/LatencyBenchmark.java
@@ -79,7 +79,7 @@ public class LatencyBenchmark {
 
     System.out.println();
     System.out.println("Running benchmark for PostgreSQL JDBC driver");
-    JdbcRunner pgJdbcRunner = new JdbcRunner(databaseId);
+    PgJdbcRunner pgJdbcRunner = new PgJdbcRunner(databaseId);
     List<Duration> pgJdbcResults =
         pgJdbcRunner.execute(
             "select col_varchar from latency_test where col_bigint=?", clients, operations);

--- a/benchmarks/latency-comparison/java/src/main/java/com/google/cloud/spanner/pgadapter/latency/PgJdbcRunner.java
+++ b/benchmarks/latency-comparison/java/src/main/java/com/google/cloud/spanner/pgadapter/latency/PgJdbcRunner.java
@@ -20,6 +20,9 @@ import com.google.cloud.spanner.pgadapter.ProxyServer;
 import com.google.cloud.spanner.pgadapter.metadata.OptionsMetadata;
 import java.time.Duration;
 import java.util.List;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 public class PgJdbcRunner extends AbstractJdbcRunner {
   private ProxyServer proxyServer;
@@ -30,12 +33,19 @@ public class PgJdbcRunner extends AbstractJdbcRunner {
 
   @Override
   public List<Duration> execute(String sql, int numClients, int numOperations) {
+    // Silence the PGAdapter logging.
+    Logger root = Logger.getLogger("");
+    root.setLevel(Level.WARNING);
+    for (Handler handler : root.getHandlers()) {
+      handler.setLevel(Level.WARNING);
+    }
     // Start PGAdapter in-process.
     OptionsMetadata options =
         new OptionsMetadata(
             new String[] {
               "-p", databaseId.getInstanceId().getProject(),
-              "-i", databaseId.getInstanceId().getInstance()
+              "-i", databaseId.getInstanceId().getInstance(),
+              "-dir=", "-s=0"
             });
     proxyServer = new ProxyServer(options);
     try {


### PR DESCRIPTION
The JDBC latency benchmark for PostgreSQL should use a randomly assigned local port. In addition, the comparison app did not run the PG benchmark.

This PR also silences the PGAdapter log so the output is not cluttered by unnecessary log lines from PGAdapter.