### PR TITLE
test: skip converting strange dates to LocalDate

### DIFF
--- a/src/test/java/com/google/cloud/spanner/pgadapter/AbortedMockServerTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/AbortedMockServerTest.java
@@ -933,7 +933,7 @@ public class AbortedMockServerTest extends AbstractMockServerTest {
                   && expected.getDayOfMonth() > 20)) {
             // Just assert that we can get the value. Dates in the Julian/Gregorian cutover period
             // are weird, as are potential intercalaris values.
-            assertNotNull(pgResult.getDate(col + 1).toLocalDate());
+            assertNotNull(pgResult.getDate(col + 1));
           } else {
             assertEquals(expected, pgResult.getDate(col + 1).toLocalDate());
           }

--- a/src/test/java/com/google/cloud/spanner/pgadapter/JdbcMockServerTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/JdbcMockServerTest.java
@@ -3140,7 +3140,7 @@ public class JdbcMockServerTest extends AbstractMockServerTest {
                   && expected.getDayOfMonth() > 20)) {
             // Just assert that we can get the value. Dates in the Julian/Gregorian cutover period
             // are weird, as are potential intercalaris values.
-            assertNotNull(pgResult.getDate(col + 1).toLocalDate());
+            assertNotNull(pgResult.getDate(col + 1));
           } else {
             assertEquals(expected, pgResult.getDate(col + 1).toLocalDate());
           }


### PR DESCRIPTION
Skip converting strange dates during the Gregorian calendar cut-off period to LocalDate. PostgreSQL and Java do not fully agree on what is valid (and Java seems to be more correct), so the current test setup just causes occasional failures. For example, PostgreSQL considers 1000-02-29 a valid date. Java does not.

Fixes #1019