### PR TITLE
docs: add npgsql sample with emulator

### DIFF
--- a/samples/dotnet/npgsql-sample/Program.cs
+++ b/samples/dotnet/npgsql-sample/Program.cs
@@ -1,0 +1,58 @@
+﻿// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using DotNet.Testcontainers.Builders;
+using DotNet.Testcontainers.Containers;
+using Npgsql;
+
+namespace npgsql_sample;
+
+internal static class Sample
+{
+    private static async Task Main(string[] args)
+    {
+        // Start PGAdapter and the Spanner emulator in a Docker container.
+        var pgadapter = await StartPGAdapterAndEmulator();
+        
+        var connectionString = $"Host=localhost;Port={pgadapter.GetMappedPublicPort(5432)};Database=my-database;SSL Mode=Disable";
+        using var connection = new NpgsqlConnection(connectionString);
+        connection.Open();
+
+        using var cmd = new NpgsqlCommand("select 'Hello World!' as hello", connection);
+        using var reader = cmd.ExecuteReader();
+        while (reader.Read())
+        {
+            var greeting = reader.GetString(0);
+            Console.WriteLine($"Greeting from Cloud Spanner PostgreSQL: {greeting}");
+        }
+        
+        // Stop PGAdapter and the emulator.
+        await pgadapter.StopAsync();
+    }
+
+    private static async Task<IContainer> StartPGAdapterAndEmulator()
+    {
+        var container = new ContainerBuilder()
+            // Use the PGAdapter image that also contains automatically starts the Spanner emulator.
+            .WithImage("gcr.io/cloud-spanner-pg-adapter/pgadapter-emulator")
+            // Bind port 5432 of the container to a random port on the host.
+            .WithPortBinding(5432, true)
+            // Wait until the PostgreSQL port is available.
+            .WithWaitStrategy(Wait.ForUnixContainer().UntilPortIsAvailable(5432))
+            // Build the container configuration.
+            .Build();
+        await container.StartAsync();
+        return container;
+    }
+}

--- a/samples/dotnet/npgsql-sample/npgsql-sample.csproj
+++ b/samples/dotnet/npgsql-sample/npgsql-sample.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFramework>net6.0</TargetFramework>
+        <RootNamespace>npgsql_sample</RootNamespace>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <PackageReference Include="Npgsql" Version="8.0.2" />
+      <PackageReference Include="Testcontainers" Version="3.8.0" />
+    </ItemGroup>
+
+</Project>

--- a/samples/dotnet/npgsql-sample/npgsql-sample.sln
+++ b/samples/dotnet/npgsql-sample/npgsql-sample.sln
@@ -1,0 +1,16 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "npgsql-sample", "npgsql-sample.csproj", "{800EC1E6-A8D9-498F-A251-CDA330319D22}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{800EC1E6-A8D9-498F-A251-CDA330319D22}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{800EC1E6-A8D9-498F-A251-CDA330319D22}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{800EC1E6-A8D9-498F-A251-CDA330319D22}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{800EC1E6-A8D9-498F-A251-CDA330319D22}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal


### PR DESCRIPTION
Adds a sample for using `npgsql` with PGAdapter. The sample automatically starts PGAdapter + Spanner Emulator in a Docker container, and then runs a simple query using `npgsql` on PGAdapter.