### PR TITLE
feat: add Prisma as a well-known-client

### DIFF
--- a/src/main/java/com/google/cloud/spanner/pgadapter/statements/local/SelectPrismaAdvisoryLockStatement.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/statements/local/SelectPrismaAdvisoryLockStatement.java
@@ -1,0 +1,50 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.cloud.spanner.pgadapter.statements.local;
+
+import com.google.api.core.InternalApi;
+import com.google.cloud.spanner.ResultSet;
+import com.google.cloud.spanner.Struct;
+import com.google.cloud.spanner.Type;
+import com.google.cloud.spanner.Type.StructField;
+import com.google.cloud.spanner.connection.StatementResult;
+import com.google.cloud.spanner.pgadapter.statements.BackendConnection;
+import com.google.cloud.spanner.pgadapter.statements.BackendConnection.QueryResult;
+import com.google.cloud.spanner.pgadapter.statements.ClientSideResultSet;
+import com.google.common.collect.ImmutableList;
+
+@InternalApi
+public class SelectPrismaAdvisoryLockStatement implements LocalStatement {
+  public static final SelectPrismaAdvisoryLockStatement INSTANCE =
+      new SelectPrismaAdvisoryLockStatement();
+
+  private SelectPrismaAdvisoryLockStatement() {}
+
+  @Override
+  public String[] getSql() {
+    return new String[] {
+      "SELECT pg_advisory_lock(72707369)",
+    };
+  }
+
+  @Override
+  public StatementResult execute(BackendConnection backendConnection) {
+    ResultSet resultSet =
+        ClientSideResultSet.forRows(
+            Type.struct(StructField.of("pg_advisory_lock", Type.string())),
+            ImmutableList.of(Struct.newBuilder().set("pg_advisory_lock").to("72707369").build()));
+    return new QueryResult(resultSet);
+  }
+}

--- a/src/main/java/com/google/cloud/spanner/pgadapter/statements/local/SelectPrismaAdvisoryUnlockStatement.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/statements/local/SelectPrismaAdvisoryUnlockStatement.java
@@ -1,0 +1,50 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.cloud.spanner.pgadapter.statements.local;
+
+import com.google.api.core.InternalApi;
+import com.google.cloud.spanner.ResultSet;
+import com.google.cloud.spanner.Struct;
+import com.google.cloud.spanner.Type;
+import com.google.cloud.spanner.Type.StructField;
+import com.google.cloud.spanner.connection.StatementResult;
+import com.google.cloud.spanner.pgadapter.statements.BackendConnection;
+import com.google.cloud.spanner.pgadapter.statements.BackendConnection.QueryResult;
+import com.google.cloud.spanner.pgadapter.statements.ClientSideResultSet;
+import com.google.common.collect.ImmutableList;
+
+@InternalApi
+public class SelectPrismaAdvisoryUnlockStatement implements LocalStatement {
+  public static final SelectPrismaAdvisoryUnlockStatement INSTANCE =
+      new SelectPrismaAdvisoryUnlockStatement();
+
+  private SelectPrismaAdvisoryUnlockStatement() {}
+
+  @Override
+  public String[] getSql() {
+    return new String[] {
+      "SELECT pg_advisory_unlock(72707369)",
+    };
+  }
+
+  @Override
+  public StatementResult execute(BackendConnection backendConnection) {
+    ResultSet resultSet =
+        ClientSideResultSet.forRows(
+            Type.struct(StructField.of("pg_advisory_unlock", Type.bool())),
+            ImmutableList.of(Struct.newBuilder().set("pg_advisory_unlock").to(true).build()));
+    return new QueryResult(resultSet);
+  }
+}

--- a/src/test/java/com/google/cloud/spanner/pgadapter/nodejs/PrismaMockServerTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/nodejs/PrismaMockServerTest.java
@@ -99,6 +99,21 @@ public class PrismaMockServerTest extends AbstractMockServerTest {
   }
 
   @Test
+  public void testShowWellKnownClient() throws Exception {
+    String output = runTest("testShowWellKnownClient", getHost(), pgServer.getLocalPort());
+
+    assertEquals("[ { 'spanner.well_known_client': 'PRISMA' } ]\n", output);
+  }
+
+  @Test
+  public void testPgAdvisoryLock() throws Exception {
+    String output = runTest("testPgAdvisoryLock", getHost(), pgServer.getLocalPort());
+
+    assertEquals(
+        "[ { pg_advisory_lock: '72707369' } ]\n" + "[ { pg_advisory_unlock: true } ]\n", output);
+  }
+
+  @Test
   public void testFindAllUsers() throws Exception {
     String sql =
         "SELECT \"public\".\"User\".\"id\", \"public\".\"User\".\"email\", \"public\".\"User\".\"name\" "


### PR DESCRIPTION
Adds Prisma as a well-known-client to PGAdapter and add default query replacements for it. Prisma does not send enough unique parameters or queries at startup for PGAdapter to automatically detect it. The well-known-client will therefore only be used if the user has specifically specified it in the connction URL.