### PR TITLE
chore: add test for tpcc benchmarking

### DIFF
--- a/.github/workflows/benchmark-tests.yml
+++ b/.github/workflows/benchmark-tests.yml
@@ -18,3 +18,6 @@ jobs:
       - name: Run Java Latency Benchmark tests
         working-directory: ./benchmarks/latency-comparison/java
         run: mvn test -B
+      - name: Run TPCC Benchmark tests (only data loading)
+        working-directory: ./benchmarks/tpcc
+        run: mvn test -B

--- a/benchmarks/tpcc/pom.xml
+++ b/benchmarks/tpcc/pom.xml
@@ -32,6 +32,13 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
+      <dependency>
+        <groupId>org.testcontainers</groupId>
+        <artifactId>testcontainers-bom</artifactId>
+        <version>1.19.8</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
     </dependencies>
   </dependencyManagement>
   <dependencies>
@@ -67,6 +74,17 @@
     <dependency>
         <groupId>io.opentelemetry</groupId>
         <artifactId>opentelemetry-exporter-otlp</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.13.2</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>testcontainers</artifactId>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 

--- a/benchmarks/tpcc/src/main/java/com/google/cloud/pgadapter/tpcc/AbstractBenchmarkRunner.java
+++ b/benchmarks/tpcc/src/main/java/com/google/cloud/pgadapter/tpcc/AbstractBenchmarkRunner.java
@@ -725,7 +725,7 @@ abstract class AbstractBenchmarkRunner implements Runnable {
       int index = 0;
       setParams(statement, params);
       Stopwatch stopwatch = Stopwatch.createStarted();
-      row = paramQueryRow(QueryRowMode.REQUIRE_ONE, statement);
+      row = paramQueryRow(QueryRowMode.ALLOW_MORE_THAN_ONE, statement);
       Duration executionDuration = stopwatch.elapsed();
       metrics.recordLatency(executionDuration.toMillis());
     }

--- a/benchmarks/tpcc/src/test/java/com/google/cloud/pgadapter/tpcc/BenchmarkApplicationTest.java
+++ b/benchmarks/tpcc/src/test/java/com/google/cloud/pgadapter/tpcc/BenchmarkApplicationTest.java
@@ -1,0 +1,94 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.cloud.pgadapter.tpcc;
+
+import io.grpc.Server;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.springframework.boot.SpringApplication;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.utility.DockerImageName;
+
+@RunWith(JUnit4.class)
+public class BenchmarkApplicationTest {
+
+  interface Server {
+    int getPort();
+
+    void shutdown();
+  }
+
+  static class PGAdapterWithEmulator implements Server {
+    private final GenericContainer<?> container;
+
+    PGAdapterWithEmulator(GenericContainer<?> container) {
+      this.container = container;
+    }
+
+    @Override
+    public int getPort() {
+      return container.getMappedPort(5432);
+    }
+
+    @Override
+    public void shutdown() {
+      container.stop();
+    }
+  }
+
+  /** Starts a Docker container that contains both PGAdapter and the Cloud Spanner Emulator. */
+  static Server startPGAdapterWithEmulator() {
+    GenericContainer<?> container =
+        new GenericContainer<>(
+            DockerImageName.parse("gcr.io/cloud-spanner-pg-adapter/pgadapter-emulator"));
+    container.addExposedPort(5432);
+    container.setWaitStrategy(Wait.forListeningPorts(5432));
+    container.start();
+
+    return new PGAdapterWithEmulator(container);
+  }
+
+  @Test
+  public void testRunApplication() throws Exception {
+    // Start a Docker container with the Cloud Spanner Emulator.
+    // The server will be started on a random available port.
+    Server server = startPGAdapterWithEmulator();
+
+    try {
+      System.setProperty("tpcc.benchmark-duration", "PT10s");
+      System.setProperty("tpcc.warehouses", "1");
+      System.setProperty("tpcc.benchmark-threads", "1");
+      System.setProperty("tpcc.load-data", "true");
+      System.setProperty("tpcc.truncate-before-load", "false");
+      System.setProperty("tpcc.run-benchmark", "false");
+      System.setProperty("tpcc.benchmark-runner", "pgadapter");
+      System.setProperty("tpcc.use-read-only-transactions", "true");
+      System.setProperty("tpcc.lock-scanned-ranges", "false");
+      System.setProperty("spanner.project", "test-project");
+      System.setProperty("spanner.instance", "test-instance");
+      System.setProperty("spanner.database", "tpcc");
+      System.setProperty("pgadapter.in-process", "false");
+      System.setProperty("pgadapter.port", String.valueOf(server.getPort()));
+      System.setProperty("pgadapter.enable-open-telemetry", "false");
+      System.setProperty("pgadapter.enable-open-telemetry-metrics", "false");
+      System.setProperty("pgadapter.credentials", "");
+      SpringApplication.run(BenchmarkApplication.class).close();
+    } finally {
+      server.shutdown();
+    }
+  }
+}


### PR DESCRIPTION
Add the build test for tpcc benchmarking. In addition, in the real tests, some queries can return multiple results so that we need `ALLOW_MORE_THAN_ONE`. 