### PR TITLE
test: verify that the JDBC driver is recognized with weird date style

### DIFF
--- a/src/main/java/com/google/cloud/spanner/pgadapter/ProxyServer.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/ProxyServer.java
@@ -183,7 +183,7 @@ public class ProxyServer extends AbstractApiService {
         listenerThread.start();
       }
       try {
-        if (startupLatch.await(30L, TimeUnit.SECONDS)) {
+        if (startupLatch.await(options.getStartupTimeout().toMillis(), TimeUnit.MILLISECONDS)) {
           notifyStarted();
         } else {
           throw SpannerExceptionFactory.newSpannerException(

--- a/src/test/java/com/google/cloud/spanner/pgadapter/JdbcMockServerTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/JdbcMockServerTest.java
@@ -875,6 +875,20 @@ public class JdbcMockServerTest extends AbstractMockServerTest {
   }
 
   @Test
+  public void testShowWellKnownClient() throws SQLException {
+    try (Connection connection =
+        DriverManager.getConnection(
+            String.format("jdbc:postgresql://localhost:%d/", pgServer.getLocalPort()))) {
+      try (ResultSet resultSet =
+          connection.createStatement().executeQuery("show spanner.well_known_client")) {
+        assertTrue(resultSet.next());
+        assertEquals("JDBC", resultSet.getString(1));
+        assertFalse(resultSet.next());
+      }
+    }
+  }
+
+  @Test
   public void testSetWellKnownClient() throws SQLException {
     for (String client : new String[] {"pgx", "npgsql", "sqlalchemy2"}) {
       try (Connection connection =

--- a/src/test/java/com/google/cloud/spanner/pgadapter/ProxyServerTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/ProxyServerTest.java
@@ -1,0 +1,54 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.cloud.spanner.pgadapter;
+
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+import com.google.cloud.spanner.pgadapter.metadata.OptionsMetadata;
+import com.google.cloud.spanner.pgadapter.metadata.TestOptionsMetadataBuilder;
+import java.time.Duration;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class ProxyServerTest {
+
+  @Test
+  public void testFailedStartProxyServer() {
+    ProxyServer server = new ProxyServer(OptionsMetadata.newBuilder().setPort(0).build());
+    server.startServer();
+
+    // Try to start another server on the same port.
+    TestOptionsMetadataBuilder builder = new TestOptionsMetadataBuilder();
+    ProxyServer server2 =
+        new ProxyServer(
+            builder
+                .setStartupTimeout(Duration.ofMillis(10L))
+                .setPort(server.getLocalPort())
+                .build());
+    IllegalStateException exception =
+        assertThrows(IllegalStateException.class, server2::startServer);
+    assertTrue(
+        exception.getMessage(),
+        exception
+            .getMessage()
+            .contains(
+                "Expected the service InnerService [FAILED] to be RUNNING, but the service has FAILED"));
+
+    server.stopServer();
+  }
+}

--- a/src/test/java/com/google/cloud/spanner/pgadapter/metadata/OptionsMetadataTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/metadata/OptionsMetadataTest.java
@@ -14,6 +14,7 @@
 
 package com.google.cloud.spanner.pgadapter.metadata;
 
+import static com.google.cloud.spanner.pgadapter.metadata.OptionsMetadata.DEFAULT_STARTUP_TIMEOUT;
 import static com.google.cloud.spanner.pgadapter.metadata.OptionsMetadata.parseSslMode;
 import static com.google.cloud.spanner.pgadapter.metadata.OptionsMetadata.toServerVersionNum;
 import static org.junit.Assert.assertEquals;
@@ -53,6 +54,7 @@ public class OptionsMetadataTest {
           new OptionsMetadata(
               Collections.emptyMap(),
               os,
+              DEFAULT_STARTUP_TIMEOUT,
               new String[] {"-p", "p", "-i", "i", "-c", "credentials.json"});
       if (options.isWindows()) {
         assertEquals("", options.getSocketFile(5432));
@@ -71,6 +73,7 @@ public class OptionsMetadataTest {
           new OptionsMetadata(
               Collections.emptyMap(),
               os,
+              DEFAULT_STARTUP_TIMEOUT,
               new String[] {"-p p", "-i i", "-c \"\"", "-dir /pgadapter"});
       assertEquals(
           "/pgadapter" + File.separatorChar + ".s.PGSQL.5432", options.getSocketFile(5432));

--- a/src/test/java/com/google/cloud/spanner/pgadapter/metadata/TestOptionsMetadataBuilder.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/metadata/TestOptionsMetadataBuilder.java
@@ -14,6 +14,8 @@
 
 package com.google.cloud.spanner.pgadapter.metadata;
 
+import java.time.Duration;
+
 public class TestOptionsMetadataBuilder extends OptionsMetadata.Builder {
 
   @Override
@@ -28,8 +30,15 @@ public class TestOptionsMetadataBuilder extends OptionsMetadata.Builder {
     return this;
   }
 
+  @Override
   public TestOptionsMetadataBuilder setUsePlainText() {
     super.setUsePlainText();
+    return this;
+  }
+
+  @Override
+  public TestOptionsMetadataBuilder setStartupTimeout(Duration timeout) {
+    super.setStartupTimeout(timeout);
     return this;
   }
 }

--- a/src/test/java/com/google/cloud/spanner/pgadapter/utils/ClientAutoDetectorTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/utils/ClientAutoDetectorTest.java
@@ -93,6 +93,28 @@ public class ClientAutoDetectorTest {
                 "client_encoding", "UTF8",
                 "DateStyle", "ISO",
                 "TimeZone", "some-time-zone")));
+    // Version 42.7.0 of the JDBC driver by accident used 'MDY' as the DateStyle.
+    assertEquals(
+        WellKnownClient.JDBC,
+        ClientAutoDetector.detectClient(
+            ImmutableList.of("user", "database", "client_encoding", "DateStyle", "TimeZone"),
+            ImmutableMap.of(
+                "user", "some-user",
+                "database", "some-database",
+                "client_encoding", "UTF8",
+                "DateStyle", "ISO, MDY",
+                "TimeZone", "some-time-zone")));
+    // Other values for DateStyle have never been used.
+    assertNotEquals(
+        WellKnownClient.JDBC,
+        ClientAutoDetector.detectClient(
+            ImmutableList.of("user", "database", "client_encoding", "DateStyle", "TimeZone"),
+            ImmutableMap.of(
+                "user", "some-user",
+                "database", "some-database",
+                "client_encoding", "UTF8",
+                "DateStyle", "ISO, DMY",
+                "TimeZone", "some-time-zone")));
     // Additional parameters are allowed.
     assertEquals(
         WellKnownClient.JDBC,


### PR DESCRIPTION
The PostgreSQL JDBC driver by accident used a weird date style only in version 42.7.0. These tests verify that the driver is always recognized.