### PR TITLE
fix: accept statements with only comments

### DIFF
--- a/src/main/java/com/google/cloud/spanner/pgadapter/statements/BackendConnection.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/statements/BackendConnection.java
@@ -277,7 +277,7 @@ public class BackendConnection {
           // Ignore the statement as it is a no-op to execute COMMIT/ROLLBACK when we are not in a
           // transaction. TODO: Return a warning.
           result.set(NO_RESULT);
-        } else if (statement.getSql().isEmpty()) {
+        } else if (parsedStatement.getSqlWithoutComments().isEmpty()) {
           result.set(NO_RESULT);
         } else if (parsedStatement.isDdl()) {
           if (analyze) {

--- a/src/test/java/com/google/cloud/spanner/pgadapter/JdbcSimpleModeMockServerTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/JdbcSimpleModeMockServerTest.java
@@ -244,6 +244,30 @@ public class JdbcSimpleModeMockServerTest extends AbstractMockServerTest {
   }
 
   @Test
+  public void testEmptyStatementWithSemiColon() throws SQLException {
+    String sql = ";";
+
+    try (Connection connection = DriverManager.getConnection(createUrl())) {
+      assertFalse(connection.createStatement().execute(sql));
+    }
+
+    // An empty statement is not sent to Spanner.
+    assertEquals(0, mockSpanner.countRequestsOfType(ExecuteSqlRequest.class));
+  }
+
+  @Test
+  public void testPing() throws SQLException {
+    String sql = "-- ping";
+
+    try (Connection connection = DriverManager.getConnection(createUrl())) {
+      assertFalse(connection.createStatement().execute(sql));
+    }
+
+    // An empty statement is not sent to Spanner.
+    assertEquals(0, mockSpanner.countRequestsOfType(ExecuteSqlRequest.class));
+  }
+
+  @Test
   public void testInvalidDml() throws SQLException {
     try (Connection connection = DriverManager.getConnection(createUrl())) {
       try (java.sql.Statement statement = connection.createStatement()) {

--- a/src/test/java/com/google/cloud/spanner/pgadapter/statements/BackendConnectionTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/statements/BackendConnectionTest.java
@@ -391,8 +391,9 @@ public class BackendConnectionTest {
   @Test
   public void testGeneralException() {
     Connection connection = mock(Connection.class);
-    ParsedStatement parsedStatement = mock(ParsedStatement.class);
     Statement statement = Statement.of("select foo from bar");
+    ParsedStatement parsedStatement = mock(ParsedStatement.class);
+    when(parsedStatement.getSqlWithoutComments()).thenReturn(statement.getSql());
     RuntimeException error = new RuntimeException("test error");
     when(connection.execute(statement)).thenThrow(error);
 
@@ -416,8 +417,9 @@ public class BackendConnectionTest {
   @Test
   public void testCancelledException() {
     Connection connection = mock(Connection.class);
-    ParsedStatement parsedStatement = mock(ParsedStatement.class);
     Statement statement = Statement.of("select foo from bar");
+    ParsedStatement parsedStatement = mock(ParsedStatement.class);
+    when(parsedStatement.getSqlWithoutComments()).thenReturn(statement.getSql());
     SpannerException error =
         SpannerExceptionFactory.newSpannerException(ErrorCode.CANCELLED, "query cancelled");
     when(connection.execute(statement)).thenThrow(error);


### PR DESCRIPTION
Some drivers send a statement containing only a comment in order to ping the server. These statements would return an error on PGAdapter. This would cause the newest pgx driver to fail with a 'driver: bad connection' error.