### PR TITLE
chore: support OpenTelemetry metrics

### DIFF
--- a/docs/open_telemetry.md
+++ b/docs/open_telemetry.md
@@ -1,7 +1,8 @@
-# Open Telemetry in PGAdapter
+# OpenTelemetry in PGAdapter
 
-PGAdapter supports Open Telemetry tracing. You can enable this by adding the `-enable_otel` command
-line argument when starting PGAdapter.
+PGAdapter supports OpenTelemetry tracing and metrics. You can enable the tracing or the metrics
+by adding the `-enable_otel` or `-enable_otel_metrics` command line argument when starting
+PGAdapter. Tracing and metrics can be enabled at the same time.
 
 Optionally, you can also set a trace sample ratio to limit the number of traces that will be
 collected and set with the `-otel_trace_ratio=<ratio>` command line argument. If you omit this
@@ -16,7 +17,8 @@ docker run \
   gcr.io/cloud-spanner-pg-adapter/pgadapter \
   -p my-project -i my-instance \
   -c /credentials.json -x \
-  -enable_otel -otel_trace_ratio=0.1
+  -enable_otel -otel_trace_ratio=0.1 \
+  -enable_otel_metrics
 ```
 
 ## Exporter
@@ -143,6 +145,15 @@ statements consists of the following spans:
    execute this batch request on Cloud Spanner.
 
 ![PGAdapter Cloud Trace - Batch DML example](img/dml_batch_trace_sample.png?raw=true "PGAdapter Cloud Trace - Batch DML example")
+
+## Metrics
+
+The available metrics in PGAdapter are:
+
+* `spanner/pgadapter/roundtrip_latencies`: Latency between PGAdapter receiving a statement from
+   the client and PGAdapter returning the last row of the response to the client.
+* `spanner/pgadapter/client_lib_latencies`: Latency when the Spanner's client library receives
+   a call and returns a response.
 
 ## Frequently Asked Questions
 

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
     <excludedIntegrationTests/>
 
     <junixsocket.version>2.8.3</junixsocket.version>
-    <opentelemetry.exporter.version>0.27.0</opentelemetry.exporter.version>
+    <opentelemetry.exporter.version>0.23.0</opentelemetry.exporter.version>
   </properties>
 
   <modelVersion>4.0.0</modelVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -37,6 +37,7 @@
     <excludedIntegrationTests/>
 
     <junixsocket.version>2.8.3</junixsocket.version>
+    <opentelemetry.exporter.version>0.27.0</opentelemetry.exporter.version>
   </properties>
 
   <modelVersion>4.0.0</modelVersion>
@@ -141,7 +142,12 @@
     <dependency>
       <groupId>com.google.cloud.opentelemetry</groupId>
       <artifactId>exporter-trace</artifactId>
-      <version>0.23.0</version>
+      <version>${opentelemetry.exporter.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.cloud.opentelemetry</groupId>
+      <artifactId>exporter-metrics</artifactId>
+      <version>${opentelemetry.exporter.version}</version>
     </dependency>
     <dependency>
       <groupId>org.jetbrains.kotlin</groupId>

--- a/src/main/java/com/google/cloud/spanner/pgadapter/Server.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/Server.java
@@ -15,6 +15,8 @@
 package com.google.cloud.spanner.pgadapter;
 
 import com.google.auth.Credentials;
+import com.google.cloud.opentelemetry.metric.GoogleCloudMetricExporter;
+import com.google.cloud.opentelemetry.metric.MetricConfiguration;
 import com.google.cloud.opentelemetry.trace.TraceConfiguration;
 import com.google.cloud.opentelemetry.trace.TraceExporter;
 import com.google.cloud.spanner.pgadapter.metadata.OptionsMetadata;
@@ -23,6 +25,8 @@ import com.google.devtools.cloudtrace.v2.AttributeValue;
 import com.google.devtools.cloudtrace.v2.TruncatableString;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdk;
+import io.opentelemetry.sdk.metrics.export.MetricExporter;
+import io.opentelemetry.sdk.metrics.export.PeriodicMetricReader;
 import io.opentelemetry.sdk.trace.export.BatchSpanProcessor;
 import io.opentelemetry.sdk.trace.export.SpanExporter;
 import io.opentelemetry.sdk.trace.samplers.Sampler;
@@ -104,12 +108,24 @@ public class Server {
             Sampler.parentBased(
                 Sampler.traceIdRatioBased(optionsMetadata.getOpenTelemetryTraceRatio()));
       }
+      MetricExporter cloudMonitoringExporter =
+          GoogleCloudMetricExporter.createWithConfiguration(
+              MetricConfiguration.builder()
+                  // Configure the cloud project id.
+                  .setProjectId(projectId)
+                  // Set the credentials to use when writing to the Cloud Monitoring API
+                  .setCredentials(credentials)
+                  .build());
       return AutoConfiguredOpenTelemetrySdk.builder()
           .addTracerProviderCustomizer(
               (sdkTracerProviderBuilder, configProperties) ->
                   sdkTracerProviderBuilder
                       .setSampler(sampler)
                       .addSpanProcessor(BatchSpanProcessor.builder(traceExporter).build()))
+          .addMeterProviderCustomizer(
+              (sdkMeterProviderBuilder, configProperties) ->
+                  sdkMeterProviderBuilder.registerMetricReader(
+                      PeriodicMetricReader.builder(cloudMonitoringExporter).build()))
           .build()
           .getOpenTelemetrySdk();
     } catch (IOException exception) {

--- a/src/main/java/com/google/cloud/spanner/pgadapter/metadata/OptionsMetadata.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/metadata/OptionsMetadata.java
@@ -550,6 +550,7 @@ public class OptionsMetadata {
   private static final String OPTION_BINARY_FORMAT = "b";
   private static final String OPTION_AUTHENTICATE = "a";
   private static final String OPTION_ENABLE_OPEN_TELEMETRY = "enable_otel";
+  private static final String OPTION_ENABLE_OPEN_TELEMETRY_METRICS = "enable_otel_metrics";
   private static final String OPTION_OPEN_TELEMETRY_TRACE_RATIO = "otel_trace_ratio";
   private static final String OPTION_SSL = "ssl";
   private static final String OPTION_DISABLE_AUTO_DETECT_CLIENT = "disable_auto_detect_client";
@@ -593,6 +594,7 @@ public class OptionsMetadata {
   private final boolean binaryFormat;
   private final boolean authenticate;
   private final boolean enableOpenTelemetry;
+  private final boolean enableOpenTelemetryMetrics;
   private final Double openTelemetryTraceRatio;
   private final SslMode sslMode;
   private final boolean disableAutoDetectClient;
@@ -679,6 +681,7 @@ public class OptionsMetadata {
     this.binaryFormat = commandLine.hasOption(OPTION_BINARY_FORMAT);
     this.authenticate = commandLine.hasOption(OPTION_AUTHENTICATE);
     this.enableOpenTelemetry = commandLine.hasOption(OPTION_ENABLE_OPEN_TELEMETRY);
+    this.enableOpenTelemetryMetrics = commandLine.hasOption(OPTION_ENABLE_OPEN_TELEMETRY_METRICS);
     this.openTelemetryTraceRatio =
         parseOpenTelemetryTraceRatio(commandLine.getOptionValue(OPTION_OPEN_TELEMETRY_TRACE_RATIO));
     this.sslMode = parseSslMode(commandLine.getOptionValue(OPTION_SSL));
@@ -757,6 +760,7 @@ public class OptionsMetadata {
     this.binaryFormat = forceBinary;
     this.authenticate = authenticate;
     this.enableOpenTelemetry = false;
+    this.enableOpenTelemetryMetrics = false;
     this.openTelemetryTraceRatio = null;
     this.sslMode = SslMode.Disable;
     this.disableAutoDetectClient = false;
@@ -1125,6 +1129,8 @@ public class OptionsMetadata {
         "Whether you wish the proxy to perform an authentication step.");
     options.addOption(null, OPTION_ENABLE_OPEN_TELEMETRY, false, "Enable OpenTelemetry tracing.");
     options.addOption(
+        null, OPTION_ENABLE_OPEN_TELEMETRY_METRICS, false, "Enable OpenTelemetry metrics.");
+    options.addOption(
         null,
         OPTION_OPEN_TELEMETRY_TRACE_RATIO,
         true,
@@ -1462,6 +1468,10 @@ public class OptionsMetadata {
 
   public boolean isEnableOpenTelemetry() {
     return this.enableOpenTelemetry;
+  }
+
+  public boolean isEnableOpenTelemetryMetrics() {
+    return this.enableOpenTelemetryMetrics;
   }
 
   public Double getOpenTelemetryTraceRatio() {

--- a/src/main/java/com/google/cloud/spanner/pgadapter/statements/BackendConnection.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/statements/BackendConnection.java
@@ -1500,7 +1500,7 @@ public class BackendConnection {
         Stopwatch stopwatch = Stopwatch.createStarted();
         long[] counts = spannerConnection.runBatch();
         Duration executionDuration = stopwatch.elapsed();
-        meter.recordClientLibLatency(executionDuration.toMillis(), metricAttributes);
+        metrics.recordClientLibLatency(executionDuration.toMillis(), metricAttributes);
         if (batchType == StatementType.DDL) {
           counts = extractDdlUpdateCounts(statementResults, counts);
         }

--- a/src/main/java/com/google/cloud/spanner/pgadapter/statements/BackendConnection.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/statements/BackendConnection.java
@@ -1491,7 +1491,10 @@ public class BackendConnection {
       }
       Span runBatchSpan = createSpan("execute_batch_on_spanner", null);
       try (Scope ignoreRunBatchSpan = runBatchSpan.makeCurrent()) {
+        Stopwatch stopwatch = Stopwatch.createStarted();
         long[] counts = spannerConnection.runBatch();
+        Duration executionDuration = stopwatch.elapsed();
+        meter.recordClientLibLatency(executionDuration.toMillis(), metricAttributes);
         if (batchType == StatementType.DDL) {
           counts = extractDdlUpdateCounts(statementResults, counts);
         }

--- a/src/main/java/com/google/cloud/spanner/pgadapter/statements/ExtendedQueryProtocolHandler.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/statements/ExtendedQueryProtocolHandler.java
@@ -76,6 +76,7 @@ public class ExtendedQueryProtocolHandler {
         new BackendConnection(
             tracer,
             meter,
+            metricAttributes,
             connectionHandler.getTraceConnectionId().toString(),
             connectionHandler::closeAllPortals,
             connectionHandler.getDatabaseId(),
@@ -110,13 +111,12 @@ public class ExtendedQueryProtocolHandler {
     return backendConnection;
   }
 
-  public static Attributes getMetricAttributes(DatabaseId databaseId) {
+  @VisibleForTesting
+  static Attributes getMetricAttributes(DatabaseId databaseId) {
     AttributesBuilder attributesBuilder = Attributes.builder();
-    if (databaseId != null) {
-      attributesBuilder.put("database", databaseId.getDatabase());
-      attributesBuilder.put("instance_id", databaseId.getInstanceId().getInstance());
-      attributesBuilder.put("project_id", databaseId.getInstanceId().getProject());
-    }
+    attributesBuilder.put("database", databaseId.getDatabase());
+    attributesBuilder.put("instance_id", databaseId.getInstanceId().getInstance());
+    attributesBuilder.put("project_id", databaseId.getInstanceId().getProject());
     return attributesBuilder.build();
   }
 

--- a/src/main/java/com/google/cloud/spanner/pgadapter/utils/Metrics.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/utils/Metrics.java
@@ -1,0 +1,75 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.google.cloud.spanner.pgadapter.utils;
+
+import com.google.api.core.InternalApi;
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.metrics.LongHistogram;
+import io.opentelemetry.api.metrics.Meter;
+import java.util.Arrays;
+import java.util.List;
+
+@InternalApi
+public class Metrics {
+  static final String INSTRUMENTATION_SCOPE = "cloud.google.com/java";
+  static final String SPANNER_CLIENT_LIB_LATENCY = "spanner/pgadapter/client_lib_latencies";
+  static final String SPANNER_CLIENT_LIB_LATENCY_DESCRIPTION =
+      "Latency when the client library receives a call and returns a response";
+  static final String PGADAPTER_LATENCY = "spanner/pgadapter/roundtrip_latencies";
+  static final String PGADAPTER_LATENCY_DESCRIPTION =
+      "Latency when the JDBC makes a call and gets a response, measured in PGAdapter";
+
+  private final LongHistogram spannerClientLibLatencies;
+  private final LongHistogram pgadapterLatencies;
+
+  public Metrics(OpenTelemetry openTelemetry) {
+    Meter meter = openTelemetry.getMeter(INSTRUMENTATION_SCOPE);
+    List<Long> RPC_MILLIS_BUCKET_BOUNDARIES =
+        Arrays.asList(
+            1L, 2L, 3L, 4L, 5L, 6L, 8L, 10L, 13L, 16L, 20L, 25L, 30L, 40L, 50L, 65L, 80L, 100L,
+            130L, 160L, 200L, 250L, 300L, 400L, 500L, 650L, 800L, 1000L, 2000L, 5000L, 10000L,
+            20000L, 50000L, 100000L);
+    spannerClientLibLatencies =
+        meter
+            .histogramBuilder(SPANNER_CLIENT_LIB_LATENCY)
+            .ofLongs()
+            .setDescription(SPANNER_CLIENT_LIB_LATENCY_DESCRIPTION)
+            .setUnit("ms")
+            .setExplicitBucketBoundariesAdvice(RPC_MILLIS_BUCKET_BOUNDARIES)
+            .build();
+    pgadapterLatencies =
+        meter
+            .histogramBuilder(PGADAPTER_LATENCY)
+            .ofLongs()
+            .setDescription(PGADAPTER_LATENCY_DESCRIPTION)
+            .setUnit("ms")
+            .setExplicitBucketBoundariesAdvice(RPC_MILLIS_BUCKET_BOUNDARIES)
+            .build();
+  }
+
+  @InternalApi
+  public void recordClientLibLatency(long value, Attributes attributes) {
+    if (spannerClientLibLatencies != null) {
+      spannerClientLibLatencies.record(value, attributes);
+    }
+  }
+
+  @InternalApi
+  public void recordPGAdapterLatency(long value, Attributes attributes) {
+    if (pgadapterLatencies != null) {
+      pgadapterLatencies.record(value, attributes);
+    }
+  }
+}

--- a/src/main/java/com/google/cloud/spanner/pgadapter/utils/Metrics.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/utils/Metrics.java
@@ -29,7 +29,7 @@ public class Metrics {
       "Latency when the client library receives a call and returns a response";
   static final String PGADAPTER_LATENCY = "spanner/pgadapter/roundtrip_latencies";
   static final String PGADAPTER_LATENCY_DESCRIPTION =
-      "Latency when the JDBC makes a call and gets a response, measured in PGAdapter";
+      "Latency between PGAdapter receiving a statement from the client and PGAdapter returning the last row of the response to the client";
 
   private final LongHistogram spannerClientLibLatencies;
   private final LongHistogram pgadapterLatencies;
@@ -61,15 +61,11 @@ public class Metrics {
 
   @InternalApi
   public void recordClientLibLatency(long value, Attributes attributes) {
-    if (spannerClientLibLatencies != null) {
-      spannerClientLibLatencies.record(value, attributes);
-    }
+    spannerClientLibLatencies.record(value, attributes);
   }
 
   @InternalApi
   public void recordPGAdapterLatency(long value, Attributes attributes) {
-    if (pgadapterLatencies != null) {
-      pgadapterLatencies.record(value, attributes);
-    }
+    pgadapterLatencies.record(value, attributes);
   }
 }

--- a/src/test/java/com/google/cloud/spanner/pgadapter/statements/BackendConnectionTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/statements/BackendConnectionTest.java
@@ -63,6 +63,7 @@ import com.google.cloud.spanner.pgadapter.utils.Metrics;
 import com.google.cloud.spanner.pgadapter.utils.MutationWriter;
 import com.google.common.collect.ImmutableList;
 import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.trace.Tracer;
 import java.util.UUID;
 import java.util.concurrent.ExecutionException;
@@ -82,6 +83,9 @@ public class BackendConnectionTest {
       AbstractStatementParser.getInstance(Dialect.POSTGRESQL);
   private static final NoResult NO_RESULT = new NoResult();
   private static final Runnable DO_NOTHING = () -> {};
+  private static final DatabaseId DATABASE_ID = DatabaseId.of("p", "i", "d");
+  private static final Attributes METRIC_ATTRIBUTES =
+      ExtendedQueryProtocolHandler.getMetricAttributes(DATABASE_ID);
 
   @Test
   public void testExtractDdlUpdateCounts() {
@@ -120,9 +124,10 @@ public class BackendConnectionTest {
         new BackendConnection(
             NOOP_OTEL,
             NOOP_OTEL_METER,
+            METRIC_ATTRIBUTES,
             UUID.randomUUID().toString(),
             DO_NOTHING,
-            DatabaseId.of("p", "i", "d"),
+            DATABASE_ID,
             spannerConnection,
             () -> WellKnownClient.UNSPECIFIED,
             mock(OptionsMetadata.class),
@@ -161,9 +166,10 @@ public class BackendConnectionTest {
         new BackendConnection(
             NOOP_OTEL,
             NOOP_OTEL_METER,
+            METRIC_ATTRIBUTES,
             UUID.randomUUID().toString(),
             DO_NOTHING,
-            DatabaseId.of("p", "i", "d"),
+            DATABASE_ID,
             spannerConnection,
             () -> WellKnownClient.UNSPECIFIED,
             mock(OptionsMetadata.class),
@@ -203,9 +209,10 @@ public class BackendConnectionTest {
         new BackendConnection(
             NOOP_OTEL,
             NOOP_OTEL_METER,
+            METRIC_ATTRIBUTES,
             UUID.randomUUID().toString(),
             DO_NOTHING,
-            DatabaseId.of("p", "i", "d"),
+            DATABASE_ID,
             spannerConnection,
             () -> WellKnownClient.UNSPECIFIED,
             mock(OptionsMetadata.class),
@@ -221,9 +228,10 @@ public class BackendConnectionTest {
         new BackendConnection(
             NOOP_OTEL,
             NOOP_OTEL_METER,
+            METRIC_ATTRIBUTES,
             UUID.randomUUID().toString(),
             DO_NOTHING,
-            DatabaseId.of("p", "i", "d"),
+            DATABASE_ID,
             spannerConnection,
             () -> WellKnownClient.UNSPECIFIED,
             mock(OptionsMetadata.class),
@@ -237,9 +245,10 @@ public class BackendConnectionTest {
         new BackendConnection(
             NOOP_OTEL,
             NOOP_OTEL_METER,
+            METRIC_ATTRIBUTES,
             UUID.randomUUID().toString(),
             DO_NOTHING,
-            DatabaseId.of("p", "i", "d"),
+            DATABASE_ID,
             spannerConnection,
             () -> WellKnownClient.UNSPECIFIED,
             mock(OptionsMetadata.class),
@@ -255,9 +264,10 @@ public class BackendConnectionTest {
         new BackendConnection(
             NOOP_OTEL,
             NOOP_OTEL_METER,
+            METRIC_ATTRIBUTES,
             UUID.randomUUID().toString(),
             DO_NOTHING,
-            DatabaseId.of("p", "i", "d"),
+            DATABASE_ID,
             spannerConnection,
             () -> WellKnownClient.UNSPECIFIED,
             mock(OptionsMetadata.class),
@@ -273,9 +283,10 @@ public class BackendConnectionTest {
         new BackendConnection(
             NOOP_OTEL,
             NOOP_OTEL_METER,
+            METRIC_ATTRIBUTES,
             UUID.randomUUID().toString(),
             DO_NOTHING,
-            DatabaseId.of("p", "i", "d"),
+            DATABASE_ID,
             spannerConnection,
             () -> WellKnownClient.UNSPECIFIED,
             mock(OptionsMetadata.class),
@@ -291,9 +302,10 @@ public class BackendConnectionTest {
         new BackendConnection(
             NOOP_OTEL,
             NOOP_OTEL_METER,
+            METRIC_ATTRIBUTES,
             UUID.randomUUID().toString(),
             DO_NOTHING,
-            DatabaseId.of("p", "i", "d"),
+            DATABASE_ID,
             spannerConnection,
             () -> WellKnownClient.UNSPECIFIED,
             mock(OptionsMetadata.class),
@@ -309,9 +321,10 @@ public class BackendConnectionTest {
         new BackendConnection(
             NOOP_OTEL,
             NOOP_OTEL_METER,
+            METRIC_ATTRIBUTES,
             UUID.randomUUID().toString(),
             DO_NOTHING,
-            DatabaseId.of("p", "i", "d"),
+            DATABASE_ID,
             spannerConnection,
             () -> WellKnownClient.UNSPECIFIED,
             mock(OptionsMetadata.class),
@@ -327,9 +340,10 @@ public class BackendConnectionTest {
         new BackendConnection(
             NOOP_OTEL,
             NOOP_OTEL_METER,
+            METRIC_ATTRIBUTES,
             UUID.randomUUID().toString(),
             DO_NOTHING,
-            DatabaseId.of("p", "i", "d"),
+            DATABASE_ID,
             spannerConnection,
             () -> WellKnownClient.UNSPECIFIED,
             mock(OptionsMetadata.class),
@@ -345,9 +359,10 @@ public class BackendConnectionTest {
         new BackendConnection(
             NOOP_OTEL,
             NOOP_OTEL_METER,
+            METRIC_ATTRIBUTES,
             UUID.randomUUID().toString(),
             DO_NOTHING,
-            DatabaseId.of("p", "i", "d"),
+            DATABASE_ID,
             spannerConnection,
             () -> WellKnownClient.UNSPECIFIED,
             mock(OptionsMetadata.class),
@@ -379,9 +394,10 @@ public class BackendConnectionTest {
         new BackendConnection(
             NOOP_OTEL,
             NOOP_OTEL_METER,
+            METRIC_ATTRIBUTES,
             UUID.randomUUID().toString(),
             DO_NOTHING,
-            DatabaseId.of("p", "i", "d"),
+            DATABASE_ID,
             connection,
             () -> WellKnownClient.UNSPECIFIED,
             mock(OptionsMetadata.class),
@@ -420,9 +436,10 @@ public class BackendConnectionTest {
         new BackendConnection(
             NOOP_OTEL,
             NOOP_OTEL_METER,
+            METRIC_ATTRIBUTES,
             UUID.randomUUID().toString(),
             DO_NOTHING,
-            DatabaseId.of("p", "i", "d"),
+            DATABASE_ID,
             connection,
             () -> WellKnownClient.UNSPECIFIED,
             mock(OptionsMetadata.class),
@@ -460,9 +477,10 @@ public class BackendConnectionTest {
         new BackendConnection(
             NOOP_OTEL,
             NOOP_OTEL_METER,
+            METRIC_ATTRIBUTES,
             UUID.randomUUID().toString(),
             DO_NOTHING,
-            DatabaseId.of("p", "i", "d"),
+            DATABASE_ID,
             connection,
             () -> WellKnownClient.UNSPECIFIED,
             mock(OptionsMetadata.class),
@@ -490,9 +508,10 @@ public class BackendConnectionTest {
         new BackendConnection(
             NOOP_OTEL,
             NOOP_OTEL_METER,
+            METRIC_ATTRIBUTES,
             UUID.randomUUID().toString(),
             DO_NOTHING,
-            DatabaseId.of("p", "i", "d"),
+            DATABASE_ID,
             connection,
             () -> WellKnownClient.UNSPECIFIED,
             mock(OptionsMetadata.class),
@@ -532,9 +551,10 @@ public class BackendConnectionTest {
         new BackendConnection(
             NOOP_OTEL,
             NOOP_OTEL_METER,
+            METRIC_ATTRIBUTES,
             UUID.randomUUID().toString(),
             DO_NOTHING,
-            DatabaseId.of("p", "i", "d"),
+            DATABASE_ID,
             connection,
             () -> WellKnownClient.UNSPECIFIED,
             mock(OptionsMetadata.class),
@@ -564,9 +584,10 @@ public class BackendConnectionTest {
         new BackendConnection(
             NOOP_OTEL,
             NOOP_OTEL_METER,
+            METRIC_ATTRIBUTES,
             UUID.randomUUID().toString(),
             DO_NOTHING,
-            DatabaseId.of("p", "i", "d"),
+            DATABASE_ID,
             connection,
             () -> WellKnownClient.UNSPECIFIED,
             options,
@@ -594,9 +615,10 @@ public class BackendConnectionTest {
         new BackendConnection(
             NOOP_OTEL,
             NOOP_OTEL_METER,
+            METRIC_ATTRIBUTES,
             UUID.randomUUID().toString(),
             DO_NOTHING,
-            DatabaseId.of("p", "i", "d"),
+            DATABASE_ID,
             connection,
             () -> WellKnownClient.UNSPECIFIED,
             options,
@@ -625,9 +647,10 @@ public class BackendConnectionTest {
           new BackendConnection(
               NOOP_OTEL,
               NOOP_OTEL_METER,
+              METRIC_ATTRIBUTES,
               UUID.randomUUID().toString(),
               DO_NOTHING,
-              DatabaseId.of("p", "i", "d"),
+              DATABASE_ID,
               connection,
               () -> WellKnownClient.UNSPECIFIED,
               mock(OptionsMetadata.class),
@@ -652,9 +675,10 @@ public class BackendConnectionTest {
         new BackendConnection(
             NOOP_OTEL,
             NOOP_OTEL_METER,
+            METRIC_ATTRIBUTES,
             UUID.randomUUID().toString(),
             DO_NOTHING,
-            DatabaseId.of("p", "i", "d"),
+            DATABASE_ID,
             connection,
             () -> WellKnownClient.UNSPECIFIED,
             mock(OptionsMetadata.class),
@@ -685,9 +709,10 @@ public class BackendConnectionTest {
         new BackendConnection(
             NOOP_OTEL,
             NOOP_OTEL_METER,
+            METRIC_ATTRIBUTES,
             UUID.randomUUID().toString(),
             DO_NOTHING,
-            DatabaseId.of("p", "i", "d"),
+            DATABASE_ID,
             connection,
             () -> WellKnownClient.UNSPECIFIED,
             mock(OptionsMetadata.class),
@@ -716,9 +741,10 @@ public class BackendConnectionTest {
         new BackendConnection(
             NOOP_OTEL,
             NOOP_OTEL_METER,
+            METRIC_ATTRIBUTES,
             UUID.randomUUID().toString(),
             DO_NOTHING,
-            DatabaseId.of("p", "i", "d"),
+            DATABASE_ID,
             connection,
             () -> WellKnownClient.UNSPECIFIED,
             mock(OptionsMetadata.class),
@@ -746,9 +772,10 @@ public class BackendConnectionTest {
         new BackendConnection(
             NOOP_OTEL,
             NOOP_OTEL_METER,
+            METRIC_ATTRIBUTES,
             UUID.randomUUID().toString(),
             DO_NOTHING,
-            DatabaseId.of("p", "i", "d"),
+            DATABASE_ID,
             connection,
             () -> WellKnownClient.UNSPECIFIED,
             mock(OptionsMetadata.class),
@@ -786,9 +813,10 @@ public class BackendConnectionTest {
         new BackendConnection(
             NOOP_OTEL,
             NOOP_OTEL_METER,
+            METRIC_ATTRIBUTES,
             UUID.randomUUID().toString(),
             DO_NOTHING,
-            DatabaseId.of("p", "i", "d"),
+            DATABASE_ID,
             connection,
             () -> WellKnownClient.UNSPECIFIED,
             mock(OptionsMetadata.class),
@@ -825,9 +853,10 @@ public class BackendConnectionTest {
         new BackendConnection(
             NOOP_OTEL,
             NOOP_OTEL_METER,
+            METRIC_ATTRIBUTES,
             UUID.randomUUID().toString(),
             DO_NOTHING,
-            DatabaseId.of("p", "i", "d"),
+            DATABASE_ID,
             connection,
             () -> WellKnownClient.UNSPECIFIED,
             mock(OptionsMetadata.class),

--- a/src/test/java/com/google/cloud/spanner/pgadapter/statements/BackendConnectionTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/statements/BackendConnectionTest.java
@@ -59,6 +59,7 @@ import com.google.cloud.spanner.pgadapter.statements.local.ListDatabasesStatemen
 import com.google.cloud.spanner.pgadapter.statements.local.LocalStatement;
 import com.google.cloud.spanner.pgadapter.utils.ClientAutoDetector.WellKnownClient;
 import com.google.cloud.spanner.pgadapter.utils.CopyDataReceiver;
+import com.google.cloud.spanner.pgadapter.utils.Metrics;
 import com.google.cloud.spanner.pgadapter.utils.MutationWriter;
 import com.google.common.collect.ImmutableList;
 import io.opentelemetry.api.OpenTelemetry;
@@ -76,6 +77,7 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class BackendConnectionTest {
   private static final Tracer NOOP_OTEL = OpenTelemetry.noop().getTracer("test");
+  private static final Metrics NOOP_OTEL_METER = new Metrics(OpenTelemetry.noop());
   private final AbstractStatementParser PARSER =
       AbstractStatementParser.getInstance(Dialect.POSTGRESQL);
   private static final NoResult NO_RESULT = new NoResult();
@@ -117,6 +119,7 @@ public class BackendConnectionTest {
     BackendConnection backendConnection =
         new BackendConnection(
             NOOP_OTEL,
+            NOOP_OTEL_METER,
             UUID.randomUUID().toString(),
             DO_NOTHING,
             DatabaseId.of("p", "i", "d"),
@@ -157,6 +160,7 @@ public class BackendConnectionTest {
     BackendConnection backendConnection =
         new BackendConnection(
             NOOP_OTEL,
+            NOOP_OTEL_METER,
             UUID.randomUUID().toString(),
             DO_NOTHING,
             DatabaseId.of("p", "i", "d"),
@@ -198,6 +202,7 @@ public class BackendConnectionTest {
     BackendConnection onlyDmlStatements =
         new BackendConnection(
             NOOP_OTEL,
+            NOOP_OTEL_METER,
             UUID.randomUUID().toString(),
             DO_NOTHING,
             DatabaseId.of("p", "i", "d"),
@@ -215,6 +220,7 @@ public class BackendConnectionTest {
     BackendConnection onlyCopyStatements =
         new BackendConnection(
             NOOP_OTEL,
+            NOOP_OTEL_METER,
             UUID.randomUUID().toString(),
             DO_NOTHING,
             DatabaseId.of("p", "i", "d"),
@@ -230,6 +236,7 @@ public class BackendConnectionTest {
     BackendConnection dmlAndCopyStatements =
         new BackendConnection(
             NOOP_OTEL,
+            NOOP_OTEL_METER,
             UUID.randomUUID().toString(),
             DO_NOTHING,
             DatabaseId.of("p", "i", "d"),
@@ -247,6 +254,7 @@ public class BackendConnectionTest {
     BackendConnection onlySelectStatements =
         new BackendConnection(
             NOOP_OTEL,
+            NOOP_OTEL_METER,
             UUID.randomUUID().toString(),
             DO_NOTHING,
             DatabaseId.of("p", "i", "d"),
@@ -264,6 +272,7 @@ public class BackendConnectionTest {
     BackendConnection onlyClientSideStatements =
         new BackendConnection(
             NOOP_OTEL,
+            NOOP_OTEL_METER,
             UUID.randomUUID().toString(),
             DO_NOTHING,
             DatabaseId.of("p", "i", "d"),
@@ -281,6 +290,7 @@ public class BackendConnectionTest {
     BackendConnection onlyUnknownStatements =
         new BackendConnection(
             NOOP_OTEL,
+            NOOP_OTEL_METER,
             UUID.randomUUID().toString(),
             DO_NOTHING,
             DatabaseId.of("p", "i", "d"),
@@ -298,6 +308,7 @@ public class BackendConnectionTest {
     BackendConnection dmlAndSelectStatements =
         new BackendConnection(
             NOOP_OTEL,
+            NOOP_OTEL_METER,
             UUID.randomUUID().toString(),
             DO_NOTHING,
             DatabaseId.of("p", "i", "d"),
@@ -315,6 +326,7 @@ public class BackendConnectionTest {
     BackendConnection copyAndSelectStatements =
         new BackendConnection(
             NOOP_OTEL,
+            NOOP_OTEL_METER,
             UUID.randomUUID().toString(),
             DO_NOTHING,
             DatabaseId.of("p", "i", "d"),
@@ -332,6 +344,7 @@ public class BackendConnectionTest {
     BackendConnection copyAndUnknownStatements =
         new BackendConnection(
             NOOP_OTEL,
+            NOOP_OTEL_METER,
             UUID.randomUUID().toString(),
             DO_NOTHING,
             DatabaseId.of("p", "i", "d"),
@@ -365,6 +378,7 @@ public class BackendConnectionTest {
     BackendConnection backendConnection =
         new BackendConnection(
             NOOP_OTEL,
+            NOOP_OTEL_METER,
             UUID.randomUUID().toString(),
             DO_NOTHING,
             DatabaseId.of("p", "i", "d"),
@@ -405,6 +419,7 @@ public class BackendConnectionTest {
     BackendConnection backendConnection =
         new BackendConnection(
             NOOP_OTEL,
+            NOOP_OTEL_METER,
             UUID.randomUUID().toString(),
             DO_NOTHING,
             DatabaseId.of("p", "i", "d"),
@@ -444,6 +459,7 @@ public class BackendConnectionTest {
     BackendConnection backendConnection =
         new BackendConnection(
             NOOP_OTEL,
+            NOOP_OTEL_METER,
             UUID.randomUUID().toString(),
             DO_NOTHING,
             DatabaseId.of("p", "i", "d"),
@@ -473,6 +489,7 @@ public class BackendConnectionTest {
     BackendConnection backendConnection =
         new BackendConnection(
             NOOP_OTEL,
+            NOOP_OTEL_METER,
             UUID.randomUUID().toString(),
             DO_NOTHING,
             DatabaseId.of("p", "i", "d"),
@@ -514,6 +531,7 @@ public class BackendConnectionTest {
     BackendConnection backendConnection =
         new BackendConnection(
             NOOP_OTEL,
+            NOOP_OTEL_METER,
             UUID.randomUUID().toString(),
             DO_NOTHING,
             DatabaseId.of("p", "i", "d"),
@@ -545,6 +563,7 @@ public class BackendConnectionTest {
     BackendConnection backendConnection =
         new BackendConnection(
             NOOP_OTEL,
+            NOOP_OTEL_METER,
             UUID.randomUUID().toString(),
             DO_NOTHING,
             DatabaseId.of("p", "i", "d"),
@@ -574,6 +593,7 @@ public class BackendConnectionTest {
     BackendConnection backendConnection =
         new BackendConnection(
             NOOP_OTEL,
+            NOOP_OTEL_METER,
             UUID.randomUUID().toString(),
             DO_NOTHING,
             DatabaseId.of("p", "i", "d"),
@@ -604,6 +624,7 @@ public class BackendConnectionTest {
       BackendConnection backendConnection =
           new BackendConnection(
               NOOP_OTEL,
+              NOOP_OTEL_METER,
               UUID.randomUUID().toString(),
               DO_NOTHING,
               DatabaseId.of("p", "i", "d"),
@@ -630,6 +651,7 @@ public class BackendConnectionTest {
     BackendConnection backendConnection =
         new BackendConnection(
             NOOP_OTEL,
+            NOOP_OTEL_METER,
             UUID.randomUUID().toString(),
             DO_NOTHING,
             DatabaseId.of("p", "i", "d"),
@@ -662,6 +684,7 @@ public class BackendConnectionTest {
     BackendConnection backendConnection =
         new BackendConnection(
             NOOP_OTEL,
+            NOOP_OTEL_METER,
             UUID.randomUUID().toString(),
             DO_NOTHING,
             DatabaseId.of("p", "i", "d"),
@@ -692,6 +715,7 @@ public class BackendConnectionTest {
     BackendConnection backendConnection =
         new BackendConnection(
             NOOP_OTEL,
+            NOOP_OTEL_METER,
             UUID.randomUUID().toString(),
             DO_NOTHING,
             DatabaseId.of("p", "i", "d"),
@@ -721,6 +745,7 @@ public class BackendConnectionTest {
     BackendConnection backendConnection =
         new BackendConnection(
             NOOP_OTEL,
+            NOOP_OTEL_METER,
             UUID.randomUUID().toString(),
             DO_NOTHING,
             DatabaseId.of("p", "i", "d"),
@@ -760,6 +785,7 @@ public class BackendConnectionTest {
     BackendConnection backendConnection =
         new BackendConnection(
             NOOP_OTEL,
+            NOOP_OTEL_METER,
             UUID.randomUUID().toString(),
             DO_NOTHING,
             DatabaseId.of("p", "i", "d"),
@@ -798,6 +824,7 @@ public class BackendConnectionTest {
     BackendConnection backendConnection =
         new BackendConnection(
             NOOP_OTEL,
+            NOOP_OTEL_METER,
             UUID.randomUUID().toString(),
             DO_NOTHING,
             DatabaseId.of("p", "i", "d"),

--- a/src/test/java/com/google/cloud/spanner/pgadapter/statements/BackendConnectionTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/statements/BackendConnectionTest.java
@@ -85,7 +85,7 @@ public class BackendConnectionTest {
   private static final Runnable DO_NOTHING = () -> {};
   private static final DatabaseId DATABASE_ID = DatabaseId.of("p", "i", "d");
   private static final Attributes METRIC_ATTRIBUTES =
-      ExtendedQueryProtocolHandler.getMetricAttributes(DATABASE_ID);
+      ExtendedQueryProtocolHandler.createMetricAttributes(DATABASE_ID);
 
   @Test
   public void testExtractDdlUpdateCounts() {

--- a/src/test/java/com/google/cloud/spanner/pgadapter/statements/ExtendedQueryProtocolHandlerTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/statements/ExtendedQueryProtocolHandlerTest.java
@@ -21,6 +21,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.google.cloud.spanner.DatabaseId;
 import com.google.cloud.spanner.pgadapter.ConnectionHandler;
 import com.google.cloud.spanner.pgadapter.ProxyServer;
 import com.google.cloud.spanner.pgadapter.error.PGException;
@@ -45,6 +46,8 @@ import org.mockito.junit.MockitoRule;
 
 @RunWith(JUnit4.class)
 public class ExtendedQueryProtocolHandlerTest {
+  private static final DatabaseId DATABASE_ID = DatabaseId.of("p", "i", "d");
+
   @Rule public MockitoRule rule = MockitoJUnit.rule();
 
   @Mock private ProxyServer server;
@@ -65,6 +68,7 @@ public class ExtendedQueryProtocolHandlerTest {
     DescribeMessage describeMessage = mock(DescribeMessage.class);
     ExecuteMessage executeMessage = mock(ExecuteMessage.class);
 
+    when(connectionHandler.getDatabaseId()).thenReturn(DATABASE_ID);
     ExtendedQueryProtocolHandler handler =
         new ExtendedQueryProtocolHandler(connectionHandler, backendConnection);
     handler.buffer(parseMessage);
@@ -82,6 +86,7 @@ public class ExtendedQueryProtocolHandlerTest {
     ConnectionMetadata connectionMetadata = mock(ConnectionMetadata.class);
     when(connectionMetadata.getOutputStream()).thenReturn(mock(DataOutputStream.class));
     when(connectionHandler.getConnectionMetadata()).thenReturn(connectionMetadata);
+    when(connectionHandler.getDatabaseId()).thenReturn(DATABASE_ID);
     ParseMessage parseMessage = mock(ParseMessage.class);
     BindMessage bindMessage = mock(BindMessage.class);
     DescribeMessage describeMessage = mock(DescribeMessage.class);
@@ -113,6 +118,7 @@ public class ExtendedQueryProtocolHandlerTest {
     ConnectionMetadata connectionMetadata = mock(ConnectionMetadata.class);
     when(connectionMetadata.getOutputStream()).thenReturn(mock(DataOutputStream.class));
     when(connectionHandler.getConnectionMetadata()).thenReturn(connectionMetadata);
+    when(connectionHandler.getDatabaseId()).thenReturn(DATABASE_ID);
     ParseMessage parseMessage = mock(ParseMessage.class);
     BindMessage bindMessage = mock(BindMessage.class);
     DescribeMessage describeMessage = mock(DescribeMessage.class);
@@ -144,6 +150,7 @@ public class ExtendedQueryProtocolHandlerTest {
     ConnectionMetadata connectionMetadata = mock(ConnectionMetadata.class);
     when(connectionMetadata.getOutputStream()).thenReturn(mock(DataOutputStream.class));
     when(connectionHandler.getConnectionMetadata()).thenReturn(connectionMetadata);
+    when(connectionHandler.getDatabaseId()).thenReturn(DATABASE_ID);
     ParseMessage parseMessage = mock(ParseMessage.class);
 
     ExtendedQueryProtocolHandler handler =

--- a/src/test/java/com/google/cloud/spanner/pgadapter/statements/ExtendedQueryProtocolHandlerTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/statements/ExtendedQueryProtocolHandlerTest.java
@@ -21,19 +21,15 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import com.google.cloud.spanner.DatabaseId;
 import com.google.cloud.spanner.pgadapter.ConnectionHandler;
-import com.google.cloud.spanner.pgadapter.ProxyServer;
 import com.google.cloud.spanner.pgadapter.error.PGException;
 import com.google.cloud.spanner.pgadapter.error.SQLState;
 import com.google.cloud.spanner.pgadapter.metadata.ConnectionMetadata;
-import com.google.cloud.spanner.pgadapter.metadata.OptionsMetadata;
 import com.google.cloud.spanner.pgadapter.wireprotocol.BindMessage;
 import com.google.cloud.spanner.pgadapter.wireprotocol.DescribeMessage;
 import com.google.cloud.spanner.pgadapter.wireprotocol.ExecuteMessage;
 import com.google.cloud.spanner.pgadapter.wireprotocol.ParseMessage;
 import com.google.common.collect.ImmutableList;
-import io.opentelemetry.api.OpenTelemetry;
 import java.io.DataOutputStream;
 import java.util.UUID;
 import org.junit.Before;
@@ -47,20 +43,13 @@ import org.mockito.junit.MockitoRule;
 
 @RunWith(JUnit4.class)
 public class ExtendedQueryProtocolHandlerTest {
-  private static final DatabaseId DATABASE_ID = DatabaseId.of("p", "i", "d");
-
   @Rule public MockitoRule rule = MockitoJUnit.rule();
-
-  @Mock private ProxyServer server;
   @Mock private ConnectionHandler connectionHandler;
   @Mock private BackendConnection backendConnection;
 
   @Before
   public void setupMocks() {
-    when(connectionHandler.getServer()).thenReturn(server);
     when(connectionHandler.getTraceConnectionId()).thenReturn(UUID.randomUUID());
-    when(server.getOpenTelemetry()).thenReturn(OpenTelemetry.noop());
-    when(server.getOptions()).thenReturn(OptionsMetadata.newBuilder().build());
   }
 
   @Test
@@ -70,7 +59,6 @@ public class ExtendedQueryProtocolHandlerTest {
     DescribeMessage describeMessage = mock(DescribeMessage.class);
     ExecuteMessage executeMessage = mock(ExecuteMessage.class);
 
-    when(connectionHandler.getDatabaseId()).thenReturn(DATABASE_ID);
     ExtendedQueryProtocolHandler handler =
         new ExtendedQueryProtocolHandler(connectionHandler, backendConnection);
     handler.buffer(parseMessage);
@@ -88,7 +76,6 @@ public class ExtendedQueryProtocolHandlerTest {
     ConnectionMetadata connectionMetadata = mock(ConnectionMetadata.class);
     when(connectionMetadata.getOutputStream()).thenReturn(mock(DataOutputStream.class));
     when(connectionHandler.getConnectionMetadata()).thenReturn(connectionMetadata);
-    when(connectionHandler.getDatabaseId()).thenReturn(DATABASE_ID);
     ParseMessage parseMessage = mock(ParseMessage.class);
     BindMessage bindMessage = mock(BindMessage.class);
     DescribeMessage describeMessage = mock(DescribeMessage.class);
@@ -120,7 +107,6 @@ public class ExtendedQueryProtocolHandlerTest {
     ConnectionMetadata connectionMetadata = mock(ConnectionMetadata.class);
     when(connectionMetadata.getOutputStream()).thenReturn(mock(DataOutputStream.class));
     when(connectionHandler.getConnectionMetadata()).thenReturn(connectionMetadata);
-    when(connectionHandler.getDatabaseId()).thenReturn(DATABASE_ID);
     ParseMessage parseMessage = mock(ParseMessage.class);
     BindMessage bindMessage = mock(BindMessage.class);
     DescribeMessage describeMessage = mock(DescribeMessage.class);
@@ -152,7 +138,6 @@ public class ExtendedQueryProtocolHandlerTest {
     ConnectionMetadata connectionMetadata = mock(ConnectionMetadata.class);
     when(connectionMetadata.getOutputStream()).thenReturn(mock(DataOutputStream.class));
     when(connectionHandler.getConnectionMetadata()).thenReturn(connectionMetadata);
-    when(connectionHandler.getDatabaseId()).thenReturn(DATABASE_ID);
     ParseMessage parseMessage = mock(ParseMessage.class);
 
     ExtendedQueryProtocolHandler handler =

--- a/src/test/java/com/google/cloud/spanner/pgadapter/statements/ExtendedQueryProtocolHandlerTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/statements/ExtendedQueryProtocolHandlerTest.java
@@ -27,6 +27,7 @@ import com.google.cloud.spanner.pgadapter.ProxyServer;
 import com.google.cloud.spanner.pgadapter.error.PGException;
 import com.google.cloud.spanner.pgadapter.error.SQLState;
 import com.google.cloud.spanner.pgadapter.metadata.ConnectionMetadata;
+import com.google.cloud.spanner.pgadapter.metadata.OptionsMetadata;
 import com.google.cloud.spanner.pgadapter.wireprotocol.BindMessage;
 import com.google.cloud.spanner.pgadapter.wireprotocol.DescribeMessage;
 import com.google.cloud.spanner.pgadapter.wireprotocol.ExecuteMessage;
@@ -59,6 +60,7 @@ public class ExtendedQueryProtocolHandlerTest {
     when(connectionHandler.getServer()).thenReturn(server);
     when(connectionHandler.getTraceConnectionId()).thenReturn(UUID.randomUUID());
     when(server.getOpenTelemetry()).thenReturn(OpenTelemetry.noop());
+    when(server.getOptions()).thenReturn(OptionsMetadata.newBuilder().build());
   }
 
   @Test

--- a/src/test/java/com/google/cloud/spanner/pgadapter/statements/StatementTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/statements/StatementTest.java
@@ -97,7 +97,7 @@ public class StatementTest {
   private static final Runnable DO_NOTHING = () -> {};
   private static final DatabaseId DATABASE_ID = DatabaseId.of("p", "i", "d");
   private static final Attributes METRIC_ATTRIBUTES =
-      ExtendedQueryProtocolHandler.getMetricAttributes(DATABASE_ID);
+      ExtendedQueryProtocolHandler.createMetricAttributes(DATABASE_ID);
 
   private static ParsedStatement parse(String sql) {
     return PARSER.parse(Statement.of(sql));
@@ -521,7 +521,7 @@ public class StatementTest {
         new BackendConnection(
             NOOP_OTEL,
             NOOP_OTEL_METER,
-            ExtendedQueryProtocolHandler.getMetricAttributes(databaseId),
+            ExtendedQueryProtocolHandler.createMetricAttributes(databaseId),
             UUID.randomUUID().toString(),
             DO_NOTHING,
             databaseId,
@@ -629,7 +629,7 @@ public class StatementTest {
         new BackendConnection(
             NOOP_OTEL,
             NOOP_OTEL_METER,
-            ExtendedQueryProtocolHandler.getMetricAttributes(databaseId),
+            ExtendedQueryProtocolHandler.createMetricAttributes(databaseId),
             UUID.randomUUID().toString(),
             DO_NOTHING,
             databaseId,
@@ -688,7 +688,7 @@ public class StatementTest {
         new BackendConnection(
             NOOP_OTEL,
             NOOP_OTEL_METER,
-            ExtendedQueryProtocolHandler.getMetricAttributes(databaseId),
+            ExtendedQueryProtocolHandler.createMetricAttributes(databaseId),
             UUID.randomUUID().toString(),
             DO_NOTHING,
             databaseId,

--- a/src/test/java/com/google/cloud/spanner/pgadapter/statements/StatementTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/statements/StatementTest.java
@@ -54,6 +54,7 @@ import com.google.cloud.spanner.pgadapter.metadata.ConnectionMetadata;
 import com.google.cloud.spanner.pgadapter.metadata.OptionsMetadata;
 import com.google.cloud.spanner.pgadapter.session.SessionState;
 import com.google.cloud.spanner.pgadapter.utils.ClientAutoDetector.WellKnownClient;
+import com.google.cloud.spanner.pgadapter.utils.Metrics;
 import com.google.cloud.spanner.pgadapter.utils.MutationWriter;
 import com.google.cloud.spanner.pgadapter.wireprotocol.ControlMessage;
 import com.google.cloud.spanner.pgadapter.wireprotocol.QueryMessage;
@@ -90,6 +91,7 @@ public class StatementTest {
       AbstractStatementParser.getInstance(Dialect.POSTGRESQL);
 
   private static final Tracer NOOP_OTEL = OpenTelemetry.noop().getTracer("test");
+  private static final Metrics NOOP_OTEL_METER = new Metrics(OpenTelemetry.noop());
 
   private static final Runnable DO_NOTHING = () -> {};
 
@@ -189,6 +191,7 @@ public class StatementTest {
     BackendConnection backendConnection =
         new BackendConnection(
             NOOP_OTEL,
+            NOOP_OTEL_METER,
             UUID.randomUUID().toString(),
             DO_NOTHING,
             connectionHandler.getDatabaseId(),
@@ -282,6 +285,7 @@ public class StatementTest {
     BackendConnection backendConnection =
         new BackendConnection(
             NOOP_OTEL,
+            NOOP_OTEL_METER,
             UUID.randomUUID().toString(),
             DO_NOTHING,
             connectionHandler.getDatabaseId(),
@@ -324,6 +328,7 @@ public class StatementTest {
     BackendConnection backendConnection =
         new BackendConnection(
             NOOP_OTEL,
+            NOOP_OTEL_METER,
             UUID.randomUUID().toString(),
             DO_NOTHING,
             connectionHandler.getDatabaseId(),
@@ -434,6 +439,7 @@ public class StatementTest {
     BackendConnection backendConnection =
         new BackendConnection(
             NOOP_OTEL,
+            NOOP_OTEL_METER,
             UUID.randomUUID().toString(),
             DO_NOTHING,
             connectionHandler.getDatabaseId(),
@@ -505,6 +511,7 @@ public class StatementTest {
     BackendConnection backendConnection =
         new BackendConnection(
             NOOP_OTEL,
+            NOOP_OTEL_METER,
             UUID.randomUUID().toString(),
             DO_NOTHING,
             DatabaseId.of("p", "i", "d"),
@@ -580,6 +587,7 @@ public class StatementTest {
     BackendConnection backendConnection =
         new BackendConnection(
             NOOP_OTEL,
+            NOOP_OTEL_METER,
             UUID.randomUUID().toString(),
             DO_NOTHING,
             connectionHandler.getDatabaseId(),
@@ -608,6 +616,7 @@ public class StatementTest {
     BackendConnection backendConnection =
         new BackendConnection(
             NOOP_OTEL,
+            NOOP_OTEL_METER,
             UUID.randomUUID().toString(),
             DO_NOTHING,
             DatabaseId.of("p", "i", "d"),
@@ -664,6 +673,7 @@ public class StatementTest {
     BackendConnection backendConnection =
         new BackendConnection(
             NOOP_OTEL,
+            NOOP_OTEL_METER,
             UUID.randomUUID().toString(),
             DO_NOTHING,
             DatabaseId.of("p", "i", "d"),

--- a/src/test/java/com/google/cloud/spanner/pgadapter/statements/StatementTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/statements/StatementTest.java
@@ -62,6 +62,7 @@ import com.google.cloud.spanner.pgadapter.wireprotocol.WireMessage;
 import com.google.common.collect.ImmutableList;
 import com.google.common.primitives.Bytes;
 import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.trace.Tracer;
 import java.io.ByteArrayInputStream;
 import java.io.DataInputStream;
@@ -94,6 +95,9 @@ public class StatementTest {
   private static final Metrics NOOP_OTEL_METER = new Metrics(OpenTelemetry.noop());
 
   private static final Runnable DO_NOTHING = () -> {};
+  private static final DatabaseId DATABASE_ID = DatabaseId.of("p", "i", "d");
+  private static final Attributes METRIC_ATTRIBUTES =
+      ExtendedQueryProtocolHandler.getMetricAttributes(DATABASE_ID);
 
   private static ParsedStatement parse(String sql) {
     return PARSER.parse(Statement.of(sql));
@@ -192,6 +196,7 @@ public class StatementTest {
         new BackendConnection(
             NOOP_OTEL,
             NOOP_OTEL_METER,
+            METRIC_ATTRIBUTES,
             UUID.randomUUID().toString(),
             DO_NOTHING,
             connectionHandler.getDatabaseId(),
@@ -286,6 +291,7 @@ public class StatementTest {
         new BackendConnection(
             NOOP_OTEL,
             NOOP_OTEL_METER,
+            METRIC_ATTRIBUTES,
             UUID.randomUUID().toString(),
             DO_NOTHING,
             connectionHandler.getDatabaseId(),
@@ -329,6 +335,7 @@ public class StatementTest {
         new BackendConnection(
             NOOP_OTEL,
             NOOP_OTEL_METER,
+            METRIC_ATTRIBUTES,
             UUID.randomUUID().toString(),
             DO_NOTHING,
             connectionHandler.getDatabaseId(),
@@ -440,6 +447,7 @@ public class StatementTest {
         new BackendConnection(
             NOOP_OTEL,
             NOOP_OTEL_METER,
+            METRIC_ATTRIBUTES,
             UUID.randomUUID().toString(),
             DO_NOTHING,
             connectionHandler.getDatabaseId(),
@@ -508,13 +516,15 @@ public class StatementTest {
             CopyStatement.create(
                 connectionHandler, mock(OptionsMetadata.class), "", parse(sql), Statement.of(sql));
 
+    DatabaseId databaseId = DatabaseId.of("p", "i", "d");
     BackendConnection backendConnection =
         new BackendConnection(
             NOOP_OTEL,
             NOOP_OTEL_METER,
+            ExtendedQueryProtocolHandler.getMetricAttributes(databaseId),
             UUID.randomUUID().toString(),
             DO_NOTHING,
-            DatabaseId.of("p", "i", "d"),
+            databaseId,
             connection,
             () -> WellKnownClient.UNSPECIFIED,
             options,
@@ -588,6 +598,7 @@ public class StatementTest {
         new BackendConnection(
             NOOP_OTEL,
             NOOP_OTEL_METER,
+            METRIC_ATTRIBUTES,
             UUID.randomUUID().toString(),
             DO_NOTHING,
             connectionHandler.getDatabaseId(),
@@ -613,13 +624,15 @@ public class StatementTest {
     when(backendConnection.getSessionState()).thenReturn(sessionState);
     when(connectionHandler.getConnectionMetadata()).thenReturn(connectionMetadata);
     setupQueryInformationSchemaResults();
+    DatabaseId databaseId = DatabaseId.of("p", "i", "d");
     BackendConnection backendConnection =
         new BackendConnection(
             NOOP_OTEL,
             NOOP_OTEL_METER,
+            ExtendedQueryProtocolHandler.getMetricAttributes(databaseId),
             UUID.randomUUID().toString(),
             DO_NOTHING,
-            DatabaseId.of("p", "i", "d"),
+            databaseId,
             connection,
             () -> WellKnownClient.UNSPECIFIED,
             options,
@@ -670,13 +683,15 @@ public class StatementTest {
     SessionState sessionState = new SessionState(options);
     when(backendConnection.getSessionState()).thenReturn(sessionState);
     setupQueryInformationSchemaResults();
+    DatabaseId databaseId = DatabaseId.of("p", "i", "d");
     BackendConnection backendConnection =
         new BackendConnection(
             NOOP_OTEL,
             NOOP_OTEL_METER,
+            ExtendedQueryProtocolHandler.getMetricAttributes(databaseId),
             UUID.randomUUID().toString(),
             DO_NOTHING,
-            DatabaseId.of("p", "i", "d"),
+            databaseId,
             connection,
             () -> WellKnownClient.UNSPECIFIED,
             options,

--- a/src/test/java/com/google/cloud/spanner/pgadapter/wireprotocol/ProtocolTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/wireprotocol/ProtocolTest.java
@@ -33,6 +33,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.google.cloud.spanner.DatabaseClient;
+import com.google.cloud.spanner.DatabaseId;
 import com.google.cloud.spanner.Dialect;
 import com.google.cloud.spanner.ReadContext;
 import com.google.cloud.spanner.ResultSet;
@@ -97,6 +98,7 @@ import org.postgresql.util.ByteConverter;
 public class ProtocolTest {
   private static final AbstractStatementParser PARSER =
       AbstractStatementParser.getInstance(Dialect.POSTGRESQL);
+  private static final DatabaseId DATABASE_ID = DatabaseId.of("p", "i", "d");
 
   @Rule public MockitoRule rule = MockitoJUnit.rule();
   @Mock private ConnectionHandler connectionHandler;
@@ -1115,6 +1117,7 @@ public class ProtocolTest {
     when(connectionHandler.getServer()).thenReturn(server);
     when(connectionHandler.getTraceConnectionId()).thenReturn(UUID.randomUUID());
     when(server.getOpenTelemetry()).thenReturn(OpenTelemetry.noop());
+    when(connectionHandler.getDatabaseId()).thenReturn(DATABASE_ID);
     ExtendedQueryProtocolHandler extendedQueryProtocolHandler =
         new ExtendedQueryProtocolHandler(connectionHandler, backendConnection);
     when(connectionHandler.getStatus()).thenReturn(ConnectionStatus.AUTHENTICATED);
@@ -1152,6 +1155,7 @@ public class ProtocolTest {
 
     when(connectionHandler.getServer()).thenReturn(server);
     when(connectionHandler.getTraceConnectionId()).thenReturn(UUID.randomUUID());
+    when(connectionHandler.getDatabaseId()).thenReturn(DATABASE_ID);
     when(server.getOpenTelemetry()).thenReturn(OpenTelemetry.noop());
     ExtendedQueryProtocolHandler extendedQueryProtocolHandler =
         new ExtendedQueryProtocolHandler(connectionHandler, backendConnection);
@@ -1244,6 +1248,7 @@ public class ProtocolTest {
     when(connectionHandler.getStatus()).thenReturn(ConnectionStatus.AUTHENTICATED);
     when(connectionHandler.getConnectionMetadata()).thenReturn(connectionMetadata);
     when(connectionHandler.getServer()).thenReturn(server);
+    when(connectionHandler.getDatabaseId()).thenReturn(DATABASE_ID);
     when(connectionHandler.getTraceConnectionId()).thenReturn(UUID.randomUUID());
     when(server.getOpenTelemetry()).thenReturn(OpenTelemetry.noop());
     when(connectionHandler.getStatement("")).thenReturn(intermediatePortalStatement);

--- a/src/test/java/com/google/cloud/spanner/pgadapter/wireprotocol/ProtocolTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/wireprotocol/ProtocolTest.java
@@ -114,7 +114,9 @@ public class ProtocolTest {
   @Mock private ResultSet resultSet;
 
   @Before
-  public void setupMocks() {}
+  public void setupMocks() {
+    when(server.getOptions()).thenReturn(OptionsMetadata.newBuilder().build());
+  }
 
   private byte[] intToBytes(int value) {
     byte[] parameters = new byte[4];

--- a/src/test/java/com/google/cloud/spanner/pgadapter/wireprotocol/ProtocolTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/wireprotocol/ProtocolTest.java
@@ -32,11 +32,7 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import com.google.cloud.spanner.DatabaseClient;
-import com.google.cloud.spanner.DatabaseId;
 import com.google.cloud.spanner.Dialect;
-import com.google.cloud.spanner.ReadContext;
-import com.google.cloud.spanner.ResultSet;
 import com.google.cloud.spanner.Statement;
 import com.google.cloud.spanner.connection.AbstractStatementParser;
 import com.google.cloud.spanner.connection.AbstractStatementParser.ParsedStatement;
@@ -62,6 +58,7 @@ import com.google.cloud.spanner.pgadapter.statements.ExtendedQueryProtocolHandle
 import com.google.cloud.spanner.pgadapter.statements.IntermediatePortalStatement;
 import com.google.cloud.spanner.pgadapter.statements.IntermediatePreparedStatement;
 import com.google.cloud.spanner.pgadapter.utils.ClientAutoDetector.WellKnownClient;
+import com.google.cloud.spanner.pgadapter.utils.Metrics;
 import com.google.cloud.spanner.pgadapter.utils.MutationWriter;
 import com.google.cloud.spanner.pgadapter.wireprotocol.ControlMessage.ManuallyCreatedToken;
 import com.google.cloud.spanner.pgadapter.wireprotocol.ControlMessage.PreparedType;
@@ -82,13 +79,10 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
-import org.json.simple.parser.JSONParser;
-import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
-import org.mockito.ArgumentMatchers;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
@@ -98,7 +92,6 @@ import org.postgresql.util.ByteConverter;
 public class ProtocolTest {
   private static final AbstractStatementParser PARSER =
       AbstractStatementParser.getInstance(Dialect.POSTGRESQL);
-  private static final DatabaseId DATABASE_ID = DatabaseId.of("p", "i", "d");
 
   @Rule public MockitoRule rule = MockitoJUnit.rule();
   @Mock private ConnectionHandler connectionHandler;
@@ -111,12 +104,6 @@ public class ProtocolTest {
   @Mock private IntermediatePortalStatement intermediatePortalStatement;
   @Mock private ConnectionMetadata connectionMetadata;
   @Mock private DataOutputStream outputStream;
-  @Mock private ResultSet resultSet;
-
-  @Before
-  public void setupMocks() {
-    when(server.getOptions()).thenReturn(OptionsMetadata.newBuilder().build());
-  }
 
   private byte[] intToBytes(int value) {
     byte[] parameters = new byte[4];
@@ -183,7 +170,6 @@ public class ProtocolTest {
 
   @Test
   public void testQueryUsesPSQLStatementWhenPSQLModeSelectedMessage() throws Exception {
-    JSONParser parser = new JSONParser();
     byte[] messageMetadata = {'Q', 0, 0, 0, 24};
     String payload = "SELECT * FROM users\0";
     byte[] value = Bytes.concat(messageMetadata, payload.getBytes());
@@ -1116,10 +1102,7 @@ public class ProtocolTest {
     ByteArrayOutputStream result = new ByteArrayOutputStream();
     DataOutputStream outputStream = new DataOutputStream(result);
 
-    when(connectionHandler.getServer()).thenReturn(server);
     when(connectionHandler.getTraceConnectionId()).thenReturn(UUID.randomUUID());
-    when(server.getOpenTelemetry()).thenReturn(OpenTelemetry.noop());
-    when(connectionHandler.getDatabaseId()).thenReturn(DATABASE_ID);
     ExtendedQueryProtocolHandler extendedQueryProtocolHandler =
         new ExtendedQueryProtocolHandler(connectionHandler, backendConnection);
     when(connectionHandler.getStatus()).thenReturn(ConnectionStatus.AUTHENTICATED);
@@ -1155,10 +1138,7 @@ public class ProtocolTest {
     ByteArrayOutputStream result = new ByteArrayOutputStream();
     DataOutputStream outputStream = new DataOutputStream(result);
 
-    when(connectionHandler.getServer()).thenReturn(server);
     when(connectionHandler.getTraceConnectionId()).thenReturn(UUID.randomUUID());
-    when(connectionHandler.getDatabaseId()).thenReturn(DATABASE_ID);
-    when(server.getOpenTelemetry()).thenReturn(OpenTelemetry.noop());
     ExtendedQueryProtocolHandler extendedQueryProtocolHandler =
         new ExtendedQueryProtocolHandler(connectionHandler, backendConnection);
     when(connectionHandler.getStatus()).thenReturn(ConnectionStatus.AUTHENTICATED);
@@ -1250,9 +1230,7 @@ public class ProtocolTest {
     when(connectionHandler.getStatus()).thenReturn(ConnectionStatus.AUTHENTICATED);
     when(connectionHandler.getConnectionMetadata()).thenReturn(connectionMetadata);
     when(connectionHandler.getServer()).thenReturn(server);
-    when(connectionHandler.getDatabaseId()).thenReturn(DATABASE_ID);
     when(connectionHandler.getTraceConnectionId()).thenReturn(UUID.randomUUID());
-    when(server.getOpenTelemetry()).thenReturn(OpenTelemetry.noop());
     when(connectionHandler.getStatement("")).thenReturn(intermediatePortalStatement);
     when(connectionHandler.getPortal("")).thenReturn(intermediatePortalStatement);
     when(intermediatePortalStatement.getCommandTag()).thenReturn("INSERT");
@@ -1260,6 +1238,8 @@ public class ProtocolTest {
     when(intermediatePortalStatement.getStatementResult()).thenReturn(new UpdateCount(1L));
     when(intermediatePortalStatement.getUpdateCount()).thenReturn(1L);
     when(backendConnection.getConnectionState()).thenReturn(ConnectionState.TRANSACTION);
+    when(backendConnection.getTracer()).thenReturn(OpenTelemetry.noop().getTracer("mock-tracer"));
+    when(backendConnection.getMetrics()).thenReturn(new Metrics(OpenTelemetry.noop()));
     OptionsMetadata options = mock(OptionsMetadata.class);
     when(server.getOptions()).thenReturn(options);
     when(connectionMetadata.getInputStream()).thenReturn(inputStream);
@@ -1944,31 +1924,5 @@ public class ProtocolTest {
     verify(connectionHandler).setStatus(ConnectionStatus.TERMINATED);
     byte[] resultBytes = result.toByteArray();
     assertEquals('E', resultBytes[0]);
-  }
-
-  private void setupQueryInformationSchemaResults() {
-    DatabaseClient databaseClient = mock(DatabaseClient.class);
-    ReadContext singleUseReadContext = mock(ReadContext.class);
-    when(databaseClient.singleUse()).thenReturn(singleUseReadContext);
-    when(connectionHandler.getSpannerConnection()).thenReturn(connection);
-    when(connection.getDatabaseClient()).thenReturn(databaseClient);
-    ResultSet spannerType = mock(ResultSet.class);
-    when(spannerType.getString("column_name")).thenReturn("key", "value");
-    when(spannerType.getString("data_type")).thenReturn("bigint", "character varying");
-    when(spannerType.next()).thenReturn(true, true, false);
-    when(singleUseReadContext.executeQuery(
-            ArgumentMatchers.argThat(
-                statement ->
-                    statement != null && statement.getSql().startsWith("SELECT column_name"))))
-        .thenReturn(spannerType);
-
-    ResultSet countResult = mock(ResultSet.class);
-    when(countResult.getLong(0)).thenReturn(2L);
-    when(countResult.next()).thenReturn(true, false);
-    when(singleUseReadContext.executeQuery(
-            ArgumentMatchers.argThat(
-                statement ->
-                    statement != null && statement.getSql().startsWith("SELECT COUNT(*)"))))
-        .thenReturn(countResult);
   }
 }


### PR DESCRIPTION
Add two latency metrics: 

* `spanner/pgadapter/roundtrip_latencies`: measure the roundtrip latency in PGAdapter that can include multiple messages between the client and PGAdapter. 
* `spanner/pgadapter/client_lib_latencies`: measure the time to make a request and get a response from the client library. 
