### PR TITLE
fix: correctly apply default client settings

### DIFF
--- a/src/main/java/com/google/cloud/spanner/pgadapter/statements/BackendConnection.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/statements/BackendConnection.java
@@ -1089,11 +1089,17 @@ public class BackendConnection {
         }
       }
     } else {
-      SimpleParser parser = new SimpleParser(name);
-      TableOrIndexName key = parser.readTableOrIndexName();
-      if (key == null) {
-        return;
-      }
+      initSessionSetting(name, value, true);
+    }
+  }
+
+  public void initSessionSetting(String name, String value, boolean overwrite) {
+    SimpleParser parser = new SimpleParser(name);
+    TableOrIndexName key = parser.readTableOrIndexName();
+    if (key == null) {
+      return;
+    }
+    if (overwrite || this.sessionState.tryGet(key.schema, key.name) == null) {
       this.sessionState.setConnectionStartupValue(key.schema, key.name, value);
     }
   }

--- a/src/main/java/com/google/cloud/spanner/pgadapter/utils/ClientAutoDetector.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/utils/ClientAutoDetector.java
@@ -477,6 +477,11 @@ public class ClientAutoDetector {
       }
 
       @Override
+      public ImmutableMap<String, String> getDefaultParameters(Map<String, String> parameters) {
+        return ImmutableMap.of("spanner.auto_add_limit_clause", "true");
+      }
+
+      @Override
       public ImmutableSet<String> getPgCatalogCheckPrefixes() {
         return checkPgCatalogPrefixes;
       }

--- a/src/main/java/com/google/cloud/spanner/pgadapter/wireprotocol/StartupMessage.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/wireprotocol/StartupMessage.java
@@ -21,7 +21,6 @@ import com.google.cloud.spanner.pgadapter.ConnectionHandler.ConnectionStatus;
 import com.google.cloud.spanner.pgadapter.utils.ClientAutoDetector;
 import com.google.cloud.spanner.pgadapter.utils.ClientAutoDetector.WellKnownClient;
 import com.google.cloud.spanner.pgadapter.wireoutput.AuthenticationCleartextPasswordResponse;
-import com.google.common.collect.Iterables;
 import java.io.IOException;
 import java.text.MessageFormat;
 import java.util.Map;
@@ -74,10 +73,7 @@ public class StartupMessage extends BootstrapMessage {
       @Nullable Credentials credentials)
       throws Exception {
     connection.connectToSpanner(database, credentials);
-    for (Entry<String, String> parameter :
-        Iterables.concat(
-            connection.getWellKnownClient().getDefaultParameters(parameters).entrySet(),
-            parameters.entrySet())) {
+    for (Entry<String, String> parameter : parameters.entrySet()) {
       connection
           .getExtendedQueryProtocolHandler()
           .getBackendConnection()
@@ -93,6 +89,13 @@ public class StartupMessage extends BootstrapMessage {
                   .getSessionState()
                   .tryGet("spanner", "well_known_client"));
       connection.setWellKnownClient(wellKnownClient);
+    }
+    for (Entry<String, String> parameter :
+        connection.getWellKnownClient().getDefaultParameters(parameters).entrySet()) {
+      connection
+          .getExtendedQueryProtocolHandler()
+          .getBackendConnection()
+          .initSessionSetting(parameter.getKey(), parameter.getValue(), /* overwrite = */ false);
     }
     if (connection.getWellKnownClient() != WellKnownClient.UNSPECIFIED) {
       connection

--- a/src/test/java/com/google/cloud/spanner/pgadapter/nodejs/PrismaMockServerTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/nodejs/PrismaMockServerTest.java
@@ -114,6 +114,13 @@ public class PrismaMockServerTest extends AbstractMockServerTest {
   }
 
   @Test
+  public void testShowAutoAddLimitClause() throws Exception {
+    String output = runTest("testShowAutoAddLimitClause", getHost(), pgServer.getLocalPort());
+
+    assertEquals("[ { 'spanner.auto_add_limit_clause': 'true' } ]\n", output);
+  }
+
+  @Test
   public void testFindAllUsers() throws Exception {
     String sql =
         "SELECT \"public\".\"User\".\"id\", \"public\".\"User\".\"email\", \"public\".\"User\".\"name\" "

--- a/src/test/nodejs/prisma-tests/src/index.ts
+++ b/src/test/nodejs/prisma-tests/src/index.ts
@@ -71,6 +71,15 @@ async function testPgAdvisoryLock(client: PrismaClient) {
   }
 }
 
+async function testShowAutoAddLimitClause(client: PrismaClient) {
+  try {
+    const wellKnownClient = await client.$queryRaw`show spanner.auto_add_limit_clause`;
+    console.log(wellKnownClient);
+  } catch (e) {
+    console.error(`Query error: ${e}`);
+  }
+}
+
 async function testFindAllUsers(client: PrismaClient) {
   const allUsers = await client.user.findMany({take: 10});
   console.log(allUsers);
@@ -365,6 +374,12 @@ require('yargs')
     'Locks/unlocks the specific advisory lock for Prisma',
     {},
     opts => runTest(opts.host, opts.port, opts.database, testPgAdvisoryLock)
+)
+.command(
+    'testShowAutoAddLimitClause <host> <port> <database>',
+    'Shows whether a LIMIT clause is automatically added when needed',
+    {},
+    opts => runTest(opts.host, opts.port, opts.database, testShowAutoAddLimitClause)
 )
 .command(
     'testFindAllUsers <host> <port> <database>',


### PR DESCRIPTION
Some auto-detected clients also set specific session state variables. These variables were however not set if the client was not auto-detected from the queries/parameters that the client sends, but was set in the connection string (e.g. Prisma). This fixes that so that the order of applying session variables at startup are:
1. Set the values in the connction string.
2. Set the client based on the connection string (if any).
3. Apply the default params for the client, but do not overwrite any existing value.