### PR TITLE
feat: support replacement of DDL statements

### DIFF
--- a/src/main/java/com/google/cloud/spanner/pgadapter/statements/BackendConnection.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/statements/BackendConnection.java
@@ -737,7 +737,8 @@ public class BackendConnection {
             () -> new PgCatalog(BackendConnection.this.sessionState, wellKnownClient.get()));
     this.spannerConnection = spannerConnection;
     this.databaseId = databaseId;
-    this.ddlExecutor = new DdlExecutor(this);
+    this.ddlExecutor =
+        new DdlExecutor(this, Suppliers.memoize(() -> wellKnownClient.get().getDdlReplacements()));
     this.localStatements =
         Suppliers.memoize(
             () -> {

--- a/src/main/java/com/google/cloud/spanner/pgadapter/statements/DdlExecutor.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/statements/DdlExecutor.java
@@ -24,6 +24,7 @@ import com.google.cloud.spanner.connection.StatementResult;
 import com.google.cloud.spanner.pgadapter.statements.SimpleParser.TableOrIndexName;
 import com.google.cloud.spanner.pgadapter.utils.QueryPartReplacer;
 import com.google.cloud.spanner.pgadapter.utils.QueryPartReplacer.ReplacementStatus;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import java.util.function.Supplier;
 
@@ -75,7 +76,8 @@ class DdlExecutor {
     return connection.execute(translate(parsedStatement, statement));
   }
 
-  private String applyReplacers(String sql) {
+  @VisibleForTesting
+  String applyReplacers(String sql) {
     for (QueryPartReplacer functionReplacement : ddlStatementReplacements.get()) {
       Tuple<String, ReplacementStatus> result = functionReplacement.replace(sql);
       if (result.y() == ReplacementStatus.STOP) {

--- a/src/main/java/com/google/cloud/spanner/pgadapter/statements/DdlExecutor.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/statements/DdlExecutor.java
@@ -14,6 +14,7 @@
 
 package com.google.cloud.spanner.pgadapter.statements;
 
+import com.google.cloud.Tuple;
 import com.google.cloud.spanner.Dialect;
 import com.google.cloud.spanner.Statement;
 import com.google.cloud.spanner.connection.AbstractStatementParser;
@@ -21,6 +22,10 @@ import com.google.cloud.spanner.connection.AbstractStatementParser.ParsedStateme
 import com.google.cloud.spanner.connection.Connection;
 import com.google.cloud.spanner.connection.StatementResult;
 import com.google.cloud.spanner.pgadapter.statements.SimpleParser.TableOrIndexName;
+import com.google.cloud.spanner.pgadapter.utils.QueryPartReplacer;
+import com.google.cloud.spanner.pgadapter.utils.QueryPartReplacer.ReplacementStatus;
+import com.google.common.collect.ImmutableList;
+import java.util.function.Supplier;
 
 /**
  * {@link DdlExecutor} inspects DDL statements before executing these to support commonly used DDL
@@ -30,11 +35,14 @@ class DdlExecutor {
 
   private final BackendConnection backendConnection;
   private final Connection connection;
+  private final Supplier<ImmutableList<QueryPartReplacer>> ddlStatementReplacements;
+
 
   /** Constructor for a {@link DdlExecutor} for the given connection. */
-  DdlExecutor(BackendConnection backendConnection) {
+  DdlExecutor(BackendConnection backendConnection, Supplier<ImmutableList<QueryPartReplacer>> ddlStatementReplacements) {
     this.backendConnection = backendConnection;
     this.connection = backendConnection.getSpannerConnection();
+    this.ddlStatementReplacements = ddlStatementReplacements;
   }
 
   /**
@@ -56,9 +64,27 @@ class DdlExecutor {
    * make the statement compatible with Cloud Spanner.
    */
   StatementResult execute(ParsedStatement parsedStatement, Statement statement) {
+    if (!ddlStatementReplacements.get().isEmpty()) {
+      String replaced = applyReplacers(statement.getSql());
+      if (!replaced.equals(statement.getSql())) {
+        statement = Statement.of(replaced);
+        parsedStatement = AbstractStatementParser.getInstance(Dialect.POSTGRESQL).parse(statement);
+      }
+    }
     return connection.execute(translate(parsedStatement, statement));
   }
-
+  
+  private String applyReplacers(String sql) {
+    for (QueryPartReplacer functionReplacement : ddlStatementReplacements.get()) {
+      Tuple<String, ReplacementStatus> result = functionReplacement.replace(sql);
+      if (result.y() == ReplacementStatus.STOP) {
+        return result.x();
+      }
+      sql = result.x();
+    }
+    return sql;
+  }
+  
   /**
    * Translates a DDL statement that can contain 'create table' statement with a named primary key
    * into one that is supported by the backend.

--- a/src/main/java/com/google/cloud/spanner/pgadapter/statements/DdlExecutor.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/statements/DdlExecutor.java
@@ -37,9 +37,10 @@ class DdlExecutor {
   private final Connection connection;
   private final Supplier<ImmutableList<QueryPartReplacer>> ddlStatementReplacements;
 
-
   /** Constructor for a {@link DdlExecutor} for the given connection. */
-  DdlExecutor(BackendConnection backendConnection, Supplier<ImmutableList<QueryPartReplacer>> ddlStatementReplacements) {
+  DdlExecutor(
+      BackendConnection backendConnection,
+      Supplier<ImmutableList<QueryPartReplacer>> ddlStatementReplacements) {
     this.backendConnection = backendConnection;
     this.connection = backendConnection.getSpannerConnection();
     this.ddlStatementReplacements = ddlStatementReplacements;
@@ -73,7 +74,7 @@ class DdlExecutor {
     }
     return connection.execute(translate(parsedStatement, statement));
   }
-  
+
   private String applyReplacers(String sql) {
     for (QueryPartReplacer functionReplacement : ddlStatementReplacements.get()) {
       Tuple<String, ReplacementStatus> result = functionReplacement.replace(sql);
@@ -84,7 +85,7 @@ class DdlExecutor {
     }
     return sql;
   }
-  
+
   /**
    * Translates a DDL statement that can contain 'create table' statement with a named primary key
    * into one that is supported by the backend.

--- a/src/main/java/com/google/cloud/spanner/pgadapter/utils/ClientAutoDetector.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/utils/ClientAutoDetector.java
@@ -318,10 +318,10 @@ public class ClientAutoDetector {
                     "CREATE\\s+TABLE\\s+(?:.*\\.)?databasechangeloglock\\s*\\(\\s*"
                         + "ID\\s+INTEGER\\s+NOT\\s+NULL\\s*,\\s*"
                         + "LOCKED\\s+BOOLEAN\\s+NOT\\s+NULL\\s*,\\s*"
-                        + "LOCKGRANTED\\s+TIMESTAMP\\s*,\\s*"
+                        + "LOCKGRANTED\\s+TIMESTAMP\\s+WITHOUT\\s+TIME\\s+ZONE\\s*,\\s*"
                         + "LOCKEDBY\\s+VARCHAR\\s*\\(255\\)\\s*,\\s*"
-                        + "PRIMARY\\s+KEY\\s*\\(ID\\)\\s*"
-                        + "\\s*\\)\\s*",
+                        + "CONSTRAINT\\s*databasechangeloglock_pkey\\s*PRIMARY\\s+KEY\\s*\\(ID\\)\\s*\\s*"
+                        + "\\)\\s*",
                     Pattern.CASE_INSENSITIVE),
                 "CREATE TABLE databasechangeloglock (\n"
                     + "    ID INTEGER NOT NULL,\n"

--- a/src/main/java/com/google/cloud/spanner/pgadapter/utils/ClientAutoDetector.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/utils/ClientAutoDetector.java
@@ -308,6 +308,63 @@ public class ClientAutoDetector {
         return ImmutableMap.of(
             "spanner.guess_types", String.format("%d,%d", Oid.TIMESTAMPTZ, Oid.DATE));
       }
+
+      @Override
+      public ImmutableList<QueryPartReplacer> getDdlReplacements() {
+        // Replace known metadata tables for Liquibase.
+        return ImmutableList.of(
+            RegexQueryPartReplacer.replace(
+                Pattern.compile(
+                    "CREATE\\s+TABLE\\s+(?:.*\\.)?databasechangeloglock\\s*\\(\\s*"
+                        + "ID\\s+INTEGER\\s+NOT\\s+NULL\\s*,\\s*"
+                        + "LOCKED\\s+BOOLEAN\\s+NOT\\s+NULL\\s*,\\s*"
+                        + "LOCKGRANTED\\s+TIMESTAMP\\s*,\\s*"
+                        + "LOCKEDBY\\s+VARCHAR\\s*\\(255\\)\\s*,\\s*"
+                        + "PRIMARY\\s+KEY\\s*\\(ID\\)\\s*"
+                        + "\\s*\\)\\s*",
+                    Pattern.CASE_INSENSITIVE),
+                "CREATE TABLE databasechangeloglock (\n"
+                    + "    ID INTEGER NOT NULL,\n"
+                    + "    LOCKED BOOLEAN NOT NULL,\n"
+                    + "    LOCKGRANTED TIMESTAMPTZ,\n"
+                    + "    LOCKEDBY VARCHAR(255),\n"
+                    + "    PRIMARY KEY (ID)\n"
+                    + ")"),
+            RegexQueryPartReplacer.replace(
+                Pattern.compile(
+                    "CREATE\\s+TABLE\\s+(?:.*\\.)?databasechangelog\\s*\\(\\s*"
+                        + "ID\\s+VARCHAR\\s*\\(255\\)\\s*NOT\\s+NULL\\s*,\\s*"
+                        + "AUTHOR\\s+VARCHAR\\s*\\(255\\)\\s*NOT\\s+NULL\\s*,\\s*"
+                        + "FILENAME\\s+VARCHAR\\s*\\(255\\)\\s*NOT\\s+NULL\\s*,\\s*"
+                        + "DATEEXECUTED\\s+TIMESTAMP(?:.*)?\\s+NOT\\s+NULL\\s*,\\s*"
+                        + "ORDEREXECUTED\\s+INTEGER\\s+NOT\\s+NULL\\s*,\\s*"
+                        + "EXECTYPE\\s+VARCHAR\\s*\\(10\\)\\s*NOT\\s+NULL\\s*,\\s*"
+                        + "MD5SUM\\s+VARCHAR\\s*\\(35\\)\\s*,\\s*"
+                        + "DESCRIPTION\\s+VARCHAR\\s*\\(255\\)\\s*,\\s*"
+                        + "COMMENTS\\s+VARCHAR\\s*\\(255\\)\\s*,\\s*"
+                        + "TAG\\s+VARCHAR\\s*\\(255\\)\\s*,\\s*"
+                        + "LIQUIBASE\\s+VARCHAR\\s*\\(20\\)\\s*,\\s*"
+                        + "CONTEXTS\\s+VARCHAR\\s*\\(255\\)\\s*,\\s*"
+                        + "LABELS\\s+VARCHAR\\s*\\(255\\)\\s*,\\s*"
+                        + "DEPLOYMENT_ID\\s+VARCHAR\\s*\\(10\\)\\s*"
+                        + "\\)\\s*"),
+                "CREATE TABLE databasechangelog (\n"
+                    + "    ID VARCHAR(255) NOT NULL PRIMARY KEY,\n"
+                    + "    AUTHOR VARCHAR(255) NOT NULL,\n"
+                    + "    FILENAME VARCHAR(255) NOT NULL,\n"
+                    + "    DATEEXECUTED TIMESTAMPTZ NOT NULL,\n"
+                    + "    ORDEREXECUTED INTEGER NOT NULL,\n"
+                    + "    EXECTYPE VARCHAR(10) NOT NULL,\n"
+                    + "    MD5SUM VARCHAR(35),\n"
+                    + "    DESCRIPTION VARCHAR(255),\n"
+                    + "    COMMENTS VARCHAR(255),\n"
+                    + "    TAG VARCHAR(255),\n"
+                    + "    LIQUIBASE VARCHAR(20),\n"
+                    + "    CONTEXTS VARCHAR(255),\n"
+                    + "    LABELS VARCHAR(255),\n"
+                    + "    DEPLOYMENT_ID VARCHAR(10)\n"
+                    + ")"));
+      }
     },
     PGX {
       @Override
@@ -470,7 +527,11 @@ public class ClientAutoDetector {
     public ImmutableList<QueryPartReplacer> getQueryPartReplacements() {
       return ImmutableList.of();
     }
-
+    
+    public ImmutableList<QueryPartReplacer> getDdlReplacements() {
+      return ImmutableList.of();
+    }
+    
     /** Creates specific notice messages for a client after startup. */
     public ImmutableList<NoticeResponse> createStartupNoticeResponses(
         ConnectionHandler connection) {

--- a/src/main/java/com/google/cloud/spanner/pgadapter/utils/ClientAutoDetector.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/utils/ClientAutoDetector.java
@@ -527,11 +527,11 @@ public class ClientAutoDetector {
     public ImmutableList<QueryPartReplacer> getQueryPartReplacements() {
       return ImmutableList.of();
     }
-    
+
     public ImmutableList<QueryPartReplacer> getDdlReplacements() {
       return ImmutableList.of();
     }
-    
+
     /** Creates specific notice messages for a client after startup. */
     public ImmutableList<NoticeResponse> createStartupNoticeResponses(
         ConnectionHandler connection) {

--- a/src/test/java/com/google/cloud/spanner/pgadapter/liquibase/ITLiquibaseTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/liquibase/ITLiquibaseTest.java
@@ -64,26 +64,26 @@ public class ITLiquibaseTest {
     database = testEnv.createDatabase(ImmutableList.of());
     testEnv.startPGAdapterServer(ImmutableList.of());
     // Create databasechangelog and databasechangeloglock tables.
-    StringBuilder builder = new StringBuilder();
-    try (Scanner scanner = new Scanner(new FileReader(LIQUIBASE_DB_CHANGELOG_DDL_FILE))) {
-      while (scanner.hasNextLine()) {
-        builder.append(scanner.nextLine()).append("\n");
-      }
-    }
-    // Note: We know that all semicolons in this file are outside of literals etc.
-    String[] ddl = builder.toString().split(";");
-    String url =
-        String.format(
-            "jdbc:postgresql://localhost:%d/%s?options=-c%%20spanner.ddl_transaction_mode=AutocommitExplicitTransaction",
-            testEnv.getPGAdapterPort(), database.getId().getDatabase());
-    try (Connection connection = DriverManager.getConnection(url)) {
-      try (Statement statement = connection.createStatement()) {
-        for (String sql : ddl) {
-          LOGGER.info("Executing " + sql);
-          statement.execute(sql);
-        }
-      }
-    }
+//    StringBuilder builder = new StringBuilder();
+//    try (Scanner scanner = new Scanner(new FileReader(LIQUIBASE_DB_CHANGELOG_DDL_FILE))) {
+//      while (scanner.hasNextLine()) {
+//        builder.append(scanner.nextLine()).append("\n");
+//      }
+//    }
+//    // Note: We know that all semicolons in this file are outside of literals etc.
+//    String[] ddl = builder.toString().split(";");
+//    String url =
+//        String.format(
+//            "jdbc:postgresql://localhost:%d/%s?options=-c%%20spanner.ddl_transaction_mode=AutocommitExplicitTransaction",
+//            testEnv.getPGAdapterPort(), database.getId().getDatabase());
+//    try (Connection connection = DriverManager.getConnection(url)) {
+//      try (Statement statement = connection.createStatement()) {
+//        for (String sql : ddl) {
+//          LOGGER.info("Executing " + sql);
+//          statement.execute(sql);
+//        }
+//      }
+//    }
 
     // Write liquibase.properties
     StringBuilder original = new StringBuilder();

--- a/src/test/java/com/google/cloud/spanner/pgadapter/liquibase/ITLiquibaseTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/liquibase/ITLiquibaseTest.java
@@ -33,7 +33,6 @@ import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.sql.Statement;
 import java.util.Scanner;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
@@ -64,26 +63,27 @@ public class ITLiquibaseTest {
     database = testEnv.createDatabase(ImmutableList.of());
     testEnv.startPGAdapterServer(ImmutableList.of());
     // Create databasechangelog and databasechangeloglock tables.
-//    StringBuilder builder = new StringBuilder();
-//    try (Scanner scanner = new Scanner(new FileReader(LIQUIBASE_DB_CHANGELOG_DDL_FILE))) {
-//      while (scanner.hasNextLine()) {
-//        builder.append(scanner.nextLine()).append("\n");
-//      }
-//    }
-//    // Note: We know that all semicolons in this file are outside of literals etc.
-//    String[] ddl = builder.toString().split(";");
-//    String url =
-//        String.format(
-//            "jdbc:postgresql://localhost:%d/%s?options=-c%%20spanner.ddl_transaction_mode=AutocommitExplicitTransaction",
-//            testEnv.getPGAdapterPort(), database.getId().getDatabase());
-//    try (Connection connection = DriverManager.getConnection(url)) {
-//      try (Statement statement = connection.createStatement()) {
-//        for (String sql : ddl) {
-//          LOGGER.info("Executing " + sql);
-//          statement.execute(sql);
-//        }
-//      }
-//    }
+    //    StringBuilder builder = new StringBuilder();
+    //    try (Scanner scanner = new Scanner(new FileReader(LIQUIBASE_DB_CHANGELOG_DDL_FILE))) {
+    //      while (scanner.hasNextLine()) {
+    //        builder.append(scanner.nextLine()).append("\n");
+    //      }
+    //    }
+    //    // Note: We know that all semicolons in this file are outside of literals etc.
+    //    String[] ddl = builder.toString().split(";");
+    //    String url =
+    //        String.format(
+    //
+    // "jdbc:postgresql://localhost:%d/%s?options=-c%%20spanner.ddl_transaction_mode=AutocommitExplicitTransaction",
+    //            testEnv.getPGAdapterPort(), database.getId().getDatabase());
+    //    try (Connection connection = DriverManager.getConnection(url)) {
+    //      try (Statement statement = connection.createStatement()) {
+    //        for (String sql : ddl) {
+    //          LOGGER.info("Executing " + sql);
+    //          statement.execute(sql);
+    //        }
+    //      }
+    //    }
 
     // Write liquibase.properties
     StringBuilder original = new StringBuilder();

--- a/src/test/java/com/google/cloud/spanner/pgadapter/liquibase/ITLiquibaseTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/liquibase/ITLiquibaseTest.java
@@ -62,28 +62,6 @@ public class ITLiquibaseTest {
     testEnv.setUp();
     database = testEnv.createDatabase(ImmutableList.of());
     testEnv.startPGAdapterServer(ImmutableList.of());
-    // Create databasechangelog and databasechangeloglock tables.
-    //    StringBuilder builder = new StringBuilder();
-    //    try (Scanner scanner = new Scanner(new FileReader(LIQUIBASE_DB_CHANGELOG_DDL_FILE))) {
-    //      while (scanner.hasNextLine()) {
-    //        builder.append(scanner.nextLine()).append("\n");
-    //      }
-    //    }
-    //    // Note: We know that all semicolons in this file are outside of literals etc.
-    //    String[] ddl = builder.toString().split(";");
-    //    String url =
-    //        String.format(
-    //
-    // "jdbc:postgresql://localhost:%d/%s?options=-c%%20spanner.ddl_transaction_mode=AutocommitExplicitTransaction",
-    //            testEnv.getPGAdapterPort(), database.getId().getDatabase());
-    //    try (Connection connection = DriverManager.getConnection(url)) {
-    //      try (Statement statement = connection.createStatement()) {
-    //        for (String sql : ddl) {
-    //          LOGGER.info("Executing " + sql);
-    //          statement.execute(sql);
-    //        }
-    //      }
-    //    }
 
     // Write liquibase.properties
     StringBuilder original = new StringBuilder();

--- a/src/test/java/com/google/cloud/spanner/pgadapter/statements/DdlExecutorTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/statements/DdlExecutorTest.java
@@ -21,6 +21,8 @@ import static org.mockito.Mockito.mock;
 import com.google.cloud.spanner.Dialect;
 import com.google.cloud.spanner.Statement;
 import com.google.cloud.spanner.connection.AbstractStatementParser;
+import com.google.common.base.Suppliers;
+import com.google.common.collect.ImmutableList;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -52,7 +54,8 @@ public class DdlExecutorTest {
 
   @Test
   public void testMaybeRemovePrimaryKeyConstraintName() {
-    DdlExecutor ddlExecutor = new DdlExecutor(mock(BackendConnection.class));
+    DdlExecutor ddlExecutor =
+        new DdlExecutor(mock(BackendConnection.class), Suppliers.ofInstance(ImmutableList.of()));
 
     assertEquals(
         Statement.of("create table foo (id bigint primary key, value text)"),

--- a/src/test/java/com/google/cloud/spanner/pgadapter/statements/DdlExecutorTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/statements/DdlExecutorTest.java
@@ -16,13 +16,16 @@ package com.google.cloud.spanner.pgadapter.statements;
 
 import static com.google.cloud.spanner.pgadapter.statements.DdlExecutor.unquoteIdentifier;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 import static org.mockito.Mockito.mock;
 
 import com.google.cloud.spanner.Dialect;
 import com.google.cloud.spanner.Statement;
 import com.google.cloud.spanner.connection.AbstractStatementParser;
+import com.google.cloud.spanner.pgadapter.utils.RegexQueryPartReplacer;
 import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableList;
+import java.util.regex.Pattern;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -109,5 +112,44 @@ public class DdlExecutorTest {
         ddlExecutor.maybeRemovePrimaryKeyConstraintName(
             Statement.of(
                 "CREATE TABLE \"user\" (\"id\" integer NOT NULL, \"firstName\" character varying NOT NULL, \"lastName\" character varying NOT NULL, \"age\" integer NOT NULL, CONSTRAINT \"PK_user\" PRIMARY KEY (\"id\"))")));
+  }
+
+  @Test
+  public void testDdlReplacements() {
+    DdlExecutor ddlExecutorWithoutReplacements =
+        new DdlExecutor(mock(BackendConnection.class), Suppliers.ofInstance(ImmutableList.of()));
+    String sql = "create table my_table (id bigint primary key, value varchar)";
+    assertSame(sql, ddlExecutorWithoutReplacements.applyReplacers(sql));
+
+    DdlExecutor ddlExecutorWithReplacements =
+        new DdlExecutor(
+            mock(BackendConnection.class),
+            Suppliers.ofInstance(
+                ImmutableList.of(
+                    RegexQueryPartReplacer.replace(Pattern.compile("timestamp"), "timestamptz"),
+                    RegexQueryPartReplacer.replaceAndStop(
+                        Pattern.compile(
+                            "create table databasechangelog \\(id bigint primary key\\)"),
+                        "create table databasechangelog_replaced (id bigint primary key)"),
+                    RegexQueryPartReplacer.replace(
+                        Pattern.compile("create table databasechangelog_replaced"),
+                        "create table databasechangelog_reverted"))));
+    assertSame(sql, ddlExecutorWithReplacements.applyReplacers(sql));
+    assertEquals(
+        "create table my_table (id bigint primary key, value timestamptz)",
+        ddlExecutorWithReplacements.applyReplacers(
+            "create table my_table (id bigint primary key, value timestamp)"));
+    assertEquals(
+        "create table databasechangelog_replaced (id bigint primary key)",
+        ddlExecutorWithReplacements.applyReplacers(
+            "create table databasechangelog (id bigint primary key)"));
+    assertEquals(
+        "create table databasechangelog_replaced (id bigint primary key); create table databasechangelog_replaced (id bigint primary key)",
+        ddlExecutorWithReplacements.applyReplacers(
+            "create table databasechangelog (id bigint primary key); create table databasechangelog (id bigint primary key)"));
+    assertEquals(
+        "create table databasechangelog_reverted (id bigint primary key)",
+        ddlExecutorWithReplacements.applyReplacers(
+            "create table databasechangelog_replaced (id bigint primary key)"));
   }
 }


### PR DESCRIPTION
Adds support for replacing DDL statements on a per-client basis. This allows us to automatically replace well-known DDL statements that are not supported with supported statements. This change also includes replacements for the Liquibase changelog tables.