### PR TITLE
chore: add qps config to latency benchmark

### DIFF
--- a/.github/workflows/benchmark-tests.yml
+++ b/.github/workflows/benchmark-tests.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 name: benchmark-tests
 jobs:
-  java-samples:
+  java-benchmarks:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -16,5 +16,5 @@ jobs:
           distribution: zulu
           java-version: 17
       - name: Run Java Latency Benchmark tests
-        working-directory: ./benchmarks/latency-comparisons/java
+        working-directory: ./benchmarks/latency-comparison/java
         run: mvn test -B

--- a/benchmarks/latency-comparison/java/README.md
+++ b/benchmarks/latency-comparison/java/README.md
@@ -41,3 +41,11 @@ Run a benchmark with 32 parallel clients each executing 5,000 operations:
 ```shell
 mvn clean compile exec:java -Dexec.args="--clients=32 --operations=5000"
 ```
+
+
+Run a benchmark with 32 parallel clients each executing 1 query per second.
+Each client executes 100 queries:
+
+```shell
+mvn clean compile exec:java -Dexec.args="--clients=32 --operations=100 --wait 1000"
+```

--- a/benchmarks/latency-comparison/java/pom.xml
+++ b/benchmarks/latency-comparison/java/pom.xml
@@ -38,6 +38,25 @@
     <version>1.7.1</version>
   </parent>
 
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>com.google.cloud</groupId>
+        <artifactId>libraries-bom</artifactId>
+        <version>26.32.0</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>io.opentelemetry</groupId>
+        <artifactId>opentelemetry-bom</artifactId>
+        <version>1.35.0</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <dependencies>
     <dependency>
       <groupId>com.google.auto.value</groupId>
@@ -46,19 +65,12 @@
     </dependency>
     <dependency>
       <groupId>com.google.cloud</groupId>
-      <artifactId>google-cloud-spanner-pgadapter</artifactId>
-      <version>0.29.1</version>
+      <artifactId>google-cloud-spanner-jdbc</artifactId>
     </dependency>
     <dependency>
       <groupId>com.google.cloud</groupId>
-      <artifactId>google-cloud-spanner-jdbc</artifactId>
-      <version>2.15.3</version>
-      <exclusions>
-        <exclusion>
-          <groupId>com.google.cloud</groupId>
-          <artifactId>google-cloud-spanner</artifactId>
-        </exclusion>
-      </exclusions>
+      <artifactId>google-cloud-spanner-pgadapter</artifactId>
+      <version>0.30.0</version>
     </dependency>
     <dependency>
       <groupId>org.postgresql</groupId>

--- a/benchmarks/latency-comparison/java/src/main/java/com/google/cloud/spanner/pgadapter/latency/BenchmarkRunner.java
+++ b/benchmarks/latency-comparison/java/src/main/java/com/google/cloud/spanner/pgadapter/latency/BenchmarkRunner.java
@@ -19,5 +19,5 @@ import java.util.List;
 
 public interface BenchmarkRunner {
 
-  List<Duration> execute(String sql, int numClients, int numOperations);
+  List<Duration> execute(String sql, int numClients, int numOperations, int waitMillis);
 }


### PR DESCRIPTION
Add a QPS configuration option to the latency comparison benchmark. This allows for running benchmarks where the clients are waiting between each query, e.g. having 32 clients all running 1 qps.