### PR TITLE
docs: enable pooling for dotnet samples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ venv
 package-lock.json
 node_modules
 .DotSettings.user
+*sln.DotSettings.user
 
 src/test/golang/**/*.h
 src/test/golang/**/*.so

--- a/samples/snippets/dotnet-snippets/AddColumn.cs
+++ b/samples/snippets/dotnet-snippets/AddColumn.cs
@@ -21,7 +21,7 @@ public static class AddColumnSample
 {
     public static void AddColumn(string host, int port, string database)
     {
-        var connectionString = $"Host={host};Port={port};Database={database};SSL Mode=Disable;Pooling=False";
+        var connectionString = $"Host={host};Port={port};Database={database};SSL Mode=Disable";
         using var connection = new NpgsqlConnection(connectionString);
         connection.Open();
 

--- a/samples/snippets/dotnet-snippets/CreateConnection.cs
+++ b/samples/snippets/dotnet-snippets/CreateConnection.cs
@@ -21,7 +21,7 @@ public static class CreateConnectionSample
 {
     public static void CreateConnection(string host, int port, string database)
     {
-        var connectionString = $"Host={host};Port={port};Database={database};SSL Mode=Disable;Pooling=False";
+        var connectionString = $"Host={host};Port={port};Database={database};SSL Mode=Disable";
         using var connection = new NpgsqlConnection(connectionString);
         connection.Open();
 

--- a/samples/snippets/dotnet-snippets/CreateTables.cs
+++ b/samples/snippets/dotnet-snippets/CreateTables.cs
@@ -21,7 +21,7 @@ public static class CreateTablesSample
 {
     public static void CreateTables(string host, int port, string database)
     {
-        var connectionString = $"Host={host};Port={port};Database={database};SSL Mode=Disable;Pooling=False";
+        var connectionString = $"Host={host};Port={port};Database={database};SSL Mode=Disable";
         using var connection = new NpgsqlConnection(connectionString);
         connection.Open();
 

--- a/samples/snippets/dotnet-snippets/DataBoost.cs
+++ b/samples/snippets/dotnet-snippets/DataBoost.cs
@@ -21,7 +21,7 @@ public static class DataBoostSample
 {
     public static void DataBoost(string host, int port, string database)
     {
-        var connectionString = $"Host={host};Port={port};Database={database};SSL Mode=Disable;Pooling=False";
+        var connectionString = $"Host={host};Port={port};Database={database};SSL Mode=Disable";
         using var connection = new NpgsqlConnection(connectionString);
         connection.Open();
 

--- a/samples/snippets/dotnet-snippets/DdlBatch.cs
+++ b/samples/snippets/dotnet-snippets/DdlBatch.cs
@@ -21,7 +21,7 @@ public static class DdlBatchSample
 {
     public static void DdlBatch(string host, int port, string database)
     {
-        var connectionString = $"Host={host};Port={port};Database={database};SSL Mode=Disable;Pooling=False";
+        var connectionString = $"Host={host};Port={port};Database={database};SSL Mode=Disable";
         using var connection = new NpgsqlConnection(connectionString);
         connection.Open();
 

--- a/samples/snippets/dotnet-snippets/PartitionedDml.cs
+++ b/samples/snippets/dotnet-snippets/PartitionedDml.cs
@@ -21,7 +21,7 @@ public static class PartitionedDmlSample
 {
     public static void PartitionedDml(string host, int port, string database)
     {
-        var connectionString = $"Host={host};Port={port};Database={database};SSL Mode=Disable;Pooling=False";
+        var connectionString = $"Host={host};Port={port};Database={database};SSL Mode=Disable";
         using var connection = new NpgsqlConnection(connectionString);
         connection.Open();
         

--- a/samples/snippets/dotnet-snippets/QueryData.cs
+++ b/samples/snippets/dotnet-snippets/QueryData.cs
@@ -21,7 +21,7 @@ public static class QueryDataSample
 {
     public static void QueryData(string host, int port, string database)
     {
-        var connectionString = $"Host={host};Port={port};Database={database};SSL Mode=Disable;Pooling=False";
+        var connectionString = $"Host={host};Port={port};Database={database};SSL Mode=Disable";
         using var connection = new NpgsqlConnection(connectionString);
         connection.Open();
 

--- a/samples/snippets/dotnet-snippets/QueryDataWithNewColumn.cs
+++ b/samples/snippets/dotnet-snippets/QueryDataWithNewColumn.cs
@@ -21,7 +21,7 @@ public static class QueryDataWithNewColumnSample
 {
     public static void QueryWithNewColumnData(string host, int port, string database)
     {
-        var connectionString = $"Host={host};Port={port};Database={database};SSL Mode=Disable;Pooling=False";
+        var connectionString = $"Host={host};Port={port};Database={database};SSL Mode=Disable";
         using var connection = new NpgsqlConnection(connectionString);
         connection.Open();
 

--- a/samples/snippets/dotnet-snippets/QueryDataWithParameter.cs
+++ b/samples/snippets/dotnet-snippets/QueryDataWithParameter.cs
@@ -21,7 +21,7 @@ public static class QueryDataWithParameterSample
 {
     public static void QueryDataWithParameter(string host, int port, string database)
     {
-        var connectionString = $"Host={host};Port={port};Database={database};SSL Mode=Disable;Pooling=False";
+        var connectionString = $"Host={host};Port={port};Database={database};SSL Mode=Disable";
         using var connection = new NpgsqlConnection(connectionString);
         connection.Open();
 

--- a/samples/snippets/dotnet-snippets/QueryWithTimeout.cs
+++ b/samples/snippets/dotnet-snippets/QueryWithTimeout.cs
@@ -21,7 +21,7 @@ public static class QueryWithTimeoutSample
 {
     public static void QueryWithTimeout(string host, int port, string database)
     {
-        var connectionString = $"Host={host};Port={port};Database={database};SSL Mode=Disable;Pooling=False";
+        var connectionString = $"Host={host};Port={port};Database={database};SSL Mode=Disable";
         using var connection = new NpgsqlConnection(connectionString);
         connection.Open();
 

--- a/samples/snippets/dotnet-snippets/ReadOnlyTransaction.cs
+++ b/samples/snippets/dotnet-snippets/ReadOnlyTransaction.cs
@@ -22,7 +22,7 @@ public static class ReadOnlyTransactionSample
 {
     public static void ReadOnlyTransaction(string host, int port, string database)
     {
-        var connectionString = $"Host={host};Port={port};Database={database};SSL Mode=Disable;Pooling=False";
+        var connectionString = $"Host={host};Port={port};Database={database};SSL Mode=Disable";
         using var connection = new NpgsqlConnection(connectionString);
         connection.Open();
         

--- a/samples/snippets/dotnet-snippets/Tags.cs
+++ b/samples/snippets/dotnet-snippets/Tags.cs
@@ -22,7 +22,7 @@ public static class TagsSample
 {
     public static void Tags(string host, int port, string database)
     {
-        var connectionString = $"Host={host};Port={port};Database={database};SSL Mode=Disable;Pooling=False";
+        var connectionString = $"Host={host};Port={port};Database={database};SSL Mode=Disable";
         using var connection = new NpgsqlConnection(connectionString);
         connection.Open();
         

--- a/samples/snippets/dotnet-snippets/UpdateDataWithCopy.cs
+++ b/samples/snippets/dotnet-snippets/UpdateDataWithCopy.cs
@@ -21,7 +21,7 @@ public static class UpdateDataWithCopySample
 {
     public static void UpdateDataWithCopy(string host, int port, string database)
     {
-        var connectionString = $"Host={host};Port={port};Database={database};SSL Mode=Disable;Pooling=False";
+        var connectionString = $"Host={host};Port={port};Database={database};SSL Mode=Disable";
         using var connection = new NpgsqlConnection(connectionString);
         connection.Open();
         

--- a/samples/snippets/dotnet-snippets/WriteDataWithCopy.cs
+++ b/samples/snippets/dotnet-snippets/WriteDataWithCopy.cs
@@ -21,7 +21,7 @@ public static class WriteDataWithCopySample
 {
     public static void WriteDataWithCopy(string host, int port, string database)
     {
-        var connectionString = $"Host={host};Port={port};Database={database};SSL Mode=Disable;Pooling=False";
+        var connectionString = $"Host={host};Port={port};Database={database};SSL Mode=Disable";
         using var connection = new NpgsqlConnection(connectionString);
         connection.Open();
         

--- a/samples/snippets/dotnet-snippets/WriteDataWithDml.cs
+++ b/samples/snippets/dotnet-snippets/WriteDataWithDml.cs
@@ -35,7 +35,7 @@ public static class WriteDataWithDmlSample
     
     public static void WriteDataWithDml(string host, int port, string database)
     {
-        var connectionString = $"Host={host};Port={port};Database={database};SSL Mode=Disable;Pooling=False";
+        var connectionString = $"Host={host};Port={port};Database={database};SSL Mode=Disable";
         using var connection = new NpgsqlConnection(connectionString);
         connection.Open();
         // Add 4 rows in one statement.

--- a/samples/snippets/dotnet-snippets/WriteDataWithDmlBatch.cs
+++ b/samples/snippets/dotnet-snippets/WriteDataWithDmlBatch.cs
@@ -35,7 +35,7 @@ public static class WriteDataWithDmlBatchSample
     
     public static void WriteDataWithDmlBatch(string host, int port, string database)
     {
-        var connectionString = $"Host={host};Port={port};Database={database};SSL Mode=Disable;Pooling=False";
+        var connectionString = $"Host={host};Port={port};Database={database};SSL Mode=Disable";
         using var connection = new NpgsqlConnection(connectionString);
         connection.Open();
 

--- a/samples/snippets/dotnet-snippets/WriteDataWithTransaction.cs
+++ b/samples/snippets/dotnet-snippets/WriteDataWithTransaction.cs
@@ -22,7 +22,7 @@ public static class UpdateDataWithTransactionSample
 {
     public static void WriteWithTransactionUsingDml(string host, int port, string database)
     {
-        var connectionString = $"Host={host};Port={port};Database={database};SSL Mode=Disable;Pooling=False";
+        var connectionString = $"Host={host};Port={port};Database={database};SSL Mode=Disable";
         using var connection = new NpgsqlConnection(connectionString);
         connection.Open();
         


### PR DESCRIPTION
Pooling was disabled for dotnet samples due to lack of support for DISCARD ALL. This has now been added and released.