### PR TITLE
fix: allow space between timestamp and timezone

### DIFF
--- a/src/main/java/com/google/cloud/spanner/pgadapter/parsers/TimestampParser.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/parsers/TimestampParser.java
@@ -67,6 +67,7 @@ public class TimestampParser extends Parser<Timestamp> {
           .parseCaseInsensitive()
           .appendPattern("yyyy-MM-dd HH:mm:ss")
           .appendFraction(ChronoField.NANO_OF_SECOND, 0, 9, true)
+          .appendPattern("[ ]")
           // Java 8 does not support seconds in timezone offset.
           .appendOffset(OptionsMetadata.isJava8() ? "+HH:mm" : "+HH:mm:ss", "+00:00:00")
           .toFormatter();
@@ -74,7 +75,7 @@ public class TimestampParser extends Parser<Timestamp> {
       new DateTimeFormatterBuilder()
           .parseLenient()
           .parseCaseInsensitive()
-          .appendPattern("yyyy-MM-dd[[ ]['T']HH:mm[:ss][XXX]]")
+          .appendPattern("yyyy-MM-dd[[ ]['T']HH:mm[:ss][ ][XXX]]")
           .appendFraction(ChronoField.NANO_OF_SECOND, 0, 9, true)
           .toFormatter();
 

--- a/src/test/java/com/google/cloud/spanner/pgadapter/parsers/TimestampParserTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/parsers/TimestampParserTest.java
@@ -143,6 +143,9 @@ public class TimestampParserTest {
     assertEquals(
         Timestamp.parseTimestamp("2011-11-04T00:05:23.123456Z"),
         TimestampParser.toTimestamp("'2011-11-04 00:05:23.123456+00:00'", ZoneId.of("UTC")));
+    assertEquals(
+        Timestamp.parseTimestamp("2011-11-04T00:05:23.123456Z"),
+        TimestampParser.toTimestamp("'2011-11-04 00:05:23.123456 +00:00'", ZoneId.of("UTC")));
     assertThrows(PGException.class, () -> TimestampParser.toTimestamp("", ZoneId.of("UTC")));
     assertThrows(PGException.class, () -> TimestampParser.toTimestamp("(", ZoneId.of("UTC")));
     assertThrows(PGException.class, () -> TimestampParser.toTimestamp(")", ZoneId.of("UTC")));
@@ -178,5 +181,9 @@ public class TimestampParserTest {
         Timestamp.parseTimestamp("2011-11-04T00:05:23.123456Z"),
         TimestampParser.toTimestamp(
             "\t\n( \"  2011-11-04 00:05:23.123456+00:00  \n\t\" )", ZoneId.of("UTC")));
+    assertEquals(
+        Timestamp.parseTimestamp("2011-11-04T00:05:23.123456Z"),
+        TimestampParser.toTimestamp(
+            "\t\n( \"  2011-11-04 00:05:23.123456 +00:00  \n\t\" )", ZoneId.of("UTC")));
   }
 }


### PR DESCRIPTION
Timestamps with a space between the timestamp and the timezone were not accepted by PGAdapter when these were given as a query parameter value.