### PR TITLE
docs: add sample for Node.js with Cloud Run

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,9 @@ src/test/csharp/**/obj
 src/test/nodejs/**/node_modules
 src/test/nodejs/**/package-lock.json
 src/test/nodejs/**/.DS_Store
+samples/nodejs/**/node_modules
+samples/nodejs/**/package-lock.json
+samples/nodejs/**/.DS_Store
 
 src/test/ruby/**/Gemfile.lock
 samples/ruby/**/Gemfile.lock

--- a/samples/nodejs/cloud-run/.dockerignore
+++ b/samples/nodejs/cloud-run/.dockerignore
@@ -1,0 +1,3 @@
+Dockerfile
+node_modules
+npm-debug.log

--- a/samples/nodejs/cloud-run/.gcloudignore
+++ b/samples/nodejs/cloud-run/.gcloudignore
@@ -1,0 +1,2 @@
+node_modules
+npm-debug.log

--- a/samples/nodejs/cloud-run/Dockerfile
+++ b/samples/nodejs/cloud-run/Dockerfile
@@ -1,0 +1,54 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Start with a Docker image that includes a JRE. This is needed for PGAdapter.
+FROM eclipse-temurin:17-jre AS jre
+
+# Use the official lightweight Node.js image.
+# https://hub.docker.com/_/node
+FROM node:18-slim
+
+# Copy the JRE into the Node.js image.
+ENV JAVA_HOME=/opt/java/openjdk
+COPY --from=jre $JAVA_HOME $JAVA_HOME
+ENV PATH="${JAVA_HOME}/bin:${PATH}"
+
+# Create and change to the app directory.
+WORKDIR /usr/src/app
+
+# Copy application dependency manifests to the container image.
+# A wildcard is used to ensure copying both package.json AND package-lock.json (when available).
+# Copying this first prevents re-running npm install on every code change.
+COPY package*.json ./
+
+# Install production dependencies.
+# If you add a package-lock.json, speed your build by switching to 'npm ci'.
+# RUN npm ci --only=production
+RUN npm install --only=production
+
+# Copy local code to the container image.
+COPY . ./
+
+# Add the latest version of PGAdapter to the container.
+ADD https://storage.googleapis.com/pgadapter-jar-releases/pgadapter.tar.gz /pgadapter.tar.gz
+RUN mkdir /pgadapter
+RUN tar -xzf /pgadapter.tar.gz -C /pgadapter
+
+# Copy the startup script that will start both PGAdapter and the web service.
+COPY ./startup.sh /startup.sh
+RUN chmod +x /startup.sh
+
+# Set an ENTRYPOINT for the container.
+# The `startup.sh` file will start both PGAdapter and the web service.
+ENTRYPOINT ["/bin/bash", "/startup.sh"]

--- a/samples/nodejs/cloud-run/README.md
+++ b/samples/nodejs/cloud-run/README.md
@@ -1,0 +1,77 @@
+# PGAdapter Cloud Run Sample for Node.js
+
+This sample application shows how to build and deploy a Node.js application with PGAdapter to Google Cloud Run.
+
+## Build
+
+First build the Docker image locally and tag it. Replace the `IMAGE_URL` in the script with your own repository.
+Make sure that the repository that you are referencing exists.
+See https://cloud.google.com/artifact-registry/docs/repositories/create-repos for more information on how to set up
+Google Cloud artifact repositories.
+
+```shell
+export IMAGE_URL=my-location-docker.pkg.dev/my-project/my-repository/my-image:latest
+docker build . --tag $IMAGE_URL
+```
+
+Example: `export IMAGE_URL=europe-north1-docker.pkg.dev/my-project/sample-test/pgadapter-sample:latest`
+
+Test the Docker image locally:
+
+```shell
+docker run \
+  -p 8080:8080 \
+  -v /path/to/local_credentials.json:/credentials.json:ro \
+  --env GOOGLE_APPLICATION_CREDENTIALS=/credentials.json \
+  --env SPANNER_PROJECT=my-project \
+  --env SPANNER_INSTANCE=my-instance \
+  --env SPANNER_DATABASE=my-database \
+  $IMAGE_URL
+```
+
+Verify that the connection to Cloud Spanner works correctly by opening a new shell and executing:
+
+```shell
+curl http://localhost:8080
+```
+
+## Deploying to Cloud Run
+
+Push the Docker image to Artifact Registry:
+
+```shell
+gcloud auth configure-docker
+docker push $IMAGE_URL
+```
+
+Then deploy the image as a service on Cloud Run:
+
+```shell
+export SERVICE=my-service
+gcloud run deploy $SERVICE \
+  --image $IMAGE_URL \
+  --update-env-vars SPANNER_PROJECT=my-project,SPANNER_INSTANCE=my-instance,SPANNER_DATABASE=my-database
+```
+
+__NOTE__: This example does not specify any credentials for PGAdapter when it is run on Cloud Run. This means that
+PGAdapter will use the default credentials that is used by Cloud Run. This is by default the default compute engine
+service account. See https://cloud.google.com/run/docs/securing/service-identity for more information on how service
+accounts work on Google Cloud Run.
+
+Test the service (replace URL with your actual service URL):
+
+```shell
+curl https://my-service-xyz.run.app
+```
+
+### Authenticated Cloud Run Service
+
+If your Cloud Run service requires authentication, then first add an IAM binding for your own account and include
+an authentication header with the request:
+
+```shell
+gcloud run services add-iam-policy-binding $SERVICE \
+  --member='user:your-email@gmail.com' \
+  --role='roles/run.invoker'
+curl -H "Authorization: Bearer $(gcloud auth print-identity-token)" https://my-service-xyz.run.app
+```

--- a/samples/nodejs/cloud-run/index.js
+++ b/samples/nodejs/cloud-run/index.js
@@ -1,0 +1,20 @@
+const express = require('express');
+const { Client } = require('pg');
+const app = express();
+const client = new Client({
+  host: 'localhost',
+  port: 5432,
+  database: `projects/${process.env.SPANNER_PROJECT}/instances/${process.env.SPANNER_INSTANCE}/databases/${process.env.SPANNER_DATABASE}`,
+});
+const port = parseInt(process.env.PORT) || 8080;
+
+client.connect().then(() => {
+  app.listen(port, () => {
+    console.log(`helloworld: listening on port ${port}`);
+  });
+});
+
+app.get('/', async (req, res) => {
+  const greeting = await client.query("select 'Hello world! from Cloud Spanner PostgreSQL' as hello");
+  res.send(greeting.rows[0].hello + '\n');
+});

--- a/samples/nodejs/cloud-run/index.js
+++ b/samples/nodejs/cloud-run/index.js
@@ -15,6 +15,7 @@ client.connect().then(() => {
 });
 
 app.get('/', async (req, res) => {
+  // Execute a query on Cloud Spanner that returns a greeting and return that to the user.
   const greeting = await client.query("select 'Hello world! from Cloud Spanner PostgreSQL' as hello");
   res.send(greeting.rows[0].hello + '\n');
 });

--- a/samples/nodejs/cloud-run/package.json
+++ b/samples/nodejs/cloud-run/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "helloworld",
+  "description": "PGAdapter Hello world sample in Node",
+  "version": "1.0.0",
+  "private": true,
+  "main": "index.js",
+  "scripts": {
+    "start": "node index.js"
+  },
+  "engines": {
+    "node": ">=12.0.0"
+  },
+  "author": "Google LLC",
+  "license": "Apache-2.0",
+  "dependencies": {
+    "express": "^4.17.1",
+    "pg": "^8.11.0"
+  }
+}

--- a/samples/nodejs/cloud-run/startup.sh
+++ b/samples/nodejs/cloud-run/startup.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# Run both PGAdapter and the web server when the Docker container is started.
+# Start PGAdapter in plain TCP only mode, that is:
+# 1. Do not specify any credentials. This will make sure PGAdapter picks the credentials from the current environment.
+#    You must ensure that the service account that is used by Cloud Run is allowed to access the Cloud Spanner database
+#    that your application is using.
+# 2. Do not specify any specific project, instance or database. This will require the application to specify a fully
+#    qualified database name when connecting to PGAdapter.
+# 3. Set the Unix domain socket directory to the empty string to disable domain sockets. Domain sockets are not
+#    supported on Cloud Run.
+
+# Start PGAdapter in the background.
+java -jar /pgadapter/pgadapter.jar -dir= &
+# Give PGAdapter a second to start up.
+sleep 1
+
+# Run the web service on container startup.
+node index.js


### PR DESCRIPTION
Adds a sample for creating and deploying an application with Node.js and PGAdapter to Cloud Run.