### PR TITLE
docs: Go sample equal to the other samples

### DIFF
--- a/samples/golang/cloud-run/Dockerfile
+++ b/samples/golang/cloud-run/Dockerfile
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Start with a Docker image that includes a JRE. This is needed for PGAdapter.
+FROM eclipse-temurin:17-jre AS jre
+
 # Use the offical golang image to create a binary.
 # This is based on Debian and sets the GOPATH to /go.
 # https://hub.docker.com/_/golang
@@ -32,12 +35,28 @@ COPY . ./
 # Build the binary.
 RUN go build -v -o server
 
-# Create the application image based on the PGAdapter Docker image.
-# This will include PGAdapter and all its dependencies in the Docker image.
-FROM gcr.io/cloud-spanner-pg-adapter/pgadapter
+## Create the application image based on the PGAdapter Docker image.
+## This will include PGAdapter and all its dependencies in the Docker image.
+#FROM gcr.io/cloud-spanner-pg-adapter/pgadapter
+
+# Use the official Debian slim image for a lean production container.
+# https://hub.docker.com/_/debian
+# https://docs.docker.com/develop/develop-images/multistage-build/#use-multi-stage-builds
+FROM debian:buster-slim
+
+# Copy the JRE into the Node.js image.
+ENV JAVA_HOME=/opt/java/openjdk
+COPY --from=jre $JAVA_HOME $JAVA_HOME
+ENV PATH="${JAVA_HOME}/bin:${PATH}"
 
 # Copy the app-server binary to the production image from the builder stage.
 COPY --from=builder /app/server /app/server
+
+# Add the latest version of PGAdapter to the container.
+ADD https://storage.googleapis.com/pgadapter-jar-releases/pgadapter.tar.gz /pgadapter.tar.gz
+RUN mkdir /pgadapter
+RUN tar -xzf /pgadapter.tar.gz -C /pgadapter
+
 # Copy the startup script that will start both PGAdapter and the app-server.
 COPY ./startup.sh /startup.sh
 RUN chmod +x /startup.sh

--- a/samples/golang/cloud-run/Dockerfile
+++ b/samples/golang/cloud-run/Dockerfile
@@ -35,10 +35,6 @@ COPY . ./
 # Build the binary.
 RUN go build -v -o server
 
-## Create the application image based on the PGAdapter Docker image.
-## This will include PGAdapter and all its dependencies in the Docker image.
-#FROM gcr.io/cloud-spanner-pg-adapter/pgadapter
-
 # Use the official Debian slim image for a lean production container.
 # https://hub.docker.com/_/debian
 # https://docs.docker.com/develop/develop-images/multistage-build/#use-multi-stage-builds

--- a/samples/golang/cloud-run/startup.sh
+++ b/samples/golang/cloud-run/startup.sh
@@ -11,7 +11,7 @@
 #    supported on Cloud Run.
 
 # Start PGAdapter in the background.
-java -jar /home/pgadapter/pgadapter.jar -dir= &
+java -jar /pgadapter/pgadapter.jar -dir= &
 
 # Start the app server as the main application of the Docker container.
 exec "/app/server"


### PR DESCRIPTION
Make the Golang Cloud Run sample work in the same way as the other non-Java samples.