### PR TITLE
Revert "deps: update gcr.io/google.com/cloudsdktool/google-cloud-cli docker tag to v474"

### DIFF
--- a/benchmarks/ycsb/Dockerfile
+++ b/benchmarks/ycsb/Dockerfile
@@ -20,7 +20,7 @@ RUN mvn package -Passembly -DskipTests
 # Docker image for the YCSB runner.
 # We pin the version to 455.0.0, because YCSB requires Python 2.x, and this is the last
 # version of the gcloud-cli Docker image that supports Python 2.x.
-FROM gcr.io/google.com/cloudsdktool/google-cloud-cli:474.0.0-slim
+FROM gcr.io/google.com/cloudsdktool/google-cloud-cli:455.0.0-slim
 
 RUN apt update && apt -y install postgresql-client
 RUN apt -y install wget


### PR DESCRIPTION
Reverts GoogleCloudPlatform/pgadapter#1702