### PR TITLE
deps: import Spanner pom instead of individual deps

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,6 @@
       com.google.cloud.spanner.pgadapter.ruby.RubyTest,
     </excludedTests>
 
-    <spanner.version>6.45.0</spanner.version>
     <junixsocket.version>2.7.0</junixsocket.version>
   </properties>
 
@@ -71,6 +70,24 @@
       <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>com.google.cloud</groupId>
+        <artifactId>google-cloud-spanner-bom</artifactId>
+        <version>6.45.0</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>com.google.cloud</groupId>
+        <artifactId>google-cloud-shared-dependencies</artifactId>
+        <version>3.14.0</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
 
   <dependencies>
     <dependency>
@@ -86,7 +103,6 @@
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-spanner</artifactId>
-      <version>${spanner.version}</version>
     </dependency>
     <dependency>
       <groupId>org.postgresql</groupId>
@@ -139,14 +155,12 @@
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-spanner</artifactId>
-      <version>${spanner.version}</version>
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.google.api</groupId>
       <artifactId>gax-grpc</artifactId>
-      <version>2.18.2</version>
       <classifier>testlib</classifier>
       <scope>test</scope>
     </dependency>


### PR DESCRIPTION
Import the Cloud Spanner client lib pom instead of adding separate dependencies.