### PR TITLE
fix: add libs to Docker build with emulator

### DIFF
--- a/.github/workflows/docker-build-and-push.yaml
+++ b/.github/workflows/docker-build-and-push.yaml
@@ -40,24 +40,24 @@ jobs:
           export TAG=`echo $GITHUB_REF | awk -F/ '{print $NF}'`
           echo $TAG
           docker buildx create --name multi_platform --use
-          docker buildx build --platform linux/amd64,linux/arm64 \
-            . -f build/Dockerfile \
-            -t "$GCR_HOSTNAME"/"$IMAGE":"$TAG" \
-            -t "$GCR_HOSTNAME"/"$IMAGE":latest \
-            --push \
-            --build-arg GITHUB_SHA="$GITHUB_SHA" \
-            --build-arg GITHUB_REF="$GITHUB_REF"
-          docker buildx build --platform linux/amd64,linux/arm64 \
-            . -f build/distroless/Dockerfile \
-            -t "$GCR_HOSTNAME"/"$IMAGE"-distroless:"$TAG" \
-            -t "$GCR_HOSTNAME"/"$IMAGE"-distroless:latest \
-            --push \
-            --build-arg GITHUB_SHA="$GITHUB_SHA" \
-            --build-arg GITHUB_REF="$GITHUB_REF"
+#          docker buildx build --platform linux/amd64,linux/arm64 \
+#            . -f build/Dockerfile \
+#            -t "$GCR_HOSTNAME"/"$IMAGE":"$TAG" \
+#            -t "$GCR_HOSTNAME"/"$IMAGE":latest \
+#            --push \
+#            --build-arg GITHUB_SHA="$GITHUB_SHA" \
+#            --build-arg GITHUB_REF="$GITHUB_REF"
+#          docker buildx build --platform linux/amd64,linux/arm64 \
+#            . -f build/distroless/Dockerfile \
+#            -t "$GCR_HOSTNAME"/"$IMAGE"-distroless:"$TAG" \
+#            -t "$GCR_HOSTNAME"/"$IMAGE"-distroless:latest \
+#            --push \
+#            --build-arg GITHUB_SHA="$GITHUB_SHA" \
+#            --build-arg GITHUB_REF="$GITHUB_REF"
           docker buildx build --platform linux/amd64,linux/arm64 \
             . -f build/emulator/Dockerfile \
             -t "$GCR_HOSTNAME"/"$IMAGE"-emulator:"$TAG" \
-            -t "$GCR_HOSTNAME"/"$IMAGE"-emulator:latest \
+#            -t "$GCR_HOSTNAME"/"$IMAGE"-emulator:latest \
             --push \
             --build-arg GITHUB_SHA="$GITHUB_SHA" \
             --build-arg GITHUB_REF="$GITHUB_REF"

--- a/.github/workflows/docker-build-and-push.yaml
+++ b/.github/workflows/docker-build-and-push.yaml
@@ -40,24 +40,9 @@ jobs:
           export TAG=`echo $GITHUB_REF | awk -F/ '{print $NF}'`
           echo $TAG
           docker buildx create --name multi_platform --use
-#          docker buildx build --platform linux/amd64,linux/arm64 \
-#            . -f build/Dockerfile \
-#            -t "$GCR_HOSTNAME"/"$IMAGE":"$TAG" \
-#            -t "$GCR_HOSTNAME"/"$IMAGE":latest \
-#            --push \
-#            --build-arg GITHUB_SHA="$GITHUB_SHA" \
-#            --build-arg GITHUB_REF="$GITHUB_REF"
-#          docker buildx build --platform linux/amd64,linux/arm64 \
-#            . -f build/distroless/Dockerfile \
-#            -t "$GCR_HOSTNAME"/"$IMAGE"-distroless:"$TAG" \
-#            -t "$GCR_HOSTNAME"/"$IMAGE"-distroless:latest \
-#            --push \
-#            --build-arg GITHUB_SHA="$GITHUB_SHA" \
-#            --build-arg GITHUB_REF="$GITHUB_REF"
           docker buildx build --platform linux/amd64,linux/arm64 \
             . -f build/emulator/Dockerfile \
             -t "$GCR_HOSTNAME"/"$IMAGE"-emulator:"$TAG" \
-#            -t "$GCR_HOSTNAME"/"$IMAGE"-emulator:latest \
             --push \
             --build-arg GITHUB_SHA="$GITHUB_SHA" \
             --build-arg GITHUB_REF="$GITHUB_REF"

--- a/.github/workflows/docker-build-and-push.yaml
+++ b/.github/workflows/docker-build-and-push.yaml
@@ -41,8 +41,23 @@ jobs:
           echo $TAG
           docker buildx create --name multi_platform --use
           docker buildx build --platform linux/amd64,linux/arm64 \
+            . -f build/Dockerfile \
+            -t "$GCR_HOSTNAME"/"$IMAGE":"$TAG" \
+            -t "$GCR_HOSTNAME"/"$IMAGE":latest \
+            --push \
+            --build-arg GITHUB_SHA="$GITHUB_SHA" \
+            --build-arg GITHUB_REF="$GITHUB_REF"
+          docker buildx build --platform linux/amd64,linux/arm64 \
+            . -f build/distroless/Dockerfile \
+            -t "$GCR_HOSTNAME"/"$IMAGE"-distroless:"$TAG" \
+            -t "$GCR_HOSTNAME"/"$IMAGE"-distroless:latest \
+            --push \
+            --build-arg GITHUB_SHA="$GITHUB_SHA" \
+            --build-arg GITHUB_REF="$GITHUB_REF"
+          docker buildx build --platform linux/amd64,linux/arm64 \
             . -f build/emulator/Dockerfile \
             -t "$GCR_HOSTNAME"/"$IMAGE"-emulator:"$TAG" \
+            -t "$GCR_HOSTNAME"/"$IMAGE"-emulator:latest \
             --push \
             --build-arg GITHUB_SHA="$GITHUB_SHA" \
             --build-arg GITHUB_REF="$GITHUB_REF"

--- a/build/emulator/Dockerfile
+++ b/build/emulator/Dockerfile
@@ -12,17 +12,17 @@ FROM gcr.io/cloud-spanner-pg-adapter/pgadapter AS pgadapter
 ADD build/emulator/startup.sh /home/pgadapter/startup.sh
 RUN chmod +x /home/pgadapter/startup.sh
 
+# Add the emulator binaries.
 COPY --from=emulator /gateway_main /emulator/gateway_main
 COPY --from=emulator /emulator_main /emulator/emulator_main
 COPY --from=emulator /licenses.txt.gz /emulator/licenses.txt.gz
 RUN chmod u+x /emulator/gateway_main
 RUN chmod u+x /emulator/emulator_main
 
-# Add the emulator binaries.
+# Add the emulator libraries.
 COPY --from=emulator /lib/* /lib/
 COPY --from=emulator /lib64/* /lib64/
 COPY --from=emulator /usr/lib/* /usr/lib/
-COPY --from=emulator /var/* /var/
 
 # Expose 5432 (PGAdapter PostgreSQL port), 9010 (Emulator gRPC port), and 9020 (Emulator REST port)
 EXPOSE 5432 9010 9020

--- a/build/emulator/Dockerfile
+++ b/build/emulator/Dockerfile
@@ -12,16 +12,17 @@ FROM gcr.io/cloud-spanner-pg-adapter/pgadapter AS pgadapter
 ADD build/emulator/startup.sh /home/pgadapter/startup.sh
 RUN chmod +x /home/pgadapter/startup.sh
 
-# Add the emulator binaries.
-COPY --from=emulator /lib/* /lib/
-COPY --from=emulator /lib64/* /lib64/
-COPY --from=emulator /usr/lib/* /usr/lib/
-COPY --from=emulator /var/* /var/
 COPY --from=emulator /gateway_main /emulator/gateway_main
 COPY --from=emulator /emulator_main /emulator/emulator_main
 COPY --from=emulator /licenses.txt.gz /emulator/licenses.txt.gz
 RUN chmod u+x /emulator/gateway_main
 RUN chmod u+x /emulator/emulator_main
+
+# Add the emulator binaries.
+COPY --from=emulator /lib/* /lib/
+COPY --from=emulator /lib64/* /lib64/
+COPY --from=emulator /usr/lib/* /usr/lib/
+COPY --from=emulator /var/* /var/
 
 # Expose 5432 (PGAdapter PostgreSQL port), 9010 (Emulator gRPC port), and 9020 (Emulator REST port)
 EXPOSE 5432 9010 9020

--- a/build/emulator/Dockerfile
+++ b/build/emulator/Dockerfile
@@ -20,9 +20,9 @@ RUN chmod u+x /emulator/gateway_main
 RUN chmod u+x /emulator/emulator_main
 
 # Add the emulator libraries.
-COPY --from=emulator /lib/* /lib/
-COPY --from=emulator /lib64/* /lib64/
-COPY --from=emulator /usr/lib/* /usr/lib/
+COPY --from=emulator /lib /lib
+COPY --from=emulator /lib64 /lib64
+COPY --from=emulator /usr/lib /usr/lib
 
 # Expose 5432 (PGAdapter PostgreSQL port), 9010 (Emulator gRPC port), and 9020 (Emulator REST port)
 EXPOSE 5432 9010 9020

--- a/build/emulator/Dockerfile
+++ b/build/emulator/Dockerfile
@@ -13,6 +13,10 @@ ADD build/emulator/startup.sh /home/pgadapter/startup.sh
 RUN chmod +x /home/pgadapter/startup.sh
 
 # Add the emulator binaries.
+COPY --from=emulator /lib/* /lib/
+COPY --from=emulator /lib64/* /lib64/
+COPY --from=emulator /usr/lib/* /usr/lib/
+COPY --from=emulator /var/* /var/
 COPY --from=emulator /gateway_main /emulator/gateway_main
 COPY --from=emulator /emulator_main /emulator/emulator_main
 COPY --from=emulator /licenses.txt.gz /emulator/licenses.txt.gz


### PR DESCRIPTION
Adds libs from the emulator Docker image to the combined PGAdapter + Emulator Docker image during the build.