### PR TITLE
deps: bump Spring Boot to 3.1.3 for Cloud Run sample

### DIFF
--- a/samples/java/cloud-run/Dockerfile
+++ b/samples/java/cloud-run/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Use the official maven/Java image to create a build artifact.
-FROM maven:3.8-jdk-11 as builder
+FROM maven:3.9.4-eclipse-temurin-17 as builder
 
 # Copy local code to the container image.
 WORKDIR /app
@@ -24,7 +24,7 @@ COPY src ./src
 RUN mvn package -DskipTests
 
 # Use AdoptOpenJDK for base image.
-FROM adoptopenjdk/openjdk11:alpine-jre
+FROM eclipse-temurin:17-jre-alpine
 
 # Copy the jar to the production image from the builder stage.
 COPY --from=builder /app/target/google-cloud-spanner-pgadapter-samples-cloud-run-*.jar /google-cloud-spanner-pgadapter-samples-cloud-run.jar

--- a/samples/java/cloud-run/README.md
+++ b/samples/java/cloud-run/README.md
@@ -1,6 +1,8 @@
 # PGAdapter Cloud Run Sample for Java
 
-This sample application shows how to build and deploy a Java application with PGAdapter to Google Cloud Run.
+This sample application shows how to build and deploy a Java application with PGAdapter to Google
+Cloud Run. This sample runs PGAdapter as an in-process dependency with the Java application. You
+can also [run PGAdapter as a side-car container](../../cloud-run/java).
 
 The sample is based on the [Cloud Run Quickstart Guide for Java](https://cloud.google.com/run/docs/quickstarts/build-and-deploy/deploy-java-service).
 Refer to that guide for more in-depth information on how to work with Cloud Run.

--- a/samples/java/cloud-run/pom.xml
+++ b/samples/java/cloud-run/pom.xml
@@ -15,13 +15,9 @@
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <properties>
-    <java.version>1.8</java.version>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
-    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-
-    <spring-boot.version>2.7.11</spring-boot.version>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
+    <java.version>17</java.version>
     <junixsocket.version>2.7.0</junixsocket.version>
   </properties>
 
@@ -40,7 +36,7 @@
       <dependency>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-dependencies</artifactId>
-        <version>${spring-boot.version}</version>
+        <version>3.1.3</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -89,7 +85,6 @@
       <plugin>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-maven-plugin</artifactId>
-        <version>${spring-boot.version}</version>
         <executions>
           <execution>
             <goals>
@@ -109,9 +104,9 @@
         </configuration>
       </plugin>
       <plugin>
-        <groupId>com.coveo</groupId>
+        <groupId>com.spotify.fmt</groupId>
         <artifactId>fmt-maven-plugin</artifactId>
-        <version>2.13</version>
+        <version>2.20</version>
         <executions>
           <execution>
             <goals>

--- a/samples/java/cloud-run/src/main/java/com/google/cloud/spanner/pgadapter/sample/PGAdapter.java
+++ b/samples/java/cloud-run/src/main/java/com/google/cloud/spanner/pgadapter/sample/PGAdapter.java
@@ -56,10 +56,11 @@ public class PGAdapter {
    * @param instance the Cloud Spanner instance that PGAdapter should connect to
    */
   static ProxyServer startPGAdapter(String project, String instance) {
-    OptionsMetadata options = OptionsMetadata.newBuilder()
-        .setProject(project)
-        .setInstance(instance)
-        .build();
+    OptionsMetadata options =
+        OptionsMetadata.newBuilder()
+            .setProject(project)
+            .setInstance(instance)
+            .build();
     ProxyServer server = new ProxyServer(options);
     server.startServer();
     server.awaitRunning();


### PR DESCRIPTION
Update the Cloud Run sample to use the latest version of Spring Boot. This also requires Java 17 or higher.