### PR TITLE
build: pin glcoud CLI Docker image version

### DIFF
--- a/benchmarks/ycsb/Dockerfile
+++ b/benchmarks/ycsb/Dockerfile
@@ -18,7 +18,9 @@ RUN mvn package -Passembly -DskipTests
 
 
 # Docker image for the YCSB runner.
-FROM gcr.io/google.com/cloudsdktool/google-cloud-cli:slim
+# We pin the version to 455.0.0, because YCSB requires Python 2.x, and this is the last
+# version of the gcloud-cli Docker image that supports Python 2.x.
+FROM gcr.io/google.com/cloudsdktool/google-cloud-cli:455.0.0-slim
 
 RUN apt update && apt -y install postgresql-client
 RUN apt -y install default-jre


### PR DESCRIPTION
Pin the google-cloud-cli Docker image to 455.0.0, as that is the last version that supports Python 2.x. YCSB requires Python 2.x and does not support Python 3.x.