### PR TITLE
fix: limit the num bytes to write to length

### DIFF
--- a/src/main/java/com/google/cloud/spanner/pgadapter/parsers/StringParser.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/parsers/StringParser.java
@@ -87,7 +87,8 @@ public class StringParser extends Parser<String> {
       } else {
         try (OutputStreamWriter writer =
             new OutputStreamWriter(dataOutputStream, StandardCharsets.UTF_8)) {
-          dataOutputStream.writeInt(Utf8.encodedLength(value) + header.length);
+          int utf8Length = Utf8.encodedLength(value) + header.length;
+          dataOutputStream.writeInt(utf8Length);
           dataOutputStream.write(header);
           for (int offset = 0; offset < length; offset += bufferSize) {
             int writeLen = Math.min(bufferSize, length - offset);


### PR DESCRIPTION
Some Java 8 implementations return more bytes from wrapped CharSource than there are. This would cause the converter to write 2 more bytes than it should, which again would cause the next message in the buffer to be wrong, as the last 2 bytes would become part of the length of the next message. This could cause the stream to get blocked.