### PR TITLE
feat: support client lib's OpenTelemetry metrics

### DIFF
--- a/docs/open_telemetry.md
+++ b/docs/open_telemetry.md
@@ -155,6 +155,9 @@ The available metrics in PGAdapter are:
 * `spanner/pgadapter/client_lib_latencies`: Latency when the Spanner's client library receives
    a call and returns a response.
 
+In addition, [client library's metrics](https://github.com/googleapis/java-spanner/tree/main?tab=readme-ov-file#available-client-side-metrics) are avaialble for use when the
+`-enable_otel_metrics` command line argument is provided.
+
 ## Frequently Asked Questions
 
 #### How can I find all the statements that were executed on the same connection as the trace I'm looking at?

--- a/src/main/java/com/google/cloud/spanner/pgadapter/ConnectionHandler.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/ConnectionHandler.java
@@ -29,6 +29,7 @@ import com.google.cloud.spanner.Spanner;
 import com.google.cloud.spanner.SpannerException;
 import com.google.cloud.spanner.SpannerException.ResourceNotFoundException;
 import com.google.cloud.spanner.SpannerExceptionFactory;
+import com.google.cloud.spanner.SpannerOptions;
 import com.google.cloud.spanner.Statement;
 import com.google.cloud.spanner.connection.AbstractStatementParser.StatementType;
 import com.google.cloud.spanner.connection.Connection;
@@ -207,6 +208,11 @@ public class ConnectionHandler implements Runnable {
     if (options.getSessionPoolOptions() != null) {
       connectionOptionsBuilder =
           connectionOptionsBuilder.setSessionPoolOptions(options.getSessionPoolOptions());
+    }
+    if (options.isEnableOpenTelemetryMetrics()) {
+      SpannerOptions.enableOpenTelemetryMetrics();
+      connectionOptionsBuilder =
+          connectionOptionsBuilder.setOpenTelemetry(server.getOpenTelemetry());
     }
     ConnectionOptions connectionOptions = connectionOptionsBuilder.build();
     Connection spannerConnection = connectionOptions.getConnection();

--- a/src/main/java/com/google/cloud/spanner/pgadapter/metadata/OptionsMetadata.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/metadata/OptionsMetadata.java
@@ -90,6 +90,7 @@ public class OptionsMetadata {
     private Credentials credentials;
     private boolean requireAuthentication;
     private boolean enableOpenTelemetry;
+    private boolean enableOpenTelemetryMetrics;
     private Double openTelemetryTraceRatio;
     private boolean skipLocalhostCheck;
     private boolean useVirtualThreads;
@@ -246,6 +247,12 @@ public class OptionsMetadata {
     /** Enables OpenTelemetry tracing for PGAdapter. */
     public Builder setEnableOpenTelemetry() {
       this.enableOpenTelemetry = true;
+      return this;
+    }
+
+    /** Enables OpenTelemetry metrics for PGAdapter. */
+    public Builder setEnableOpenTelemetryMetrics() {
+      this.enableOpenTelemetryMetrics = true;
       return this;
     }
 
@@ -412,6 +419,9 @@ public class OptionsMetadata {
       }
       if (enableOpenTelemetry) {
         addOption(args, OPTION_ENABLE_OPEN_TELEMETRY);
+      }
+      if (enableOpenTelemetryMetrics) {
+        addOption(args, OPTION_ENABLE_OPEN_TELEMETRY_METRICS);
       }
       if (openTelemetryTraceRatio != null) {
         addLongOption(


### PR DESCRIPTION
This includes the following changes: 

* When enabling OpenTelemetry metrics in PGAdapter, we also enable the client lib's OT metrics. 
* The builder for OptionsMetadata should support the configuration to enable OT metrics. 