### PR TITLE
Fix Lower Bound of Binary Arrays

### DIFF
--- a/src/main/java/com/google/cloud/spanner/pgadapter/parsers/ArrayParser.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/parsers/ArrayParser.java
@@ -320,7 +320,7 @@ public class ArrayParser extends Parser<List<?>> {
       arrayStream.write(IntegerParser.binaryParse(1)); // Set null flag
       arrayStream.write(IntegerParser.binaryParse(Parser.toOid(this.arrayElementType))); // Set type
       arrayStream.write(IntegerParser.binaryParse(this.item.size())); // Set array length
-      arrayStream.write(IntegerParser.binaryParse(0)); // Lower bound (?)
+      arrayStream.write(IntegerParser.binaryParse(1)); // Lower bound of 1 by default
       for (Object currentItem : this.item) {
         if (currentItem == null) {
           arrayStream.write(IntegerParser.binaryParse(-1));


### PR DESCRIPTION
This Postgres defaults to 1. See https://github.com/GoogleCloudPlatform/pgadapter/issues/1259