### PR TITLE
feat: return exit code 0 on successful shutdown

### DIFF
--- a/.ci/run-with-credentials.sh
+++ b/.ci/run-with-credentials.sh
@@ -63,7 +63,7 @@ e2e-psql)
   echo "Starting PGAdapter"
   ls -lh target
   UBER_JAR="pgadapter.jar"
-  (java -jar target/"${UBER_JAR}" -p "${GOOGLE_CLOUD_PROJECT}" -i "${GOOGLE_CLOUD_INSTANCE}" -d "${GOOGLE_CLOUD_DATABASE_WITH_VERSION}" -e "${GOOGLE_CLOUD_ENDPOINT}" -s 4242 -v "${PG_BACKEND_VERSION}" -ddl AutocommitImplicitTransaction > /dev/null 2>&1) &
+  (java -jar target/"${UBER_JAR}" -p "${GOOGLE_CLOUD_PROJECT}" -i "${GOOGLE_CLOUD_INSTANCE}" -d "${GOOGLE_CLOUD_DATABASE_WITH_VERSION}" -e "${GOOGLE_CLOUD_ENDPOINT}" -s 4242 -v "${PG_BACKEND_VERSION}" -ddl AutocommitImplicitTransaction -exit_mode USE_JVM_EXIT_CODE > /dev/null 2>&1) &
   BACK_PID=$!
   sleep 1
 #  execute psql and evaluate result
@@ -73,7 +73,8 @@ e2e-psql)
 #  cleanup and exit
   rm -r .ci/e2e-result
   kill ${BACK_PID}
-  sleep 1
+  wait ${BACK_PID}
+  RETURN_CODE=$?
   gcloud spanner databases delete "${GOOGLE_CLOUD_DATABASE_WITH_VERSION}" --instance=${GOOGLE_CLOUD_INSTANCE} --quiet
   echo "exiting with ${RETURN_CODE}"
   exit ${RETURN_CODE}

--- a/.ci/run-with-credentials.sh
+++ b/.ci/run-with-credentials.sh
@@ -63,7 +63,7 @@ e2e-psql)
   echo "Starting PGAdapter"
   ls -lh target
   UBER_JAR="pgadapter.jar"
-  (java -jar target/"${UBER_JAR}" -p "${GOOGLE_CLOUD_PROJECT}" -i "${GOOGLE_CLOUD_INSTANCE}" -d "${GOOGLE_CLOUD_DATABASE_WITH_VERSION}" -e "${GOOGLE_CLOUD_ENDPOINT}" -s 4242 -v "${PG_BACKEND_VERSION}" -ddl AutocommitImplicitTransaction -exit_mode USE_JVM_EXIT_CODE > /dev/null 2>&1) &
+  (java -jar target/"${UBER_JAR}" -p "${GOOGLE_CLOUD_PROJECT}" -i "${GOOGLE_CLOUD_INSTANCE}" -d "${GOOGLE_CLOUD_DATABASE_WITH_VERSION}" -e "${GOOGLE_CLOUD_ENDPOINT}" -s 4242 -v "${PG_BACKEND_VERSION}" -ddl AutocommitImplicitTransaction > /dev/null 2>&1) &
   BACK_PID=$!
   sleep 1
 #  execute psql and evaluate result

--- a/src/main/java/com/google/cloud/spanner/pgadapter/ConnectionHandler.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/ConnectionHandler.java
@@ -528,7 +528,9 @@ public class ConnectionHandler implements Runnable {
    * shutting down while the connection is still active.
    */
   void terminate() {
-    getThread().interrupt();
+    if (this.thread != null && this.thread.isAlive()) {
+      getThread().interrupt();
+    }
     handleTerminate();
     try {
       if (!socket.isClosed()) {

--- a/src/main/java/com/google/cloud/spanner/pgadapter/ExitMode.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/ExitMode.java
@@ -1,0 +1,26 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.cloud.spanner.pgadapter;
+
+public enum ExitMode {
+  /** Halts the JVM with exit code 0 if the shutdown was successful. */
+  HALT_WITH_EXIT_CODE_ZERO_ON_SUCCESS,
+
+  /**
+   * Uses the default JVM exit code. This is equal to 128 + signal code if the server was halted by
+   * a signal (e.g. ctrl-c or kill -2), or the exit code passed to System.exit(code).
+   */
+  USE_JVM_EXIT_CODE,
+}

--- a/src/main/java/com/google/cloud/spanner/pgadapter/ProxyServer.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/ProxyServer.java
@@ -213,6 +213,7 @@ public class ProxyServer extends AbstractApiService {
 
   @Override
   protected void doStop() {
+    // First close all server sockets to prevent new connections from being accepted.
     for (ServerSocket serverSocket : this.serverSockets) {
       try {
         logger.log(
@@ -227,6 +228,9 @@ public class ProxyServer extends AbstractApiService {
             () -> String.format("Closing server socket %s failed: %s", serverSocket, exception));
       }
     }
+    // Close all existing connections.
+    // TODO: Implement smart shutdown that waits for all connections to finish before shutting down.
+    // See https://www.postgresql.org/docs/current/server-shutdown.html
     for (ConnectionHandler handler : getConnectionHandlers()) {
       handler.terminate();
     }

--- a/src/main/java/com/google/cloud/spanner/pgadapter/Server.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/Server.java
@@ -61,6 +61,10 @@ public class Server {
       OpenTelemetry openTelemetry = setupOpenTelemetry(optionsMetadata);
       ProxyServer server = new ProxyServer(optionsMetadata, openTelemetry);
       server.startServer();
+      // Register a shutdown hook that stops the ProxyServer when the JVM is being shut down.
+      // The exit code will be zero if the shutdown succeeds.
+      Runtime.getRuntime()
+          .addShutdownHook(new ServerShutdownHook(server, optionsMetadata.getExitMode()));
     } catch (Exception e) {
       printError(e, System.err, System.out);
     }

--- a/src/main/java/com/google/cloud/spanner/pgadapter/ServerShutdownHook.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/ServerShutdownHook.java
@@ -1,0 +1,55 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.cloud.spanner.pgadapter;
+
+import com.google.common.base.Stopwatch;
+import java.util.concurrent.TimeUnit;
+
+class ServerShutdownHook extends Thread {
+
+  private final ProxyServer server;
+
+  private final ExitMode exitMode;
+
+  ServerShutdownHook(ProxyServer server, ExitMode exitMode) {
+    this.server = server;
+    this.exitMode = exitMode;
+  }
+
+  @Override
+  public void run() {
+    try {
+      if (this.server != null && this.server.isRunning()) {
+        this.server.stopServer();
+        this.server.awaitTerminated();
+      }
+      if (this.exitMode == ExitMode.HALT_WITH_EXIT_CODE_ZERO_ON_SUCCESS) {
+        // Halt the system with a zero exit code if the shutdown succeeded.
+        // Wait with calling halt(0) until there are only two threads alive.
+        // That should be the DestroyJavaVM thread + this thread.
+        Stopwatch stopwatch = Stopwatch.createStarted();
+        while (Thread.activeCount() > 2 && stopwatch.elapsed(TimeUnit.MILLISECONDS) < 100) {
+          Thread.yield();
+        }
+        Runtime.getRuntime().halt(0);
+      }
+    } catch (Exception exception) {
+      // Shutdown hooks cannot use java.util.logging.
+      // See https://bugs.openjdk.org/browse/JDK-8161253.
+      System.err.println("Server shutdown failed");
+      exception.printStackTrace(System.err);
+    }
+  }
+}

--- a/src/test/java/com/google/cloud/spanner/pgadapter/metadata/OptionsMetadataTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/metadata/OptionsMetadataTest.java
@@ -15,6 +15,7 @@
 package com.google.cloud.spanner.pgadapter.metadata;
 
 import static com.google.cloud.spanner.pgadapter.metadata.OptionsMetadata.DEFAULT_STARTUP_TIMEOUT;
+import static com.google.cloud.spanner.pgadapter.metadata.OptionsMetadata.parseExitMode;
 import static com.google.cloud.spanner.pgadapter.metadata.OptionsMetadata.parseSslMode;
 import static com.google.cloud.spanner.pgadapter.metadata.OptionsMetadata.toServerVersionNum;
 import static org.junit.Assert.assertEquals;
@@ -32,6 +33,7 @@ import com.google.cloud.spanner.ErrorCode;
 import com.google.cloud.spanner.InstanceId;
 import com.google.cloud.spanner.SessionPoolOptions;
 import com.google.cloud.spanner.SpannerException;
+import com.google.cloud.spanner.pgadapter.ExitMode;
 import com.google.cloud.spanner.pgadapter.metadata.OptionsMetadata.DdlTransactionMode;
 import com.google.cloud.spanner.pgadapter.metadata.OptionsMetadata.SslMode;
 import com.google.cloud.spanner.pgadapter.metadata.OptionsMetadata.TextFormat;
@@ -314,6 +316,26 @@ public class OptionsMetadataTest {
     assertFalse(SslMode.Disable.isSslEnabled());
     assertTrue(SslMode.Enable.isSslEnabled());
     assertTrue(SslMode.Require.isSslEnabled());
+  }
+
+  @Test
+  public void testParseExitMode() {
+    assertEquals(ExitMode.HALT_WITH_EXIT_CODE_ZERO_ON_SUCCESS, parseExitMode(null));
+    assertEquals(
+        ExitMode.HALT_WITH_EXIT_CODE_ZERO_ON_SUCCESS,
+        parseExitMode("HALT_WITH_EXIT_CODE_ZERO_ON_SUCCESS"));
+    assertEquals(
+        ExitMode.HALT_WITH_EXIT_CODE_ZERO_ON_SUCCESS,
+        parseExitMode("halt_with_exit_code_zero_on_success"));
+    assertEquals(ExitMode.USE_JVM_EXIT_CODE, parseExitMode("USE_JVM_EXIT_CODE"));
+    assertEquals(ExitMode.USE_JVM_EXIT_CODE, parseExitMode("use_jvm_exit_code"));
+
+    IllegalArgumentException exception =
+        assertThrows(IllegalArgumentException.class, () -> parseExitMode("foo"));
+    assertEquals(
+        "Invalid exit mode value specified: foo\n"
+            + "It must be one of HALT_WITH_EXIT_CODE_ZERO_ON_SUCCESS,USE_JVM_EXIT_CODE",
+        exception.getMessage());
   }
 
   @Test


### PR DESCRIPTION
The default behavior of Java applications is to return exit code 128 + signal if the application was shut down due to receiving a signal. This means that SIGINT returns 130 and SIGTERM returns 143.

This change modifies this behavior so exit code 0 is returned if the shutdown is successful. The old behavior that returns the JVM default can be restored by starting PGAdapter with the -exit_mode startup argument.

This also prepares the server for adding Smart Shutdown mode, which will allow the server to start refusing new connections, while giving existing connections time to finish their work. See https://www.postgresql.org/docs/current/server-shutdown.html for more information on Smart Shutdown.