### PR TITLE
feat: support large batches in gorm

### DIFF
--- a/samples/golang/gorm/README.md
+++ b/samples/golang/gorm/README.md
@@ -71,7 +71,6 @@ The following limitations are currently known:
 | Nested transactions    | Nested transactions and savepoints are not supported. It is therefore recommended to set the configuration option `DisableNestedTransaction: true,`                                                                                                                |
 | Locking                | Lock clauses (e.g. `clause.Locking{Strength: "UPDATE"}`) are not supported. These are generally speaking also not required, as the default isolation level that is used by Cloud Spanner is serializable.                                                          |
 | Auto-save associations | Auto saved associations are not supported, as these will automatically use an OnConflict clause                                                                                                                                                                    |
-| Large CreateInBatches  | PGAdapter can handle at most 50 parameters in a prepared statement. A large number of rows in a `CreateInBatches` call can exceed this limit. Limit the batch size to a smaller number to prevent `gorm` from generating a statement with more than 50 parameters. |
 
 ### Migrations
 Migrations are not supported as Cloud Spanner does not support the full PostgreSQL DDL dialect.

--- a/samples/golang/gorm/drop_data_model.sql
+++ b/samples/golang/gorm/drop_data_model.sql
@@ -4,6 +4,7 @@
 /* skip_on_open_source_pg */ start batch ddl;
 
 drop table if exists ticket_sales;
+drop sequence if exists ticket_sale_seq;
 drop table if exists concerts;
 drop table if exists venues;
 drop table if exists tracks;

--- a/samples/golang/gorm/sample.go
+++ b/samples/golang/gorm/sample.go
@@ -20,19 +20,18 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"github.com/lib/pq"
 	"math/rand"
 	"os"
 	"strings"
 	"time"
 
+	wrapper "github.com/GoogleCloudPlatform/pgadapter/wrappers/golang"
+	"github.com/google/uuid"
+	"github.com/lib/pq"
+	"github.com/shopspring/decimal"
 	"github.com/testcontainers/testcontainers-go"
 	pgWrapper "github.com/testcontainers/testcontainers-go/modules/postgres"
 	"github.com/testcontainers/testcontainers-go/wait"
-
-	wrapper "github.com/GoogleCloudPlatform/pgadapter/wrappers/golang"
-	"github.com/google/uuid"
-	"github.com/shopspring/decimal"
 	"gorm.io/datatypes"
 	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
@@ -697,10 +696,8 @@ func CreateAlbumWithRandomTracks(db *gorm.DB, singerId, albumTitle string, numTr
 		tracks[n] = &Track{BaseModel: BaseModel{ID: albumId}, TrackNumber: int64(n + 1), Title: randTrackTitle(), SampleRate: randFloat64(30.0, 60.0)}
 	}
 
-	// Note: The batch size is deliberately kept small here in order to prevent the statement from getting too big and
-	// exceeding the maximum number of parameters in a prepared statement. PGAdapter can currently handle at most 50
-	// parameters in a prepared statement.
-	res = db.CreateInBatches(tracks, 8)
+	// Using a relatively large batch size reduces the number of round-trips to the database.
+	res = db.CreateInBatches(tracks, 100)
 	return albumId, res.Error
 }
 

--- a/src/test/golang/pgadapter_gorm_tests/gorm.go
+++ b/src/test/golang/pgadapter_gorm_tests/gorm.go
@@ -428,15 +428,16 @@ func TestCreateInBatches(connString string) *C.char {
 	}
 	defer conn.Close()
 
-	res := db.CreateInBatches([]*AllTypes{
-		{ColVarchar: stringRef("1")},
-		{ColVarchar: stringRef("2")},
-		{ColVarchar: stringRef("3")},
-	}, 10)
+	numRows := 100
+	rows := make([]*AllTypes, numRows)
+	for i := 0; i < numRows; i++ {
+		rows[i] = &AllTypes{ColVarchar: stringRef(fmt.Sprintf("%d", i))}
+	}
+	res := db.CreateInBatches(rows, 10)
 	if res.Error != nil {
 		return C.CString(fmt.Sprintf("failed to execute insert batch: %v", res.Error))
 	}
-	if g, w := res.RowsAffected, int64(3); g != w {
+	if g, w := res.RowsAffected, int64(numRows); g != w {
 		return C.CString(fmt.Sprintf("rows affected mismatch\nGot:  %v\nWant: %v", g, w))
 	}
 


### PR DESCRIPTION
The limitation that large batches are not supported in gorm can now be removed, as PGAdapter supports statements with more than 50 query parameters. This is also supported on the emulator, and can be enabled in the sample application.