### PR TITLE
fix: add translations for unsupported statements for Liquibase

### DIFF
--- a/samples/java/liquibase/pom.xml
+++ b/samples/java/liquibase/pom.xml
@@ -62,7 +62,7 @@
         <plugin>
           <groupId>org.liquibase</groupId>
           <artifactId>liquibase-maven-plugin</artifactId>
-          <version>4.27.0</version>
+          <version>4.29.1</version>
           <configuration>
             <propertyFile>liquibase.properties</propertyFile>
             <outputChangeLogFile>changelog-master.xml</outputChangeLogFile>

--- a/src/main/java/com/google/cloud/spanner/pgadapter/statements/JdbcMetadataStatementHelper.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/statements/JdbcMetadataStatementHelper.java
@@ -34,9 +34,10 @@ class JdbcMetadataStatementHelper {
    * @return true if the query could be a JDBC metadata query, and false if it definitely not.
    */
   static boolean isPotentialJdbcMetadataStatement(String sql) {
-    // All JDBC metadata queries that need any replacements reference the pg_catalog schema or the
-    // pg_settings table.
-    return sql.contains("pg_catalog.") || sql.contains("pg_settings") || sql.contains("pg_class");
+    // All JDBC metadata queries that need any replacements reference the pg_catalog schema.
+    return sql.contains("pg_catalog.")
+        || sql.contains("pg_class")
+        || sql.contains("databasechangelog");
   }
 
   static String replaceJdbcMetadataStatement(String sql) {
@@ -49,8 +50,13 @@ class JdbcMetadataStatementHelper {
     if (sql.startsWith(PgJdbcCatalog.PG_JDBC_GET_SCHEMAS_PREFIX)) {
       return replaceGetSchemasQuery(sql);
     }
-    if (sql.equals(PgJdbcCatalog.PG_JDBC_GET_EDB_REDWOOD_DATE_QUERY)) {
-      return PgJdbcCatalog.PG_JDBC_GET_EDB_REDWOOD_DATE_REPLACEMENT;
+    if (sql.contains(LiquibaseStatementHelper.TAG_STATEMENT_PART)) {
+      return LiquibaseStatementHelper.replaceTagStatement(sql);
+    }
+    if (sql.endsWith(LiquibaseStatementHelper.MD5SUM_NOT_LIKE)) {
+      return sql.replace(
+          LiquibaseStatementHelper.MD5SUM_NOT_LIKE,
+          LiquibaseStatementHelper.MD5SUM_NOT_LIKE_REPLACEMENT);
     }
     if (sql.startsWith(PgJdbcCatalog.PG_JDBC_GET_TABLES_PREFIX_1)
         || sql.startsWith(PgJdbcCatalog.PG_JDBC_GET_TABLES_PREFIX_2)

--- a/src/main/java/com/google/cloud/spanner/pgadapter/statements/LiquibaseStatementHelper.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/statements/LiquibaseStatementHelper.java
@@ -1,0 +1,48 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.cloud.spanner.pgadapter.statements;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+class LiquibaseStatementHelper {
+  static final String TAG_STATEMENT_PART = "databasechangelog t SET TAG=";
+  private static final Pattern TAG_STATEMENT_PATTERN =
+      Pattern.compile(
+          "UPDATE (?<schema>.+\\.)?databasechangelog t "
+              + "SET TAG='(?<tag>.*)' "
+              + "FROM \\(SELECT DATEEXECUTED, ORDEREXECUTED "
+              + "FROM (?<schema2>.+\\.)?databasechangelog "
+              + "ORDER BY DATEEXECUTED DESC, ORDEREXECUTED DESC LIMIT 1\\) sub "
+              + "WHERE t\\.DATEEXECUTED=sub\\.DATEEXECUTED AND t\\.ORDEREXECUTED=sub\\.ORDEREXECUTED");
+
+  static final String MD5SUM_NOT_LIKE = " MD5SUM IS NOT NULL AND MD5SUM NOT LIKE '9:%'";
+  static final String MD5SUM_NOT_LIKE_REPLACEMENT = " MD5SUM IS NOT NULL AND NOT MD5SUM LIKE '9:%'";
+
+  static String replaceTagStatement(String input) {
+    Matcher matcher = TAG_STATEMENT_PATTERN.matcher(input);
+    if (matcher.matches()) {
+      return matcher.replaceFirst(
+          "UPDATE ${schema}databasechangelog t "
+              + "SET TAG='${tag}' "
+              + "WHERE ID=("
+              + "  SELECT ID "
+              + "  FROM ${schema}databasechangelog "
+              + "  ORDER BY DATEEXECUTED DESC, ORDEREXECUTED DESC "
+              + "  LIMIT 1)");
+    }
+    return input;
+  }
+}

--- a/src/main/java/com/google/cloud/spanner/pgadapter/utils/PgJdbcCatalog.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/utils/PgJdbcCatalog.java
@@ -125,11 +125,6 @@ public class PgJdbcCatalog {
           + ") f\n"
           + "where false";
 
-  public static final String PG_JDBC_GET_EDB_REDWOOD_DATE_QUERY =
-      "select setting from pg_settings where name = 'edb_redwood_date'";
-  public static final String PG_JDBC_GET_EDB_REDWOOD_DATE_REPLACEMENT =
-      "select * from (select ''::varchar as setting) s where false";
-
   public static final String PG_JDBC_GET_SCHEMAS_PREFIX =
       "SELECT nspname AS TABLE_SCHEM, NULL AS TABLE_CATALOG FROM pg_catalog.pg_namespace "
           + " WHERE nspname <> 'pg_toast' AND (nspname !~ '^pg_temp_' "

--- a/src/test/java/com/google/cloud/spanner/pgadapter/liquibase/ITLiquibaseTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/liquibase/ITLiquibaseTest.java
@@ -172,6 +172,18 @@ public class ITLiquibaseTest {
         assertEquals(5L, resultSet.getLong(1));
         assertFalse(resultSet.next());
       }
+      // Manually add a tag to the database.
+      runLiquibaseCommand(
+          "liquibase:tag", "-Dliquibase.tag=tag-set-with-command", "-Dliquibase.verbose=true");
+      try (ResultSet resultSet =
+          connection
+              .createStatement()
+              .executeQuery(
+                  "select tag from databasechangelog where id='23 - remove all addresses'")) {
+        assertTrue(resultSet.next());
+        assertEquals("tag-set-with-command", resultSet.getString(1));
+        assertFalse(resultSet.next());
+      }
 
       // Rollback to v3.1.
       runLiquibaseCommand("liquibase:rollback", "-Dliquibase.rollbackTag=v3.1");


### PR DESCRIPTION
This change fixes two issues with Liquibase:
1. The 'tag' command did not work, as it used an UPDATE .. FROM statement.
2. Liquibase 4.28.0 and later did not work due to a NOT LIKE clause.

Both the above types of statements are now automatically replaced by PGAdapter by compatible statements.

Fixes #2187