### PR TITLE
deps: update opentelemetry.exporter.version to 0.29

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
     <excludedIntegrationTests/>
 
     <junixsocket.version>2.9.1</junixsocket.version>
-    <opentelemetry.exporter.version>0.23.0</opentelemetry.exporter.version>
+    <opentelemetry.exporter.version>0.29.0</opentelemetry.exporter.version>
   </properties>
 
   <modelVersion>4.0.0</modelVersion>


### PR DESCRIPTION
Problem: with the old version, it can get weird an error reporting that the type of a field label is BOOL instead of STRING when creating MetricDescriptor. Similar to this [issue](https://github.com/GoogleCloudPlatform/opentelemetry-operations-java/issues/159) which should be fixed in the latest version. 

After upgrading to the 0.29 version, the metrics in Cloud Monitoring will be put into `Generic Node` category instead of `Generic Task` category. 