### PR TITLE
feat: translate Aborted to SerializationFailure errors

### DIFF
--- a/src/main/java/com/google/cloud/spanner/pgadapter/error/PGExceptionFactory.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/error/PGExceptionFactory.java
@@ -74,6 +74,13 @@ public class PGExceptionFactory {
 
   /** Converts the given {@link SpannerException} to a {@link PGException}. */
   public static PGException toPGException(SpannerException spannerException) {
+    if (spannerException.getErrorCode() == ErrorCode.ABORTED) {
+      return PGException.newBuilder(extractMessage(spannerException))
+          // This is the equivalent of an Aborted transaction error in Cloud Spanner.
+          // A client should be prepared to retry this.
+          .setSQLState(SQLState.SerializationFailure)
+          .build();
+    }
     if (spannerException.getErrorCode() == ErrorCode.INVALID_ARGUMENT
         && RELATION_NOT_FOUND_PATTERN.matcher(spannerException.getMessage()).find()) {
       return PGException.newBuilder(extractMessage(spannerException))

--- a/src/main/java/com/google/cloud/spanner/pgadapter/error/SQLState.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/error/SQLState.java
@@ -156,6 +156,13 @@ public enum SQLState {
   SavepointException("3B000"),
   InvalidSavepointSpecification("3B001"),
 
+  // Class 40 — Transaction Rollback
+  TransactionRollback("40000"),
+  TransactionIntegrityConstraintViolation("40002"),
+  SerializationFailure("40001"),
+  StatementCompletionUnknown("40003"),
+  DeadlockDetected("40P01"),
+
   // Class 42 — Syntax Error or Access Rule Violation
   SyntaxErrorOrAccessRuleViolation("42000"),
   SyntaxError("42601"),

--- a/src/test/java/com/google/cloud/spanner/pgadapter/error/PGExceptionFactoryTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/error/PGExceptionFactoryTest.java
@@ -52,6 +52,12 @@ public class PGExceptionFactoryTest {
                     /* cause= */ null,
                     GrpcStatusCode.of(Code.NOT_FOUND),
                     /* retryable= */ false))));
+    assertEquals(
+        SQLState.SerializationFailure,
+        toPGException(
+                SpannerExceptionFactory.newSpannerException(
+                    ErrorCode.ABORTED, "The transaction was aborted"))
+            .getSQLState());
   }
 
   @Test


### PR DESCRIPTION
Cloud Spanner returns Aborted if a transaction failed due to conflicts or for other reasons need to be retried. PostgreSQL returns serialization_failure in such cases. Both error codes indicate to the client that the transaction should be retried.

See also
https://www.postgresql.org/docs/current/mvcc-serialization-failure-handling.html and https://www.postgresql.org/docs/current/errcodes-appendix.html.