### PR TITLE
chore: create a codecov config

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,2 @@
+ignore:
+  - src/main/java/com/google/cloud/spanner/pgadapter/statements/JdbcMetadataStatementHelper.java


### PR DESCRIPTION
Add a codecov config file and ignore a file with only static query strings that are used for replacing.