### PR TITLE
fix: re-instante public constructor for ProxyServer

### DIFF
--- a/src/main/java/com/google/cloud/spanner/pgadapter/ProxyServer.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/ProxyServer.java
@@ -80,8 +80,13 @@ public class ProxyServer extends AbstractApiService {
   private final ConcurrentLinkedQueue<WireMessage> debugMessages = new ConcurrentLinkedQueue<>();
   private final AtomicInteger debugMessageCount = new AtomicInteger();
 
-  ProxyServer(OptionsMetadata optionsMetadata) {
-    this(optionsMetadata, OpenTelemetry.noop());
+  /**
+   * Instantiates the ProxyServer from CLI-gathered metadata.
+   *
+   * @param optionsMetadata Resulting metadata from CLI.
+   */
+  public ProxyServer(OptionsMetadata optionsMetadata) {
+    this(optionsMetadata, Server.setupOpenTelemetry(optionsMetadata));
   }
 
   /**

--- a/src/test/java/com/google/cloud/spanner/pgadapter/AbstractMockServerTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/AbstractMockServerTest.java
@@ -68,6 +68,7 @@ import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
 import io.grpc.netty.shaded.io.grpc.netty.NettyServerBuilder;
 import io.grpc.stub.StreamObserver;
+import io.opentelemetry.api.OpenTelemetry;
 import java.net.InetSocketAddress;
 import java.nio.charset.StandardCharsets;
 import java.sql.SQLException;
@@ -1036,7 +1037,7 @@ public abstract class AbstractMockServerTest {
         .setEndpoint(String.format("localhost:%d", spannerServer.getPort()))
         .setCredentials(NoCredentials.getInstance());
     optionsConfigurator.accept(builder);
-    pgServer = new ProxyServer(builder.build());
+    pgServer = new ProxyServer(builder.build(), OpenTelemetry.noop());
     pgServer.startServer();
   }
 

--- a/src/test/java/com/google/cloud/spanner/pgadapter/PgAdapterTestEnv.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/PgAdapterTestEnv.java
@@ -43,6 +43,7 @@ import com.google.common.collect.Iterables;
 import com.google.common.primitives.Bytes;
 import com.google.spanner.admin.database.v1.CreateDatabaseMetadata;
 import com.google.spanner.admin.database.v1.UpdateDatabaseDdlMetadata;
+import io.opentelemetry.api.OpenTelemetry;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.FileInputStream;
@@ -209,7 +210,7 @@ public class PgAdapterTestEnv {
       }
       argsListBuilder.addAll(additionalPGAdapterOptions);
       String[] args = argsListBuilder.build().toArray(new String[0]);
-      server = new ProxyServer(new OptionsMetadata(args));
+      server = new ProxyServer(new OptionsMetadata(args), OpenTelemetry.noop());
       server.startServer();
     }
   }


### PR DESCRIPTION
The signature of the public constructor for ProxyServer was accidentally changed in version 0.27.0. This re-instantes the constructor with the same signature.