### PR TITLE
docs: update Hibernate sample to Hibernate 6.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ PGAdapter can be used with the following drivers and clients:
 
 ## ORMs, Frameworks and Tools
 PGAdapter can be used with the following frameworks and tools:
-1. `Hibernate`: Version 5.3.20. Final and higher are supported. See [hibernate support](samples/java/hibernate/README.md) for more details.
+1. `Hibernate`: Version 5.3.20.Final and higher are supported. See [hibernate support](samples/java/hibernate/README.md) for more details.
 1. `Spring Data JPA`: Spring Data JPA in combination with Hibernate is also supported. See the [Spring Data JPA Sample Application](samples/java/spring-data-jpa) for a full example.
 1. `Liquibase`: Version 4.12.0 and higher are supported. See [Liquibase support](docs/liquibase.md)
    for more details. See also [this directory](samples/java/liquibase) for a sample application using `Liquibase`.

--- a/samples/java/hibernate/README.md
+++ b/samples/java/hibernate/README.md
@@ -55,17 +55,11 @@ Cloud Spanner supports the following data types in combination with `Hibernate`.
 | date                                   | LocalDate         |
 | jsonb                                  | Custom Data Type  |
 
-### JSONB
-Hibernate 5.* does not have native support for JSONB. For this, a custom data type
-must be added. This sample uses [vladmihalcea/hibernate-types](https://github.com/vladmihalcea/hibernate-types).
-
 ## Limitations
 The following limitations are currently known:
 
 | Limitation             | Workaround                                                                                                                                                                                                                                                                   |
 |------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| Hibernate Version      | Version 5.3.20.Final is supported.                                                                                                                                                                                                                                           |
-| Postgresql JDBC driver | Version 42.4.3 is supported.                                                                                                                                                                                                                                                 |
 | Schema updates         | Cloud Spanner does not support the full PostgreSQL DDL dialect. Automated schema updates using `hibernate` are therefore not supported. It is recommended to set the option `hibernate.hbm2ddl.auto=none` (or `spring.jpa.hibernate.ddl-auto=none` if you are using Spring). |
 | Generated primary keys | Cloud Spanner does not support `sequences`. Auto-increment primary key is not supported. Remove auto increment annotation for primary key columns. The recommended type of primary key is a client side generated `UUID` stored as a string.                                 |
 | Pessimistic Locking    | Cloud Spanner does not support `LockMode.UPGRADE` and `LockMode.UPGRADE_NOWAIT` lock modes.                                                                                                                                                                                  |
@@ -73,8 +67,13 @@ The following limitations are currently known:
 
 ### Schema Updates
 Schema updates are not supported as Cloud Spanner does not support the full PostgreSQL DDL dialect.
-It is recommended to create the schema manually.
+For this sample, the schema must be created manually.
 See [sample-schema.sql](src/main/resources/sample-schema-sql) for the data model for this example.
+
+It is recommended to use a higher-level schema management tool like Liquibase for gradual updates of
+your schema in production. This gives you more control over the changes that are applied, and allows
+you to store schema changes in a code repository. See [Spring Data JPA with PGAdapter here](../spring-data-jpa)
+for an example of how to integrate Liquibase with your application.
 
 ### Generated Primary Keys
 `Sequences` are not supported. Hence, auto increment primary key is not supported and should be replaced with primary key definitions that
@@ -86,8 +85,8 @@ keys.
 public class User {
 	// This uses auto generated UUID.
     @Id
-    @Column(columnDefinition = "varchar", nullable = false)
-    @GeneratedValue
+    @Column(columnDefinition = "varchar(36)")
+    @GeneratedValue(strategy = GenerationType.UUID)
     private UUID id;
 }
 ```

--- a/samples/java/hibernate/pom.xml
+++ b/samples/java/hibernate/pom.xml
@@ -23,52 +23,19 @@
       <version>6.2.7.Final</version>
     </dependency>
 
-    <!-- The Postgresql JDBC driver dependency -->
+    <!-- Postgresql JDBC driver dependency -->
     <dependency>
       <groupId>org.postgresql</groupId>
       <artifactId>postgresql</artifactId>
       <version>42.6.0</version>
     </dependency>
 
-<!--    &lt;!&ndash; Support for JSONB data type &ndash;&gt;-->
-<!--    <dependency>-->
-<!--      <groupId>com.vladmihalcea</groupId>-->
-<!--      <artifactId>hibernate-types-52</artifactId>-->
-<!--      <version>2.21.1</version>-->
-<!--    </dependency>-->
-<!--    <dependency>-->
-<!--      <groupId>com.fasterxml.jackson.core</groupId>-->
-<!--      <artifactId>jackson-core</artifactId>-->
-<!--      <version>2.15.2</version>-->
-<!--    </dependency>-->
-
+    <!-- Jackson is required if you want to use JSONB with Hibernate. -->
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
       <version>2.15.2</version>
     </dependency>
-
-<!--    <dependency>-->
-<!--      <groupId>com.fasterxml.jackson.module</groupId>-->
-<!--      <artifactId>jackson-module-jaxb-annotations</artifactId>-->
-<!--      <version>2.15.2</version>-->
-<!--    </dependency>-->
-
-<!--    <dependency>-->
-<!--      <groupId>javax.xml.bind</groupId>-->
-<!--      <artifactId>jaxb-api</artifactId>-->
-<!--      <version>2.3.1</version>-->
-<!--    </dependency>-->
-<!--    <dependency>-->
-<!--      <groupId>com.sun.xml.bind</groupId>-->
-<!--      <artifactId>jaxb-impl</artifactId>-->
-<!--      <version>2.3.4</version>-->
-<!--    </dependency>-->
-<!--    <dependency>-->
-<!--      <groupId>org.javassist</groupId>-->
-<!--      <artifactId>javassist</artifactId>-->
-<!--      <version>3.29.2-GA</version>-->
-<!--    </dependency>-->
 
   </dependencies>
 </project>

--- a/samples/java/hibernate/pom.xml
+++ b/samples/java/hibernate/pom.xml
@@ -9,34 +9,18 @@
   <version>1.0-SNAPSHOT</version>
 
   <properties>
-    <java.version>1.8</java.version>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
-    <hibernate.version>5.3.20.Final</hibernate.version>
-    <skipTests>false</skipTests>
-    <skipUnits>${skipTests}</skipUnits>
-    <skipITs>true</skipITs>
-    <it.forkCount>8</it.forkCount>
-    <clirr.skip>true</clirr.skip>
+    <java.version>11</java.version>
+    <maven.compiler.source>11</maven.compiler.source>
+    <maven.compiler.target>11</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <spanner.version>6.31.1</spanner.version>
-    <junixsocket.version>2.5.1</junixsocket.version>
   </properties>
   <dependencies>
-    <!-- [START spanner_hibernate_dependencies] -->
-    <!-- Hibernate for Entity Management -->
-    <dependency>
-      <groupId>org.hibernate</groupId>
-      <artifactId>hibernate-entitymanager</artifactId>
-      <version>5.3.20.Final</version>
-    </dependency>
-
     <!-- Hibernate core dependency -->
     <dependency>
-      <groupId>org.hibernate</groupId>
+      <groupId>org.hibernate.orm</groupId>
       <artifactId>hibernate-core</artifactId>
-      <version>5.3.20.Final</version>
+      <version>6.2.7.Final</version>
     </dependency>
 
     <!-- The Postgresql JDBC driver dependency -->
@@ -45,14 +29,18 @@
       <artifactId>postgresql</artifactId>
       <version>42.6.0</version>
     </dependency>
-    <!-- [END spanner_hibernate_dependencies] -->
 
-    <!-- Support for JSONB data type -->
-    <dependency>
-      <groupId>com.vladmihalcea</groupId>
-      <artifactId>hibernate-types-52</artifactId>
-      <version>2.21.1</version>
-    </dependency>
+<!--    &lt;!&ndash; Support for JSONB data type &ndash;&gt;-->
+<!--    <dependency>-->
+<!--      <groupId>com.vladmihalcea</groupId>-->
+<!--      <artifactId>hibernate-types-52</artifactId>-->
+<!--      <version>2.21.1</version>-->
+<!--    </dependency>-->
+<!--    <dependency>-->
+<!--      <groupId>com.fasterxml.jackson.core</groupId>-->
+<!--      <artifactId>jackson-core</artifactId>-->
+<!--      <version>2.15.2</version>-->
+<!--    </dependency>-->
 
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
@@ -60,27 +48,27 @@
       <version>2.15.2</version>
     </dependency>
 
-    <dependency>
-      <groupId>com.fasterxml.jackson.module</groupId>
-      <artifactId>jackson-module-jaxb-annotations</artifactId>
-      <version>2.15.2</version>
-    </dependency>
+<!--    <dependency>-->
+<!--      <groupId>com.fasterxml.jackson.module</groupId>-->
+<!--      <artifactId>jackson-module-jaxb-annotations</artifactId>-->
+<!--      <version>2.15.2</version>-->
+<!--    </dependency>-->
 
-    <dependency>
-      <groupId>javax.xml.bind</groupId>
-      <artifactId>jaxb-api</artifactId>
-      <version>2.3.1</version>
-    </dependency>
-    <dependency>
-      <groupId>com.sun.xml.bind</groupId>
-      <artifactId>jaxb-impl</artifactId>
-      <version>2.3.4</version>
-    </dependency>
-    <dependency>
-      <groupId>org.javassist</groupId>
-      <artifactId>javassist</artifactId>
-      <version>3.29.2-GA</version>
-    </dependency>
+<!--    <dependency>-->
+<!--      <groupId>javax.xml.bind</groupId>-->
+<!--      <artifactId>jaxb-api</artifactId>-->
+<!--      <version>2.3.1</version>-->
+<!--    </dependency>-->
+<!--    <dependency>-->
+<!--      <groupId>com.sun.xml.bind</groupId>-->
+<!--      <artifactId>jaxb-impl</artifactId>-->
+<!--      <version>2.3.4</version>-->
+<!--    </dependency>-->
+<!--    <dependency>-->
+<!--      <groupId>org.javassist</groupId>-->
+<!--      <artifactId>javassist</artifactId>-->
+<!--      <version>3.29.2-GA</version>-->
+<!--    </dependency>-->
 
   </dependencies>
 </project>

--- a/samples/java/hibernate/src/main/java/com/google/cloud/postgres/HibernateSampleTest.java
+++ b/samples/java/hibernate/src/main/java/com/google/cloud/postgres/HibernateSampleTest.java
@@ -20,17 +20,16 @@ import com.google.cloud.postgres.models.HibernateConfiguration;
 import com.google.cloud.postgres.models.Singers;
 import com.google.cloud.postgres.models.Tracks;
 import com.google.cloud.postgres.models.Venues;
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaDelete;
+import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.CriteriaUpdate;
+import jakarta.persistence.criteria.Root;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.UUID;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import javax.persistence.criteria.CriteriaBuilder;
-import javax.persistence.criteria.CriteriaDelete;
-import javax.persistence.criteria.CriteriaQuery;
-import javax.persistence.criteria.CriteriaUpdate;
-import javax.persistence.criteria.Root;
 import org.hibernate.Session;
 import org.hibernate.Transaction;
 import org.hibernate.query.Query;
@@ -95,7 +94,7 @@ public class HibernateSampleTest {
       CriteriaUpdate<Albums> albumsCriteriaUpdate = cb.createCriteriaUpdate(Albums.class);
       Root<Albums> albumsRoot = albumsCriteriaUpdate.from(Albums.class);
       albumsCriteriaUpdate.set("marketingBudget", new BigDecimal("5.0"));
-      albumsCriteriaUpdate.where(cb.equal(albumsRoot.get("id"), UUID.fromString(albumsId.get(0))));
+      albumsCriteriaUpdate.where(cb.equal(albumsRoot.get("id"), albumsId.get(0)));
       Transaction transaction = s.beginTransaction();
       s.createQuery(albumsCriteriaUpdate).executeUpdate();
       transaction.commit();
@@ -133,6 +132,8 @@ public class HibernateSampleTest {
 
       query = s.createQuery("from Singers order by fullName");
       query.setFirstResult(2);
+      // We must use a limit when we use an offset.
+      query.setMaxResults(Integer.MAX_VALUE);
       list = query.list();
       System.out.println("Singers list size with first result: " + list.size());
 
@@ -149,7 +150,7 @@ public class HibernateSampleTest {
 
   public void testOneToManyData() {
     try (Session s = hibernateConfiguration.openSession()) {
-      Venues venues = s.get(Venues.class, UUID.fromString(venuesId.get(0)));
+      Venues venues = s.get(Venues.class, venuesId.get(0));
       if (venues == null) {
         logger.log(Level.SEVERE, "Previously Added Venues Not Found.");
       }

--- a/samples/java/hibernate/src/main/java/com/google/cloud/postgres/Utils.java
+++ b/samples/java/hibernate/src/main/java/com/google/cloud/postgres/Utils.java
@@ -61,7 +61,7 @@ public class Utils {
     return concerts;
   }
 
-  public static Tracks createTracks(UUID albumId) {
+  public static Tracks createTracks(String albumId) {
     final Tracks tracks = new Tracks();
     tracks.setCreatedAt(LocalDateTime.now());
     tracks.setTitle("Perfect");

--- a/samples/java/hibernate/src/main/java/com/google/cloud/postgres/models/Albums.java
+++ b/samples/java/hibernate/src/main/java/com/google/cloud/postgres/models/Albums.java
@@ -1,40 +1,44 @@
 package com.google.cloud.postgres.models;
 
 import com.google.cloud.postgres.CurrentLocalDateTimeGenerator;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.Lob;
+import jakarta.persistence.ManyToOne;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.UUID;
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.Id;
-import javax.persistence.JoinColumn;
-import javax.persistence.Lob;
-import javax.persistence.ManyToOne;
 import org.hibernate.annotations.GenerationTime;
 import org.hibernate.annotations.GeneratorType;
+import org.hibernate.annotations.JdbcType;
 import org.hibernate.annotations.Type;
+import org.hibernate.type.descriptor.jdbc.BinaryJdbcType;
+import org.hibernate.type.descriptor.jdbc.VarbinaryJdbcType;
 
 @Entity
 public class Albums {
 
   @Id
-  @Column(columnDefinition = "varchar", nullable = false)
-  @GeneratedValue
-  private UUID id;
+  @Column(columnDefinition = "varchar(36)")
+  @GeneratedValue(strategy = GenerationType.UUID)
+  private String id;
 
   private String title;
 
-  @Column(name = "marketing_budget")
+  @Column(name = "marketing_budget", columnDefinition = "numeric")
   private BigDecimal marketingBudget;
 
   @Column(name = "release_date", columnDefinition = "date")
   private LocalDate releaseDate;
 
   @Lob
-  @Type(type = "org.hibernate.type.BinaryType")
+  @JdbcType(BinaryJdbcType.class)
   @Column(name = "cover_picture")
   private byte[] coverPicture;
 
@@ -49,11 +53,11 @@ public class Albums {
   @Column(name = "updated_at", columnDefinition = "timestamptz")
   private LocalDateTime updatedAt;
 
-  public UUID getId() {
+  public String getId() {
     return id;
   }
 
-  public void setId(UUID id) {
+  public void setId(String id) {
     this.id = id;
   }
 

--- a/samples/java/hibernate/src/main/java/com/google/cloud/postgres/models/Concerts.java
+++ b/samples/java/hibernate/src/main/java/com/google/cloud/postgres/models/Concerts.java
@@ -15,14 +15,15 @@
 package com.google.cloud.postgres.models;
 
 import com.google.cloud.postgres.CurrentLocalDateTimeGenerator;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import java.time.LocalDateTime;
 import java.util.UUID;
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.Id;
-import javax.persistence.JoinColumn;
-import javax.persistence.ManyToOne;
 import org.hibernate.annotations.GenerationTime;
 import org.hibernate.annotations.GeneratorType;
 
@@ -30,9 +31,9 @@ import org.hibernate.annotations.GeneratorType;
 public class Concerts {
 
   @Id
-  @Column(columnDefinition = "varchar", nullable = false)
-  @GeneratedValue
-  private UUID id;
+  @Column(columnDefinition = "varchar(36)")
+  @GeneratedValue(strategy = GenerationType.UUID)
+  private String id;
 
   @Column(name = "name", nullable = false)
   private String name;
@@ -58,11 +59,11 @@ public class Concerts {
   @Column(name = "updated_at", columnDefinition = "timestamptz")
   private LocalDateTime updatedAt;
 
-  public UUID getId() {
+  public String getId() {
     return id;
   }
 
-  public void setId(UUID id) {
+  public void setId(String id) {
     this.id = id;
   }
 

--- a/samples/java/hibernate/src/main/java/com/google/cloud/postgres/models/Singers.java
+++ b/samples/java/hibernate/src/main/java/com/google/cloud/postgres/models/Singers.java
@@ -15,12 +15,14 @@
 package com.google.cloud.postgres.models;
 
 import com.google.cloud.postgres.CurrentLocalDateTimeGenerator;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import java.sql.Types;
 import java.time.LocalDateTime;
 import java.util.UUID;
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.Id;
 import org.hibernate.annotations.Generated;
 import org.hibernate.annotations.GenerationTime;
 import org.hibernate.annotations.GeneratorType;
@@ -29,9 +31,9 @@ import org.hibernate.annotations.GeneratorType;
 public class Singers {
 
   @Id
-  @Column(columnDefinition = "varchar", nullable = false)
-  @GeneratedValue
-  private UUID id;
+  @Column(columnDefinition = "varchar(36)")
+  @GeneratedValue(strategy = GenerationType.UUID)
+  private String id;
 
   @Column(name = "first_name")
   private String firstName;
@@ -52,7 +54,7 @@ public class Singers {
   @Column(name = "updated_at", columnDefinition = "timestamptz")
   private LocalDateTime updatedAt;
 
-  public UUID getId() {
+  public String getId() {
     return id;
   }
 
@@ -72,7 +74,7 @@ public class Singers {
     return active;
   }
 
-  public void setId(UUID id) {
+  public void setId(String id) {
     this.id = id;
   }
 

--- a/samples/java/hibernate/src/main/java/com/google/cloud/postgres/models/Tracks.java
+++ b/samples/java/hibernate/src/main/java/com/google/cloud/postgres/models/Tracks.java
@@ -15,10 +15,10 @@
 package com.google.cloud.postgres.models;
 
 import com.google.cloud.postgres.CurrentLocalDateTimeGenerator;
+import jakarta.persistence.Column;
+import jakarta.persistence.EmbeddedId;
+import jakarta.persistence.Entity;
 import java.time.LocalDateTime;
-import javax.persistence.Column;
-import javax.persistence.EmbeddedId;
-import javax.persistence.Entity;
 import org.hibernate.annotations.GenerationTime;
 import org.hibernate.annotations.GeneratorType;
 
@@ -26,7 +26,8 @@ import org.hibernate.annotations.GeneratorType;
 public class Tracks {
 
   // For composite primary keys, @EmbeddedId will have to be used.
-  @EmbeddedId private TracksId id;
+  @EmbeddedId
+  private TracksId id;
 
   @Column(name = "title", nullable = false)
   private String title;

--- a/samples/java/hibernate/src/main/java/com/google/cloud/postgres/models/TracksId.java
+++ b/samples/java/hibernate/src/main/java/com/google/cloud/postgres/models/TracksId.java
@@ -14,35 +14,38 @@
 
 package com.google.cloud.postgres.models;
 
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
 import java.io.Serializable;
 import java.util.UUID;
-import javax.persistence.Column;
-import javax.persistence.Embeddable;
 
 /**
- * @Embeddable is to be used for composite primary key.
+ * {@link Embeddable} is to be used for composite primary key.
  */
 @Embeddable
 public class TracksId implements Serializable {
 
-  @Column(columnDefinition = "varchar", nullable = false)
-  private UUID id;
+  @Column(columnDefinition = "varchar(36)")
+  private String id;
 
   @Column(name = "track_number", nullable = false)
   private long trackNumber;
 
   public TracksId() {}
 
-  public TracksId(UUID id, long trackNumber) {
+  public TracksId(String id, long trackNumber) {
     this.id = id;
     this.trackNumber = trackNumber;
   }
 
-  public UUID getId() {
+  public String getId() {
     return id;
   }
 
-  public void setId(UUID id) {
+  public void setId(String id) {
     this.id = id;
   }
 

--- a/samples/java/hibernate/src/main/java/com/google/cloud/postgres/models/Venues.java
+++ b/samples/java/hibernate/src/main/java/com/google/cloud/postgres/models/Venues.java
@@ -15,33 +15,35 @@
 package com.google.cloud.postgres.models;
 
 import com.google.cloud.postgres.CurrentLocalDateTimeGenerator;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToMany;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
-import javax.persistence.CascadeType;
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.Id;
-import javax.persistence.JoinColumn;
-import javax.persistence.OneToMany;
 import org.hibernate.annotations.GenerationTime;
 import org.hibernate.annotations.GeneratorType;
-import org.hibernate.annotations.Type;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
 
 @Entity
 public class Venues {
 
   @Id
-  @Column(columnDefinition = "varchar", nullable = false)
-  @GeneratedValue
-  private UUID id;
+  @Column(columnDefinition = "varchar(36)")
+  @GeneratedValue(strategy = GenerationType.UUID)
+  private String id;
 
   @Column(name = "name", nullable = false)
   private String name;
 
   @Column(name = "description", nullable = false, columnDefinition = "jsonb")
-  @Type(type = "com.vladmihalcea.hibernate.type.json.JsonBinaryType")
+  @JdbcTypeCode(SqlTypes.JSON)
   private VenueDescription description;
 
   @Column(name = "created_at", columnDefinition = "timestamptz")
@@ -55,11 +57,11 @@ public class Venues {
   @JoinColumn(name = "venue_id")
   private List<Concerts> concerts;
 
-  public UUID getId() {
+  public String getId() {
     return id;
   }
 
-  public void setId(UUID id) {
+  public void setId(String id) {
     this.id = id;
   }
 

--- a/samples/java/hibernate/src/main/resources/hibernate.properties
+++ b/samples/java/hibernate/src/main/resources/hibernate.properties
@@ -1,14 +1,13 @@
-# [START spanner_hibernate_config]
-hibernate.dialect org.hibernate.dialect.PostgreSQLDialect
-hibernate.connection.driver_class org.postgresql.Driver
-# [END spanner_hibernate_config]
+hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
+hibernate.connection.driver_class=org.postgresql.Driver
 
-hibernate.connection.url jdbc:postgresql://localhost:5432/test-database
-hibernate.connection.username pratick
+hibernate.connection.url=jdbc:postgresql://localhost:5432/test-database
+hibernate.connection.username=pratick
 
-hibernate.connection.pool_size 5
+hibernate.connection.pool_size=5
 
-hibernate.show_sql true
-hibernate.format_sql true
+hibernate.show_sql=true
+hibernate.format_sql=true
 
-hibernate.hbm2ddl.auto validate
+# hibernate.hbm2ddl.auto validate
+hibernate.hbm2ddl.auto=update

--- a/src/test/java/com/google/cloud/spanner/pgadapter/hibernate/ITHibernateTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/hibernate/ITHibernateTest.java
@@ -53,7 +53,6 @@ public class ITHibernateTest {
   private static final String HIBERNATE_DEFAULT_URL =
       "jdbc:postgresql://localhost:5432/test-database";
   private static final PgAdapterTestEnv testEnv = new PgAdapterTestEnv();
-  private static Database database;
   private static String originalHibernateProperties;
 
   @BeforeClass
@@ -63,7 +62,7 @@ public class ITHibernateTest {
     Class.forName("org.postgresql.Driver");
 
     testEnv.setUp();
-    database = testEnv.createDatabase(ImmutableList.of());
+    Database database = testEnv.createDatabase(ImmutableList.of());
     testEnv.startPGAdapterServer(ImmutableList.of());
     // Create the sample schema.
     StringBuilder builder = new StringBuilder();
@@ -114,8 +113,7 @@ public class ITHibernateTest {
   }
 
   @Test
-  public void testHibernateUpdate() throws IOException, InterruptedException {
-    System.out.println("Running hibernate test");
+  public void testHibernateSample() throws IOException, InterruptedException {
     ImmutableList<String> hibernateCommand =
         ImmutableList.<String>builder()
             .add(
@@ -124,22 +122,17 @@ public class ITHibernateTest {
                 "-Dexec.mainClass=com.google.cloud.postgres.HibernateSampleTest")
             .build();
     runCommand(hibernateCommand);
-    System.out.println("Hibernate Test Ended");
   }
 
   static void buildHibernateSample() throws IOException, InterruptedException {
-    System.out.println("Building Hibernate Sample.");
     ImmutableList<String> hibernateCommand =
         ImmutableList.<String>builder()
             .add("mvn", "-B", "--no-transfer-progress", "clean", "compile")
             .build();
     runCommand(hibernateCommand);
-    System.out.println("Hibernate Sample build complete.");
   }
 
   static void runCommand(ImmutableList<String> commands) throws IOException, InterruptedException {
-    System.out.println(
-        "Executing commands: " + commands + ". Sample Directory: " + HIBERNATE_SAMPLE_DIRECTORY);
     ProcessBuilder builder = new ProcessBuilder();
     builder.command(commands);
     builder.directory(new File(HIBERNATE_SAMPLE_DIRECTORY));
@@ -151,13 +144,11 @@ public class ITHibernateTest {
             new BufferedReader(new InputStreamReader(process.getInputStream()));
         BufferedReader errorReader =
             new BufferedReader(new InputStreamReader(process.getErrorStream()))) {
-      System.out.println("Printing hibernate loadings");
       output = reader.lines().collect(Collectors.joining("\n"));
       errors = errorReader.lines().collect(Collectors.joining("\n"));
-      System.out.println(output);
     }
 
     // Verify that there were no errors, and print the error output if there was an error.
-    assertEquals(errors, 0, process.waitFor());
+    assertEquals(errors + "\n\nOUTPUT:\n" + output, 0, process.waitFor());
   }
 }


### PR DESCRIPTION
Updates the Hibernate sample to use the most recent Hibernate version. This is more relevant, as new users as more likely to use a recent version of Hibernate than an old 5.x version that is no longer supported.