### PR TITLE
fix: use array lower bound 1 by default

### DIFF
--- a/src/main/java/com/google/cloud/spanner/pgadapter/parsers/ArrayParser.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/parsers/ArrayParser.java
@@ -320,7 +320,9 @@ public class ArrayParser extends Parser<List<?>> {
       arrayStream.write(IntegerParser.binaryParse(1)); // Set null flag
       arrayStream.write(IntegerParser.binaryParse(Parser.toOid(this.arrayElementType))); // Set type
       arrayStream.write(IntegerParser.binaryParse(this.item.size())); // Set array length
-      arrayStream.write(IntegerParser.binaryParse(0)); // Lower bound (?)
+      // Use lower bound 1 for all arrays. This is the only possible value in the text format, as
+      // it does not have a field for the lower bound. It is also the default that is used by PG.
+      arrayStream.write(IntegerParser.binaryParse(1)); // Lower bound.
       for (Object currentItem : this.item) {
         if (currentItem == null) {
           arrayStream.write(IntegerParser.binaryParse(-1));

--- a/src/test/java/com/google/cloud/spanner/pgadapter/golang/ITPgxTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/golang/ITPgxTest.java
@@ -35,6 +35,7 @@ import com.google.cloud.spanner.pgadapter.PgAdapterTestEnv;
 import com.google.cloud.spanner.pgadapter.metadata.OptionsMetadata;
 import java.math.BigDecimal;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import org.junit.AfterClass;
@@ -147,6 +148,33 @@ public class ITPgxTest implements IntegrationTest {
                 .to("test")
                 .set("col_jsonb")
                 .to("{\"key\": \"value\"}")
+                .set("col_array_bigint")
+                .toInt64Array(Arrays.asList(1L, null, 2L))
+                .set("col_array_bool")
+                .toBoolArray(Arrays.asList(true, null, false))
+                .set("col_array_bytea")
+                .toBytesArray(
+                    Arrays.asList(ByteArray.copyFrom("bytes1"), null, ByteArray.copyFrom("bytes2")))
+                .set("col_array_float8")
+                .toFloat64Array(Arrays.asList(3.14d, null, -99.99d))
+                .set("col_array_int")
+                .toInt64Array(Arrays.asList(-100L, null, -200L))
+                .set("col_array_numeric")
+                .toPgNumericArray(Arrays.asList("6.626", null, "-3.14"))
+                .set("col_array_timestamptz")
+                .toTimestampArray(
+                    Arrays.asList(
+                        Timestamp.parseTimestamp("2022-02-16T16:18:02.123456Z"),
+                        null,
+                        Timestamp.parseTimestamp("2000-01-01T00:00:00Z")))
+                .set("col_array_date")
+                .toDateArray(
+                    Arrays.asList(Date.parseDate("2023-02-20"), null, Date.parseDate("2000-01-01")))
+                .set("col_array_varchar")
+                .toStringArray(Arrays.asList("string1", null, "string2"))
+                .set("col_array_jsonb")
+                .toPgJsonbArray(
+                    Arrays.asList("{\"key\": \"value1\"}", null, "{\"key\": \"value2\"}"))
                 .build()));
   }
 

--- a/src/test/java/com/google/cloud/spanner/pgadapter/golang/PgxMockServerTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/golang/PgxMockServerTest.java
@@ -253,6 +253,16 @@ public class PgxMockServerTest extends AbstractMockServerTest {
           Oid.TIMESTAMPTZ,
           Oid.VARCHAR,
           Oid.JSONB,
+          Oid.INT8_ARRAY,
+          Oid.BOOL_ARRAY,
+          Oid.BYTEA_ARRAY,
+          Oid.FLOAT8_ARRAY,
+          Oid.INT4_ARRAY,
+          Oid.NUMERIC_ARRAY,
+          Oid.DATE_ARRAY,
+          Oid.TIMESTAMPTZ_ARRAY,
+          Oid.VARCHAR_ARRAY,
+          Oid.JSONB_ARRAY,
         }) {
       for (int format : new int[] {0, 1}) {
         String res = pgxTest.TestQueryAllDataTypes(createConnString(), oid, format);
@@ -261,8 +271,7 @@ public class PgxMockServerTest extends AbstractMockServerTest {
         List<ExecuteSqlRequest> requests = mockSpanner.getRequestsOfType(ExecuteSqlRequest.class);
         // pgx by default always uses prepared statements. As this statement does not contain any
         // parameters, we don't need to describe the parameter types, so it is 'only' sent twice to
-        // the
-        // backend.
+        // the backend.
         assertEquals(2, requests.size());
         ExecuteSqlRequest describeRequest = requests.get(0);
         assertEquals(sql, describeRequest.getSql());

--- a/src/test/java/com/google/cloud/spanner/pgadapter/parsers/ParserTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/parsers/ParserTest.java
@@ -266,7 +266,7 @@ public class ParserTest {
     // https://github.com/GoogleCloudPlatform/pgadapter/pull/36
     // has been merged.
     byte[] byteResult = {
-      0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 4, 19, 0, 0, 0, 3, 0, 0, 0, 0, 0, 0, 0, 3, 97, 98, 99, 0, 0, 0,
+      0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 4, 19, 0, 0, 0, 3, 0, 0, 0, 1, 0, 0, 0, 3, 97, 98, 99, 0, 0, 0,
       3, 100, 101, 102, 0, 0, 0, 3, 106, 104, 105
     };
     byte[] stringResult = {
@@ -296,7 +296,7 @@ public class ParserTest {
     // https://github.com/GoogleCloudPlatform/pgadapter/pull/36
     // has been merged.
     byte[] byteResult = {
-      0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 20, 0, 0, 0, 3, 0, 0, 0, 0, 0, 0, 0, 8, 0, 0, 0, 0, 0, 0, 0,
+      0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 20, 0, 0, 0, 3, 0, 0, 0, 1, 0, 0, 0, 8, 0, 0, 0, 0, 0, 0, 0,
       1, 0, 0, 0, 8, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 8, 0, 0, 0, 0, 0, 0, 0, 3
     };
     byte[] stringResult = {'{', '1', ',', '2', ',', '3', '}'};


### PR DESCRIPTION
PGAdapter would return arrays in binary format with lower bound 0 (zero) by default. This is not consistent with open-source PostgreSQL, which uses 1 as the default lower bound, and also not consistent with the text format, which does not have a field for returning the lower bound. The lower bound is then assumed to be 1. This changes the default lower bound for binary encoded arrays to 1.

Fixes #1259