### PR TITLE
deps: use libraries bom for google cloud deps

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -141,7 +141,7 @@
     <dependency>
       <groupId>com.google.cloud.opentelemetry</groupId>
       <artifactId>exporter-trace</artifactId>
-      <version>0.26.0</version>
+      <version>0.23.0</version>
     </dependency>
     <dependency>
       <groupId>org.jetbrains.kotlin</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -75,22 +75,15 @@
     <dependencies>
       <dependency>
         <groupId>com.google.cloud</groupId>
-        <artifactId>google-cloud-spanner-bom</artifactId>
-        <version>6.51.0</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-      <dependency>
-        <groupId>com.google.cloud</groupId>
-        <artifactId>google-cloud-shared-dependencies</artifactId>
-        <version>3.17.0</version>
+        <artifactId>libraries-bom</artifactId>
+        <version>26.29.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>io.opentelemetry</groupId>
         <artifactId>opentelemetry-bom</artifactId>
-        <version>1.31.0</version>
+        <version>1.33.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -101,7 +94,6 @@
     <dependency>
       <groupId>com.google.auto.value</groupId>
       <artifactId>auto-value-annotations</artifactId>
-      <version>1.10.4</version>
     </dependency>
     <dependency>
       <groupId>org.checkerframework</groupId>
@@ -149,7 +141,13 @@
     <dependency>
       <groupId>com.google.cloud.opentelemetry</groupId>
       <artifactId>exporter-trace</artifactId>
-      <version>0.15.0</version>
+      <version>0.26.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.jetbrains.kotlin</groupId>
+      <artifactId>kotlin-stdlib-jdk8</artifactId>
+      <version>1.9.10</version>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.postgresql</groupId>

--- a/src/main/java/com/google/cloud/spanner/pgadapter/ProxyServer.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/ProxyServer.java
@@ -27,6 +27,7 @@ import com.google.cloud.spanner.pgadapter.statements.IntermediateStatement;
 import com.google.cloud.spanner.pgadapter.wireprotocol.WireMessage;
 import com.google.common.collect.ImmutableList;
 import io.opentelemetry.api.OpenTelemetry;
+import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
 import java.net.InetAddress;
@@ -307,6 +308,9 @@ public class ProxyServer extends AbstractApiService {
                   serverSocket, e));
     } finally {
       logger.log(Level.INFO, () -> String.format("Socket %s stopped", serverSocket));
+      if (openTelemetry instanceof Closeable) {
+        ((Closeable) openTelemetry).close();
+      }
       stoppedLatch.countDown();
     }
   }

--- a/src/main/java/com/google/cloud/spanner/pgadapter/Server.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/Server.java
@@ -24,6 +24,7 @@ import com.google.devtools.cloudtrace.v2.TruncatableString;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdk;
 import io.opentelemetry.sdk.trace.export.BatchSpanProcessor;
+import io.opentelemetry.sdk.trace.export.SpanExporter;
 import io.opentelemetry.sdk.trace.samplers.Sampler;
 import java.io.File;
 import java.io.FileReader;
@@ -94,7 +95,7 @@ public class Server {
                           .build())
                   .build()));
       TraceConfiguration configuration = builder.build();
-      TraceExporter traceExporter = TraceExporter.createWithConfiguration(configuration);
+      SpanExporter traceExporter = TraceExporter.createWithConfiguration(configuration);
       Sampler sampler;
       if (optionsMetadata.getOpenTelemetryTraceRatio() == null) {
         sampler = Sampler.parentBased(Sampler.traceIdRatioBased(0.05d));

--- a/src/test/java/com/google/cloud/spanner/pgadapter/AbstractMockServerTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/AbstractMockServerTest.java
@@ -938,14 +938,20 @@ public abstract class AbstractMockServerTest {
   @BeforeClass
   public static void startMockSpannerAndPgAdapterServers() throws Exception {
     doStartMockSpannerAndPgAdapterServers(
-        createMockSpannerThatReturnsOneQueryPartition(), "d", configurator -> {});
+        createMockSpannerThatReturnsOneQueryPartition(),
+        "d",
+        configurator -> {},
+        OpenTelemetry.noop());
   }
 
   protected static void doStartMockSpannerAndPgAdapterServers(
       String defaultDatabase, Consumer<TestOptionsMetadataBuilder> optionsConfigurator)
       throws Exception {
     doStartMockSpannerAndPgAdapterServers(
-        createMockSpannerThatReturnsOneQueryPartition(), defaultDatabase, optionsConfigurator);
+        createMockSpannerThatReturnsOneQueryPartition(),
+        defaultDatabase,
+        optionsConfigurator,
+        OpenTelemetry.noop());
   }
 
   public static PGobject createJdbcPgJsonbObject(String value) throws SQLException {
@@ -958,7 +964,8 @@ public abstract class AbstractMockServerTest {
   protected static void doStartMockSpannerAndPgAdapterServers(
       MockSpannerServiceImpl mockSpannerService,
       String defaultDatabase,
-      Consumer<TestOptionsMetadataBuilder> optionsConfigurator)
+      Consumer<TestOptionsMetadataBuilder> optionsConfigurator,
+      OpenTelemetry openTelemetry)
       throws Exception {
     mockSpanner = mockSpannerService;
     mockSpanner.setAbortProbability(0.0D); // We don't want any unpredictable aborted transactions.
@@ -1037,7 +1044,7 @@ public abstract class AbstractMockServerTest {
         .setEndpoint(String.format("localhost:%d", spannerServer.getPort()))
         .setCredentials(NoCredentials.getInstance());
     optionsConfigurator.accept(builder);
-    pgServer = new ProxyServer(builder.build(), OpenTelemetry.noop());
+    pgServer = new ProxyServer(builder.build(), openTelemetry);
     pgServer.startServer();
   }
 

--- a/src/test/java/com/google/cloud/spanner/pgadapter/CopyOutMockServerTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/CopyOutMockServerTest.java
@@ -44,6 +44,7 @@ import com.google.spanner.v1.*;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
 import io.grpc.stub.StreamObserver;
+import io.opentelemetry.api.OpenTelemetry;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.PipedInputStream;
@@ -86,7 +87,7 @@ public class CopyOutMockServerTest extends AbstractMockServerTest {
   @BeforeClass
   public static void startMockSpannerAndPgAdapterServers() throws Exception {
     doStartMockSpannerAndPgAdapterServers(
-        createMockSpannerServiceWithQueryPartitions(), "d", builder -> {});
+        createMockSpannerServiceWithQueryPartitions(), "d", builder -> {}, OpenTelemetry.noop());
   }
 
   private static MockSpannerServiceImpl createMockSpannerServiceWithQueryPartitions() {

--- a/src/test/java/com/google/cloud/spanner/pgadapter/ITAuthTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/ITAuthTest.java
@@ -115,7 +115,7 @@ public class ITAuthTest implements IntegrationTest {
 
   @Test
   public void testConnectWithOAuth2Token() throws Exception {
-    skipOnEmulator("Credentials are never used with the emulator");
+    IntegrationTest.skipOnEmulator("Credentials are never used with the emulator");
     String credentialsFile = System.getenv("GOOGLE_APPLICATION_CREDENTIALS");
     assumeTrue("Auth tests require default (service account) credentials", credentialsFile != null);
     assumeTrue("OAuth2 test requires gcloud", isGcloudAvailable());
@@ -154,7 +154,7 @@ public class ITAuthTest implements IntegrationTest {
 
   @Test
   public void testConnectWithCredentials() throws Exception {
-    skipOnEmulator("Credentials are never used with the emulator");
+    IntegrationTest.skipOnEmulator("Credentials are never used with the emulator");
     String credentialsFile = System.getenv("GOOGLE_APPLICATION_CREDENTIALS");
     assumeTrue("Auth tests require default (service account) credentials", credentialsFile != null);
 
@@ -177,7 +177,7 @@ public class ITAuthTest implements IntegrationTest {
 
   @Test
   public void testConnectWithPrivateKey() throws Exception {
-    skipOnEmulator("Credentials are never used with the emulator");
+    IntegrationTest.skipOnEmulator("Credentials are never used with the emulator");
     String credentialsFile = System.getenv("GOOGLE_APPLICATION_CREDENTIALS");
     assumeTrue("Auth tests require default (service account) credentials", credentialsFile != null);
 

--- a/src/test/java/com/google/cloud/spanner/pgadapter/ITDdlTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/ITDdlTest.java
@@ -191,10 +191,10 @@ public class ITDdlTest implements IntegrationTest {
         statement.addBatch("create unique index idx_tracks_title on tracks (id, title)");
         statement.addBatch(
             "create view v_singers sql security invoker as select first_name, last_name from singers"
-                + (isRunningOnEmulator() ? "" : " order by last_name"));
+                + (IntegrationTest.isRunningOnEmulator() ? "" : " order by last_name"));
         statement.addBatch(
             "create view v_venues sql security invoker as select name, description from venues"
-                + (isRunningOnEmulator() ? "" : " order by name"));
+                + (IntegrationTest.isRunningOnEmulator() ? "" : " order by name"));
 
         assertArrayEquals(new int[] {0, 0, 0, 0, 0, 0, 0, 0, 0}, statement.executeBatch());
       }

--- a/src/test/java/com/google/cloud/spanner/pgadapter/ITJdbcMetadataTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/ITJdbcMetadataTest.java
@@ -1045,7 +1045,8 @@ public class ITJdbcMetadataTest implements IntegrationTest {
     runForAllVersions(
         (connection, version) -> {
           try {
-            String expectedCatalog = isRunningOnEmulator() ? "" : database.getId().getDatabase();
+            String expectedCatalog =
+                IntegrationTest.isRunningOnEmulator() ? "" : database.getId().getDatabase();
             DatabaseMetaData metadata = connection.getMetaData();
             try (ResultSet schemas = metadata.getSchemas()) {
               assertTrue(schemas.next());

--- a/src/test/java/com/google/cloud/spanner/pgadapter/ITJdbcTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/ITJdbcTest.java
@@ -886,7 +886,9 @@ public class ITJdbcTest implements IntegrationTest {
       // when it tries to delete all data using a normal transaction.
       connection
           .createStatement()
-          .execute("delete from all_types" + (isRunningOnEmulator() ? " where true" : ""));
+          .execute(
+              "delete from all_types"
+                  + (IntegrationTest.isRunningOnEmulator() ? " where true" : ""));
     }
   }
 

--- a/src/test/java/com/google/cloud/spanner/pgadapter/ITOpenTelemetryTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/ITOpenTelemetryTest.java
@@ -1,0 +1,124 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.cloud.spanner.pgadapter;
+
+import static com.google.cloud.spanner.pgadapter.ITJdbcMetadataTest.getDdlStatements;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.cloud.spanner.Database;
+import com.google.cloud.spanner.pgadapter.metadata.OptionsMetadata;
+import com.google.cloud.trace.v1.TraceServiceClient;
+import com.google.cloud.trace.v1.TraceServiceClient.ListTracesPagedResponse;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
+import com.google.devtools.cloudtrace.v1.ListTracesRequest;
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.sdk.OpenTelemetrySdk;
+import io.opentelemetry.semconv.SemanticAttributes;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@Category(IntegrationTest.class)
+@RunWith(JUnit4.class)
+public class ITOpenTelemetryTest implements IntegrationTest {
+  private static final PgAdapterTestEnv testEnv = new PgAdapterTestEnv();
+
+  @BeforeClass
+  public static void setup() throws IOException {
+    IntegrationTest.skipOnEmulator("This test requires credentials");
+
+    OptionsMetadata.Builder openTelemetryOptionsBuilder =
+        OptionsMetadata.newBuilder()
+            .setProject(testEnv.getProjectId())
+            .setEnableOpenTelemetry()
+            .setOpenTelemetryTraceRatio(1.0);
+    if (testEnv.getCredentials() != null) {
+      openTelemetryOptionsBuilder.setCredentials(
+          GoogleCredentials.fromStream(Files.newInputStream(Paths.get(testEnv.getCredentials()))));
+    }
+    OpenTelemetry openTelemetry = Server.setupOpenTelemetry(openTelemetryOptionsBuilder.build());
+
+    testEnv.setUp();
+    Database database = testEnv.createDatabase(getDdlStatements());
+    testEnv.startPGAdapterServerWithDefaultDatabase(
+        database.getId(), ImmutableList.of(), openTelemetry);
+  }
+
+  @AfterClass
+  public static void teardown() {
+    testEnv.stopPGAdapterServer();
+    testEnv.cleanUp();
+  }
+
+  private String getConnectionUrl() {
+    return String.format("jdbc:postgresql://%s/", testEnv.getPGAdapterHostAndPort());
+  }
+
+  @Test
+  public void testSimpleSelect() throws Exception {
+    // Generate a unique select statement so it is easy to find in the traces.
+    UUID uuid = UUID.randomUUID();
+    String sql = "select '" + uuid + "'";
+    try (Connection connection = DriverManager.getConnection(getConnectionUrl())) {
+      try (ResultSet resultSet = connection.createStatement().executeQuery(sql)) {
+        assertTrue(resultSet.next());
+        assertEquals(uuid.toString(), resultSet.getString(1));
+        assertFalse(resultSet.next());
+      }
+    }
+    flushOpenTelemetry();
+    try (TraceServiceClient client = TraceServiceClient.create()) {
+      // It can take a few seconds before the trace is visible.
+      boolean foundTrace = false;
+      for (int attempts = 0; attempts < 20; attempts++) {
+        ListTracesPagedResponse response =
+            client.listTraces(
+                ListTracesRequest.newBuilder()
+                    .setProjectId(testEnv.getProjectId())
+                    .setFilter(SemanticAttributes.DB_STATEMENT + ":\"" + sql + "\"")
+                    .build());
+        int size = Iterables.size(response.iterateAll());
+        if (size != 0) {
+          assertEquals(1, Iterables.size(response.iterateAll()));
+          foundTrace = true;
+          break;
+        } else {
+          Thread.sleep(500L);
+        }
+      }
+      assertTrue(foundTrace);
+    }
+  }
+
+  private void flushOpenTelemetry() {
+    OpenTelemetrySdk openTelemetrySdk = (OpenTelemetrySdk) testEnv.getServer().getOpenTelemetry();
+    openTelemetrySdk.getSdkTracerProvider().forceFlush().join(10, TimeUnit.SECONDS);
+  }
+}

--- a/src/test/java/com/google/cloud/spanner/pgadapter/ITPgClassTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/ITPgClassTest.java
@@ -282,7 +282,7 @@ public class ITPgClassTest implements IntegrationTest {
           assertEquals(
               expected.indexrelid, expected.indisprimary, resultSet.getBoolean("indisprimary"));
           // TODO: Remove when the emulator supports indpred.
-          if (isRunningOnEmulator()) {
+          if (IntegrationTest.isRunningOnEmulator()) {
             assertNull(expected.indexrelid, resultSet.getString("indpred"));
           } else {
             assertEquals(expected.indexrelid, expected.indpred, resultSet.getString("indpred"));
@@ -616,7 +616,7 @@ public class ITPgClassTest implements IntegrationTest {
           assertEquals(expected.confdeltype, resultSet.getString("confdeltype"));
           assertEquals(expected.confmatchtype, resultSet.getString("confmatchtype"));
           // TODO: Remove check when we array_agg with order by is supported.
-          if (!isRunningOnEmulator()) {
+          if (!IntegrationTest.isRunningOnEmulator()) {
             assertArrayEquals(expected.conkey, (Long[]) resultSet.getArray("conkey").getArray());
           }
           assertArrayEquals(

--- a/src/test/java/com/google/cloud/spanner/pgadapter/IntegrationTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/IntegrationTest.java
@@ -18,11 +18,11 @@ import static org.junit.Assume.assumeFalse;
 
 /** Integration Test interface. */
 public interface IntegrationTest {
-  default void skipOnEmulator(String reason) {
+  static void skipOnEmulator(String reason) {
     assumeFalse(reason, isRunningOnEmulator());
   }
 
-  default boolean isRunningOnEmulator() {
+  static boolean isRunningOnEmulator() {
     return System.getenv("SPANNER_EMULATOR_HOST") != null;
   }
 }

--- a/src/test/java/com/google/cloud/spanner/pgadapter/OpenTelemetryMockServerTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/OpenTelemetryMockServerTest.java
@@ -1,0 +1,70 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.cloud.spanner.pgadapter;
+
+import static org.junit.Assert.assertEquals;
+
+import com.google.cloud.NoCredentials;
+import com.google.cloud.spanner.Dialect;
+import com.google.cloud.spanner.MockSpannerServiceImpl.StatementResult;
+import com.google.cloud.spanner.Statement;
+import com.google.cloud.spanner.connection.RandomResultSetGenerator;
+import com.google.cloud.spanner.pgadapter.metadata.OptionsMetadata;
+import io.opentelemetry.api.OpenTelemetry;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class OpenTelemetryMockServerTest extends AbstractMockServerTest {
+
+  @BeforeClass
+  public static void startMockSpannerAndPgAdapterServers() throws Exception {
+    OptionsMetadata options =
+        OptionsMetadata.newBuilder()
+            .setProject("p")
+            .setCredentials(NoCredentials.getInstance())
+            .setEnableOpenTelemetry()
+            .setOpenTelemetryTraceRatio(1.0)
+            .build();
+    OpenTelemetry openTelemetry = Server.setupOpenTelemetry(options);
+    doStartMockSpannerAndPgAdapterServers(
+        createMockSpannerThatReturnsOneQueryPartition(), "d", configurator -> {}, openTelemetry);
+  }
+
+  private String createUrl() {
+    return String.format("jdbc:postgresql://localhost:%d/", pgServer.getLocalPort());
+  }
+
+  @Test
+  public void testSelectInAutoCommit() throws SQLException {
+    String sql = "select * from random";
+    RandomResultSetGenerator generator = new RandomResultSetGenerator(5, Dialect.POSTGRESQL);
+    mockSpanner.putStatementResult(StatementResult.query(Statement.of(sql), generator.generate()));
+
+    try (Connection connection = DriverManager.getConnection(createUrl())) {
+      try (ResultSet resultSet = connection.createStatement().executeQuery(sql)) {
+        while (resultSet.next()) {
+          assertEquals(18, resultSet.getMetaData().getColumnCount());
+        }
+      }
+    }
+  }
+}

--- a/src/test/java/com/google/cloud/spanner/pgadapter/PgAdapterTestEnv.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/PgAdapterTestEnv.java
@@ -179,16 +179,24 @@ public class PgAdapterTestEnv {
   }
 
   public void startPGAdapterServer(Iterable<String> additionalPGAdapterOptions) {
-    startPGAdapterServer(null, additionalPGAdapterOptions);
+    startPGAdapterServer(null, additionalPGAdapterOptions, OpenTelemetry.noop());
   }
 
   public void startPGAdapterServerWithDefaultDatabase(
       DatabaseId databaseId, Iterable<String> additionalPGAdapterOptions) {
-    startPGAdapterServer(databaseId.getDatabase(), additionalPGAdapterOptions);
+    startPGAdapterServer(
+        databaseId.getDatabase(), additionalPGAdapterOptions, OpenTelemetry.noop());
+  }
+
+  public void startPGAdapterServerWithDefaultDatabase(
+      DatabaseId databaseId,
+      Iterable<String> additionalPGAdapterOptions,
+      OpenTelemetry openTelemetry) {
+    startPGAdapterServer(databaseId.getDatabase(), additionalPGAdapterOptions, openTelemetry);
   }
 
   private void startPGAdapterServer(
-      String databaseId, Iterable<String> additionalPGAdapterOptions) {
+      String databaseId, Iterable<String> additionalPGAdapterOptions, OpenTelemetry openTelemetry) {
     if (PG_ADAPTER_ADDRESS == null) {
       additionalPGAdapterOptions = maybeAddAutoConfigEmulator(additionalPGAdapterOptions);
       String credentials = getCredentials();
@@ -210,7 +218,7 @@ public class PgAdapterTestEnv {
       }
       argsListBuilder.addAll(additionalPGAdapterOptions);
       String[] args = argsListBuilder.build().toArray(new String[0]);
-      server = new ProxyServer(new OptionsMetadata(args), OpenTelemetry.noop());
+      server = new ProxyServer(new OptionsMetadata(args), openTelemetry);
       server.startServer();
     }
   }

--- a/src/test/java/com/google/cloud/spanner/pgadapter/PsqlMockServerTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/PsqlMockServerTest.java
@@ -34,6 +34,7 @@ import com.google.spanner.admin.database.v1.UpdateDatabaseDdlRequest;
 import com.google.spanner.v1.ResultSet;
 import com.google.spanner.v1.ResultSetStats;
 import com.google.spanner.v1.TypeCode;
+import io.opentelemetry.api.OpenTelemetry;
 import java.io.BufferedReader;
 import java.io.ByteArrayOutputStream;
 import java.io.DataOutputStream;
@@ -64,7 +65,8 @@ public class PsqlMockServerTest extends AbstractMockServerTest {
     doStartMockSpannerAndPgAdapterServers(
         createMockSpannerThatReturnsOneQueryPartition(),
         "d",
-        builder -> builder.setDdlTransactionMode(DdlTransactionMode.AutocommitExplicitTransaction));
+        builder -> builder.setDdlTransactionMode(DdlTransactionMode.AutocommitExplicitTransaction),
+        OpenTelemetry.noop());
   }
 
   private static boolean isPsqlAvailable() {

--- a/src/test/java/com/google/cloud/spanner/pgadapter/SSLMockServerTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/SSLMockServerTest.java
@@ -22,6 +22,7 @@ import static org.junit.Assume.assumeTrue;
 import com.google.cloud.spanner.MockSpannerServiceImpl;
 import com.google.cloud.spanner.pgadapter.metadata.OptionsMetadata.SslMode;
 import com.google.cloud.spanner.pgadapter.wireprotocol.SSLMessage;
+import io.opentelemetry.api.OpenTelemetry;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.InputStreamReader;
@@ -52,7 +53,10 @@ public class SSLMockServerTest extends AbstractMockServerTest {
     System.setProperty("javax.net.ssl.keyStorePassword", "password");
 
     doStartMockSpannerAndPgAdapterServers(
-        new MockSpannerServiceImpl(), "d", builder -> builder.setSslMode(SslMode.Require));
+        new MockSpannerServiceImpl(),
+        "d",
+        builder -> builder.setSslMode(SslMode.Require),
+        OpenTelemetry.noop());
   }
 
   @AfterClass

--- a/src/test/java/com/google/cloud/spanner/pgadapter/nodejs/ITNodePostgresTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/nodejs/ITNodePostgresTest.java
@@ -362,7 +362,7 @@ public class ITNodePostgresTest implements IntegrationTest {
 
     String output =
         runTest("testErrorInReadWriteTransaction", getHost(), testEnv.getServer().getLocalPort());
-    if (isRunningOnEmulator()) {
+    if (IntegrationTest.isRunningOnEmulator()) {
       assertEquals(
           "Insert error: error: com.google.api.gax.rpc.AlreadyExistsException: io.grpc.StatusRuntimeException: ALREADY_EXISTS: Failed to insert row with primary key ({pk#name:\"foo\"}) due to previously existing row\n"
               + "Second insert failed with error: error: current transaction is aborted, commands ignored until end of transaction block\n"

--- a/src/test/java/com/google/cloud/spanner/pgadapter/python/psycopg3/ITPsycopg3Test.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/python/psycopg3/ITPsycopg3Test.java
@@ -448,7 +448,7 @@ public class ITPsycopg3Test implements IntegrationTest {
 
     String result = execute("batch_execution_error");
     assertTrue(result, result.contains("Executing batch failed with error"));
-    if (isRunningOnEmulator()) {
+    if (IntegrationTest.isRunningOnEmulator()) {
       assertTrue(
           result,
           result.contains(
@@ -563,7 +563,7 @@ public class ITPsycopg3Test implements IntegrationTest {
             + "col_array_jsonb: None\n";
 
     String result = execute("binary_copy_out");
-    if (isRunningOnEmulator()) {
+    if (IntegrationTest.isRunningOnEmulator()) {
       assertEquals(row2 + row1, result);
     } else {
       assertEquals(row1 + row2, result);
@@ -619,7 +619,7 @@ public class ITPsycopg3Test implements IntegrationTest {
             + "col_array_jsonb: None\n";
 
     String result = execute("text_copy_out");
-    if (isRunningOnEmulator()) {
+    if (IntegrationTest.isRunningOnEmulator()) {
       assertEquals(row2 + row1, result);
     } else {
       assertEquals(row1 + row2, result);


### PR DESCRIPTION
- Use the `libraries-bom` instead of separate dependencies and/or only the `cloud-spanner-bom`. This makes it easier to add compatible dependencies for other Google Cloud products to the stack, such as Cloud Tracing.
- Adds tests for Cloud Tracing.