### PR TITLE
fix: replace fully-qualified column names

### DIFF
--- a/src/main/java/com/google/cloud/spanner/pgadapter/statements/SimpleParser.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/statements/SimpleParser.java
@@ -806,7 +806,9 @@ public class SimpleParser {
         || peekKeyword("full")
         || peekKeyword("inner")
         || peekKeyword("outer")
-        || peekKeyword("cross");
+        || peekKeyword("cross")
+        || peekKeyword("on")
+        || peekKeyword("using");
   }
 
   boolean eatJoinType() {

--- a/src/main/java/com/google/cloud/spanner/pgadapter/statements/TableParser.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/statements/TableParser.java
@@ -89,21 +89,13 @@ class TableParser {
           parseTableList(detectAndReplaceMap, replacedTables, detectedTablesBuilder, multipleTables)
               || detectedOrReplacedTable;
     }
-    // Reset to start and search for the WHERE clause.
+    // Reset to start replace full-qualified column names of tables that have been replaced.
     parser.setPos(0);
-    parser.parseExpressionUntilKeyword(ImmutableList.of("where"), true, false, false);
-    // Check whether we found a keyword.
-    if (parser.peekKeyword("where")) {
-      int positionBeforeWhereClause = parser.getPos();
-      String replaced =
-          replaceFullyQualifiedColumnNames(
-              detectAndReplaceMap,
-              replacedTables,
-              positionBeforeWhereClause,
-              parser.getSql().length());
-      if (replaced != null) {
-        parser.setSql(parser.getSql().substring(0, positionBeforeWhereClause) + replaced);
-      }
+    String replaced =
+        replaceFullyQualifiedColumnNames(
+            detectAndReplaceMap, replacedTables, 0, parser.getSql().length());
+    if (replaced != null) {
+      parser.setSql(replaced);
     }
 
     return detectedOrReplacedTable

--- a/src/main/java/com/google/cloud/spanner/pgadapter/statements/TableParser.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/statements/TableParser.java
@@ -20,6 +20,7 @@ import com.google.cloud.spanner.pgadapter.statements.SimpleParser.TableOrIndexNa
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import java.util.HashSet;
 import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Set;
@@ -38,11 +39,12 @@ class TableParser {
 
   Tuple<Set<TableOrIndexName>, Statement> detectAndReplaceTables(
       ImmutableMap<TableOrIndexName, TableOrIndexName> detectAndReplaceMap) {
-    return detectAndReplaceTables(detectAndReplaceMap, true);
+    return detectAndReplaceTables(detectAndReplaceMap, new HashSet<>(), true);
   }
 
   Tuple<Set<TableOrIndexName>, Statement> detectAndReplaceTables(
       ImmutableMap<TableOrIndexName, TableOrIndexName> detectAndReplaceMap,
+      Set<TableOrIndexName> replacedTables,
       boolean searchForKeywordBeforeFirstTable) {
     boolean potentialMatch = false;
     String lowerCaseSql = parser.getSql().toLowerCase();
@@ -84,9 +86,26 @@ class TableParser {
       }
       searchForKeywordBeforeFirstTable = true;
       detectedOrReplacedTable =
-          parseTableList(detectAndReplaceMap, detectedTablesBuilder, multipleTables)
+          parseTableList(detectAndReplaceMap, replacedTables, detectedTablesBuilder, multipleTables)
               || detectedOrReplacedTable;
     }
+    // Reset to start and search for the WHERE clause.
+    parser.setPos(0);
+    parser.parseExpressionUntilKeyword(ImmutableList.of("where"), true, false, false);
+    // Check whether we found a keyword.
+    if (parser.peekKeyword("where")) {
+      int positionBeforeWhereClause = parser.getPos();
+      String replaced =
+          replaceFullyQualifiedColumnNames(
+              detectAndReplaceMap,
+              replacedTables,
+              positionBeforeWhereClause,
+              parser.getSql().length());
+      if (replaced != null) {
+        parser.setSql(parser.getSql().substring(0, positionBeforeWhereClause) + replaced);
+      }
+    }
+
     return detectedOrReplacedTable
         ? Tuple.of(
             detectedTablesBuilder.build(),
@@ -96,6 +115,7 @@ class TableParser {
 
   private boolean parseTableList(
       ImmutableMap<TableOrIndexName, TableOrIndexName> detectAndReplaceMap,
+      Set<TableOrIndexName> replacedTables,
       ImmutableSet.Builder<TableOrIndexName> detectedTablesBuilder,
       boolean multipleTables) {
     boolean detectedOrReplacedTable = false;
@@ -108,6 +128,7 @@ class TableParser {
         Tuple<Set<TableOrIndexName>, Statement> subResult =
             subParser.detectAndReplaceTables(
                 detectAndReplaceMap,
+                replacedTables,
                 subParser.parser.peekKeyword("select") || subParser.parser.peekKeyword("with"));
         if (!subResult.x().isEmpty()) {
           detectedOrReplacedTable = true;
@@ -131,10 +152,10 @@ class TableParser {
         if (detectAndReplaceMap.containsKey(tableOrIndexName)) {
           detectedOrReplacedTable = true;
           // Add the translated table name to the set of discovered tables so that a CTE can be
-          // added
-          // for it.
+          // added for it.
           detectedTablesBuilder.add(
               Objects.requireNonNull(detectAndReplaceMap.get(tableOrIndexName)));
+          replacedTables.add(tableOrIndexName);
           // Check if the entry in the table map contains a different replacement value than the
           // original. Some tables may be added to the map of replacements with the same replacement
           // value as the original with the sole purpose of detecting the use of the table.
@@ -159,11 +180,56 @@ class TableParser {
       }
       if (wasJoin) {
         // Skip the join condition.
+        int positionBeforeJoinCondition = parser.getPos();
         parser.eatJoinCondition();
+        // Replace fully-qualified table names with unqualified table names in the join condition.
+        String joinCondition =
+            replaceFullyQualifiedColumnNames(
+                detectAndReplaceMap, replacedTables, positionBeforeJoinCondition, parser.getPos());
+        if (joinCondition != null) {
+          parser.setSql(
+              parser.getSql().substring(0, positionBeforeJoinCondition)
+                  + joinCondition
+                  + parser.getSql().substring(parser.getPos()));
+          // Set the position of the parser to after the replaced join condition.
+          parser.setPos(positionBeforeJoinCondition + joinCondition.length());
+        }
       }
     } while (multipleTables && (parser.eatToken(",") || (wasJoin = parser.eatJoinType())));
 
     return detectedOrReplacedTable;
+  }
+
+  private String replaceFullyQualifiedColumnNames(
+      ImmutableMap<TableOrIndexName, TableOrIndexName> detectAndReplaceMap,
+      Set<TableOrIndexName> replacedTables,
+      int replaceFromPosition,
+      int replaceToPosition) {
+    boolean replaced = false;
+    String sql = parser.getSql().substring(replaceFromPosition, replaceToPosition);
+    for (TableOrIndexName table : replacedTables) {
+      if (table.schema != null) {
+        TableOrIndexName replacement = detectAndReplaceMap.get(table);
+        if (replacement != null) {
+          while (true) {
+            String replacedSql =
+                sql.replaceAll(
+                    table.getUnquotedSchema() + "\\." + table.getUnquotedName() + "\\.(.+)",
+                    replacement.getUnquotedName() + ".$1");
+            if (!Objects.equals(replacedSql, sql)) {
+              sql = replacedSql;
+              replaced = true;
+            } else {
+              break;
+            }
+          }
+        }
+      }
+    }
+    if (replaced) {
+      return sql;
+    }
+    return null;
   }
 
   @Override

--- a/src/main/java/com/google/cloud/spanner/pgadapter/utils/ClientAutoDetector.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/utils/ClientAutoDetector.java
@@ -432,7 +432,9 @@ public class ClientAutoDetector {
                   Suppliers.ofInstance("'' as regtype")),
               RegexQueryPartReplacer.replace(
                   Pattern.compile("WHERE t\\.oid = to_regtype\\(\\$1\\)"),
-                  Suppliers.ofInstance("WHERE t.typname = \\$1")));
+                  Suppliers.ofInstance("WHERE t.typname = \\$1")),
+              RegexQueryPartReplacer.replace(
+                  Pattern.compile("COLLATE \"C\""), Suppliers.ofInstance("")));
 
       @Override
       boolean isClient(List<String> orderedParameterKeys, Map<String, String> parameters) {

--- a/src/test/java/com/google/cloud/spanner/pgadapter/python/sqlalchemy2/SqlAlchemy2SampleTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/python/sqlalchemy2/SqlAlchemy2SampleTest.java
@@ -1083,9 +1083,9 @@ public class SqlAlchemy2SampleTest extends AbstractMockServerTest {
             + "        schema_name as nspname, null as nspowner, null as nspacl\n"
             + "  from information_schema.schemata\n"
             + ")\n"
-            + "SELECT pg_catalog.pg_class.relname \n"
-            + "FROM pg_class JOIN pg_namespace ON pg_catalog.pg_namespace.oid = pg_catalog.pg_class.relnamespace \n"
-            + "WHERE pg_catalog.pg_class.relname = $1::VARCHAR(64) COLLATE \"C\" AND pg_catalog.pg_class.relkind = ANY (ARRAY[$2::VARCHAR, $3::VARCHAR, $4::VARCHAR, $5::VARCHAR, $6::VARCHAR]) AND true COLLATE \"C\"";
+            + "SELECT pg_class.relname \n"
+            + "FROM pg_class JOIN pg_namespace ON pg_namespace.oid = pg_class.relnamespace \n"
+            + "WHERE pg_class.relname = $1::VARCHAR(64)  AND pg_class.relkind = ANY (ARRAY[$2::VARCHAR, $3::VARCHAR, $4::VARCHAR, $5::VARCHAR, $6::VARCHAR]) AND true ";
     mockSpanner.putStatementResult(
         StatementResult.query(
             Statement.of(checkTableExistsSql),

--- a/src/test/java/com/google/cloud/spanner/pgadapter/statements/TableParserTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/statements/TableParserTest.java
@@ -137,6 +137,21 @@ public class TableParserTest {
             "pg_type",
             null,
             "pg_type"));
+    assertEquals(
+        Statement.of(
+            "select * from pg_namespace "
+                + "inner join pg_class on pg_namespace.oid = pg_class.relnamespace "
+                + "where pg_class.relname = $1::VARCHAR AND pg_class.relkind = ANY (ARRAY[$2::VARCHAR, $3::VARCHAR, $4::VARCHAR, $5::VARCHAR, $6::VARCHAR]) AND true AND pg_namespace.nspname != $7::VARCHAR'"),
+        replace(
+            Statement.of(
+                "select * from pg_catalog.pg_namespace "
+                    + "inner join pg_catalog.pg_class on pg_catalog.pg_namespace.oid = pg_catalog.pg_class.relnamespace "
+                    + "where pg_catalog.pg_class.relname = $1::VARCHAR AND pg_catalog.pg_class.relkind = ANY (ARRAY[$2::VARCHAR, $3::VARCHAR, $4::VARCHAR, $5::VARCHAR, $6::VARCHAR]) AND true AND pg_catalog.pg_namespace.nspname != $7::VARCHAR'"),
+            ImmutableMap.of(
+                TableOrIndexName.of("pg_catalog", "pg_namespace"),
+                    TableOrIndexName.of(null, "pg_namespace"),
+                TableOrIndexName.of("pg_catalog", "pg_class"),
+                    TableOrIndexName.of(null, "pg_class"))));
 
     assertEquals(
         Statement.of("insert into pg_type (name) values ('foo')"),
@@ -862,5 +877,10 @@ public class TableParserTest {
             ImmutableMap.of(
                 new TableOrIndexName(schema, table), new TableOrIndexName(withSchema, withTable)))
         .y();
+  }
+
+  static Statement replace(
+      Statement original, ImmutableMap<TableOrIndexName, TableOrIndexName> detectAndReplaceMap) {
+    return new TableParser(original).detectAndReplaceTables(detectAndReplaceMap).y();
   }
 }

--- a/src/test/java/com/google/cloud/spanner/pgadapter/statements/TableParserTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/statements/TableParserTest.java
@@ -139,12 +139,12 @@ public class TableParserTest {
             "pg_type"));
     assertEquals(
         Statement.of(
-            "select * from pg_namespace "
+            "select pg_class.relname from pg_namespace "
                 + "inner join pg_class on pg_namespace.oid = pg_class.relnamespace "
                 + "where pg_class.relname = $1::VARCHAR AND pg_class.relkind = ANY (ARRAY[$2::VARCHAR, $3::VARCHAR, $4::VARCHAR, $5::VARCHAR, $6::VARCHAR]) AND true AND pg_namespace.nspname != $7::VARCHAR'"),
         replace(
             Statement.of(
-                "select * from pg_catalog.pg_namespace "
+                "select pg_catalog.pg_class.relname from pg_catalog.pg_namespace "
                     + "inner join pg_catalog.pg_class on pg_catalog.pg_namespace.oid = pg_catalog.pg_class.relnamespace "
                     + "where pg_catalog.pg_class.relname = $1::VARCHAR AND pg_catalog.pg_class.relkind = ANY (ARRAY[$2::VARCHAR, $3::VARCHAR, $4::VARCHAR, $5::VARCHAR, $6::VARCHAR]) AND true AND pg_catalog.pg_namespace.nspname != $7::VARCHAR'"),
             ImmutableMap.of(


### PR DESCRIPTION
pg_catalog queries that include a fully-qualified column name in either a join clause or a where clause would fail, as the pg_catalog table names are replaced with a unqualified reference to a common table expression.

This change adds an additional step to replace fully qualified column names of qualified table names that have been replaced, with column names that only include the table name and not the schema name. That is:

`pg_catalog.pg_class.relname -> pg_class.relname`

Fixes #1129