### PR TITLE
build: run Python samples on MacOS

### DIFF
--- a/.github/workflows/samples.yaml
+++ b/.github/workflows/samples.yaml
@@ -36,7 +36,10 @@ jobs:
         working-directory: ./samples/golang/pgx
         run: go test
   python-samples:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5


### PR DESCRIPTION
Also run the Python samples on MacOS, as the Python dependencies often have OS-specific issues.