### PR TITLE
fix: respect the SPANNER_EMULATOR_HOST env var

### DIFF
--- a/src/test/java/com/google/cloud/spanner/pgadapter/metadata/OptionsMetadataTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/metadata/OptionsMetadataTest.java
@@ -590,13 +590,13 @@ public class OptionsMetadataTest {
   @Test
   public void testBuildConnectionUrlWithEmulator() {
     assertEquals(
-        "cloudspanner:/projects/my-project/instances/my-instance/databases/my-database;userAgent=pg-adapter",
+        "cloudspanner://localhost:9010/projects/my-project/instances/my-instance/databases/my-database;userAgent=pg-adapter;usePlainText=true",
         OptionsMetadata.newBuilder()
             .setEnvironment(ImmutableMap.of("SPANNER_EMULATOR_HOST", "localhost:9010"))
             .build()
             .buildConnectionURL("projects/my-project/instances/my-instance/databases/my-database"));
     assertEquals(
-        "cloudspanner:/projects/my-project/instances/my-instance/databases/my-database;userAgent=pg-adapter",
+        "cloudspanner://localhost:9010/projects/my-project/instances/my-instance/databases/my-database;userAgent=pg-adapter;usePlainText=true",
         OptionsMetadata.newBuilder()
             .setRequireAuthentication()
             .setEnvironment(ImmutableMap.of("SPANNER_EMULATOR_HOST", "localhost:9010"))


### PR DESCRIPTION
Only setting the SPANNER_EMULATOR_HOST environment variable without the autoConfigEmulator=true option would not cause PGAdapter to connect to the emulator.