### PR TITLE
fix: support pg_database

### DIFF
--- a/src/main/java/com/google/cloud/spanner/pgadapter/statements/PgCatalog.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/statements/PgCatalog.java
@@ -48,6 +48,10 @@ public class PgCatalog {
               new TableOrIndexName(null, "pg_namespace"),
               new TableOrIndexName(null, "pg_namespace"))
           .put(
+              new TableOrIndexName("pg_catalog", "pg_database"),
+              new TableOrIndexName(null, "pg_database"))
+          .put(new TableOrIndexName(null, "pg_database"), new TableOrIndexName(null, "pg_database"))
+          .put(
               new TableOrIndexName("pg_collation", "pg_collation"),
               new TableOrIndexName(null, "pg_collation"))
           .put(
@@ -134,6 +138,7 @@ public class PgCatalog {
   private static final Map<TableOrIndexName, PgCatalogTable> DEFAULT_PG_CATALOG_TABLES =
       ImmutableMap.<TableOrIndexName, PgCatalogTable>builder()
           .put(new TableOrIndexName(null, "pg_namespace"), new PgNamespace())
+          .put(new TableOrIndexName(null, "pg_database"), new PgDatabase())
           .put(new TableOrIndexName(null, "pg_collation"), new PgCollation())
           .put(new TableOrIndexName(null, "pg_proc"), new PgProc())
           .put(new TableOrIndexName(null, "pg_enum"), new EmptyPgEnum())
@@ -304,6 +309,38 @@ public class PgCatalog {
     @Override
     public String getTableExpression() {
       return PG_NAMESPACE_CTE;
+    }
+  }
+
+  @InternalApi
+  public static class PgDatabase implements PgCatalogTable {
+    // https://www.postgresql.org/docs/current/catalog-pg-database.html
+    public static final String PG_DATABASE_CTE =
+        "pg_database as (\n"
+            + "  select 0::bigint as oid,\n"
+            + "         catalog_name as datname,\n"
+            + "         0::bigint as datdba,\n"
+            + "         6::bigint as encoding,\n"
+            + "         'c' as datlocprovider,\n"
+            + "         'C' as datcollate,\n"
+            + "         'C' as datctype,\n"
+            + "         false as datistemplate,\n"
+            + "         true as datallowconn,\n"
+            + "         -1::bigint as datconnlimit,\n"
+            + "         0::bigint as datlastsysoid,\n"
+            + "         0::bigint as datfrozenxid,\n"
+            + "         0::bigint as datminmxid,\n"
+            + "         0::bigint as dattablespace,\n"
+            + "         null as daticulocale,\n"
+            + "         null as daticurules,\n"
+            + "         null as datcollversion,\n"
+            + "         null as datacl"
+            + "  from information_schema.information_schema_catalog_name\n"
+            + ")";
+
+    @Override
+    public String getTableExpression() {
+      return PG_DATABASE_CTE;
     }
   }
 

--- a/src/test/java/com/google/cloud/spanner/pgadapter/ITJdbcMetadataTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/ITJdbcMetadataTest.java
@@ -1026,8 +1026,6 @@ public class ITJdbcMetadataTest implements IntegrationTest {
 
   @Test
   public void testDatabaseMetaDataCatalogs() throws Exception {
-    skipOnEmulator("The emulator does not support pg_catalog.pg_database");
-
     runForAllVersions(
         (connection, version) -> {
           try {

--- a/src/test/java/com/google/cloud/spanner/pgadapter/ITJdbcMetadataTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/ITJdbcMetadataTest.java
@@ -1026,6 +1026,9 @@ public class ITJdbcMetadataTest implements IntegrationTest {
 
   @Test
   public void testDatabaseMetaDataCatalogs() throws Exception {
+    skipOnEmulator(
+        "information_schema.information_schema_catalog_name is not supported on the emulator");
+
     runForAllVersions(
         (connection, version) -> {
           try {

--- a/src/test/java/com/google/cloud/spanner/pgadapter/JdbcMockServerTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/JdbcMockServerTest.java
@@ -372,6 +372,59 @@ public class JdbcMockServerTest extends AbstractMockServerTest {
   }
 
   @Test
+  public void testGetCatalogs() throws SQLException {
+    mockSpanner.putStatementResult(
+        StatementResult.query(
+            Statement.of(
+                "with pg_database as (\n"
+                    + "  select 0::bigint as oid,\n"
+                    + "         catalog_name as datname,\n"
+                    + "         0::bigint as datdba,\n"
+                    + "         6::bigint as encoding,\n"
+                    + "         'c' as datlocprovider,\n"
+                    + "         'C' as datcollate,\n"
+                    + "         'C' as datctype,\n"
+                    + "         false as datistemplate,\n"
+                    + "         true as datallowconn,\n"
+                    + "         -1::bigint as datconnlimit,\n"
+                    + "         0::bigint as datlastsysoid,\n"
+                    + "         0::bigint as datfrozenxid,\n"
+                    + "         0::bigint as datminmxid,\n"
+                    + "         0::bigint as dattablespace,\n"
+                    + "         null as daticulocale,\n"
+                    + "         null as daticurules,\n"
+                    + "         null as datcollversion,\n"
+                    + "         null as datacl  from information_schema.information_schema_catalog_name\n"
+                    + ")\n"
+                    + "SELECT datname AS TABLE_CAT FROM pg_database WHERE datallowconn = true ORDER BY datname"),
+            com.google.spanner.v1.ResultSet.newBuilder()
+                .setMetadata(
+                    ResultSetMetadata.newBuilder()
+                        .setRowType(
+                            StructType.newBuilder()
+                                .addFields(
+                                    Field.newBuilder()
+                                        .setName("TABLE_CAT")
+                                        .setType(Type.newBuilder().setCode(TypeCode.STRING).build())
+                                        .build())
+                                .build())
+                        .build())
+                .addRows(
+                    ListValue.newBuilder()
+                        .addValues(Value.newBuilder().setStringValue("test-database").build())
+                        .build())
+                .build()));
+
+    try (Connection connection = DriverManager.getConnection(createUrl())) {
+      try (ResultSet catalogs = connection.getMetaData().getCatalogs()) {
+        assertTrue(catalogs.next());
+        assertEquals("test-database", catalogs.getString("TABLE_CAT"));
+        assertFalse(catalogs.next());
+      }
+    }
+  }
+
+  @Test
   public void testStatementReturnGeneratedKeys() throws SQLException {
     String sql = "insert into test (id, value) values (1, 'One')";
     mockSpanner.putStatementResult(


### PR DESCRIPTION
The newest version of the PostgreSQL JDBC driver uses pg_database to produce a result for the DatabaseMetaData#getCatalogs() method. This change adds support for pg_database through a common table expression.

Fixes #1306
Fixes #1307