### PR TITLE
test: skip sample test on non-prod envs

### DIFF
--- a/samples/golang/pgx/pgx_sample.go
+++ b/samples/golang/pgx/pgx_sample.go
@@ -17,8 +17,6 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"net"
-
 	pgadapter "github.com/GoogleCloudPlatform/pgadapter/wrappers/golang"
 	"github.com/jackc/pgx/v5"
 )
@@ -60,13 +58,7 @@ func main() {
 		return
 	}
 	// Connect to Cloud Spanner through PGAdapter.
-	addr, err := net.ResolveTCPAddr("tcp", fmt.Sprintf("localhost:%d", port))
-	if err != nil {
-		fmt.Printf("failed to resolve localhost address %v\n", err)
-		return
-	}
-	fmt.Printf("Connecting to PGAdapter on address %s\n", addr)
-	connString := fmt.Sprintf("postgres://uid:pwd@%s/%s?sslmode=disable", addr, *database)
+	connString := fmt.Sprintf("postgres://uid:pwd@localhost:%d/%s?sslmode=disable", port, *database)
 	conn, err := pgx.Connect(ctx, connString)
 	if err != nil {
 		fmt.Printf("failed to connect to PGAdapter: %v\n", err)

--- a/src/test/java/com/google/cloud/spanner/pgadapter/golang/ITPgxSampleTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/golang/ITPgxSampleTest.java
@@ -16,6 +16,7 @@ package com.google.cloud.spanner.pgadapter.golang;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeTrue;
 
 import com.google.cloud.spanner.Database;
 import com.google.cloud.spanner.pgadapter.IntegrationTest;
@@ -41,6 +42,8 @@ public class ITPgxSampleTest implements IntegrationTest {
 
   @BeforeClass
   public static void setup() throws Exception {
+    assumeTrue("This test only works on the default Spanner URL", testEnv.getSpannerUrl() == null);
+
     String currentPath = new java.io.File(".").getCanonicalPath();
     String relativeSampleFilePath = "samples/golang/pgx/pgx_sample.go";
     String sampleFilePath = String.format("%s/%s", currentPath, relativeSampleFilePath);
@@ -56,18 +59,11 @@ public class ITPgxSampleTest implements IntegrationTest {
     assertEquals(0, res);
 
     testEnv.setUp();
-    database =
-        testEnv.createDatabase(
-            ImmutableList.of(
-                "create table test (\n"
-                    + "  id bigint primary key,\n"
-                    + "  value varchar\n"
-                    + ")"));
+    database = testEnv.createDatabase(ImmutableList.of());
   }
 
   @AfterClass
   public static void teardown() {
-    testEnv.stopPGAdapterServer();
     testEnv.cleanUp();
   }
 


### PR DESCRIPTION
Skip sample test on non-prod environments, as the PGAdapter wrapper does not support setting a custom endpoint.