### PR TITLE
feat: add option for partitioned COPY TO STDOUT

### DIFF
--- a/src/main/java/com/google/cloud/spanner/pgadapter/session/CopySettings.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/session/CopySettings.java
@@ -18,6 +18,7 @@ import com.google.cloud.spanner.Options.RpcPriority;
 import java.util.Locale;
 import java.util.Map;
 
+/** Settings for COPY FROM STDIN operations. */
 public class CopySettings {
   private static final int DEFAULT_PIPE_BUFFER_SIZE = 1 << 16;
   private static final int DEFAULT_MAX_MUTATION_LIMIT = 80_000; // 80k mutations limit
@@ -83,17 +84,17 @@ public class CopySettings {
     return this.sessionState;
   }
 
-  /** Returns the maximum number of parallel transactions for a single COPY operation. */
+  /** Returns the maximum number of parallel transactions for a single COPY FROM STDIN operation. */
   public int getMaxParallelism() {
     return sessionState.getIntegerSetting("spanner", "copy_max_parallelism", 128);
   }
 
-  /** Returns the commit timeout for COPY operations in seconds. */
+  /** Returns the commit timeout for COPY FROM STDIN operations in seconds. */
   public int getCommitTimeoutSeconds() {
     return sessionState.getIntegerSetting("spanner", "copy_commit_timeout", 300);
   }
 
-  /** Returns the request priority for commits executed by COPY operations. */
+  /** Returns the request priority for commits executed by COPY FROM STDIN operations. */
   public RpcPriority getCommitPriority() {
     String setting =
         sessionState
@@ -106,7 +107,7 @@ public class CopySettings {
     }
   }
 
-  /** Returns the batch size to use for non-atomic COPY operations. */
+  /** Returns the batch size to use for non-atomic COPY FROM STDIN operations. */
   public int getNonAtomicBatchSize() {
     return sessionState.getIntegerSetting("spanner", "copy_batch_size", 5000);
   }
@@ -144,12 +145,12 @@ public class CopySettings {
   }
 
   /**
-   * Returns whether COPY operations should use upsert instead of insert.
+   * Returns whether COPY FROM STDIN operations should use upsert instead of insert.
    *
-   * <p>COPY will INSERT records by default. This is consistent with how COPY on PostgreSQL works.
-   * This option allows PGAdapter to use InsertOrUpdate instead. This can be slightly more efficient
-   * for bulk uploading, and it makes it easier to retry a failed non-atomic batch that might have
-   * already uploaded some but not all data.
+   * <p>COPY FROM STDIN will INSERT records by default. This is consistent with how COPY on
+   * PostgreSQL works. This option allows PGAdapter to use InsertOrUpdate instead. This can be
+   * slightly more efficient for bulk uploading, and it makes it easier to retry a failed non-atomic
+   * batch that might have already uploaded some but not all data.
    */
   public boolean isCopyUpsert() {
     return sessionState.getBoolSetting("spanner", "copy_upsert", false);

--- a/src/main/java/com/google/cloud/spanner/pgadapter/session/SessionState.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/session/SessionState.java
@@ -403,10 +403,10 @@ public class SessionState {
   /**
    * Returns whether COPY TO STDOUT operations should try to use PartitionQuery.
    *
-   * <p>COPY TO STDOUT tries to use PartitionQuery by default and then execute the partitions in
+   * <p>COPY TO STDOUT tries to use PartitionQuery by default and then executes the partitions in
    * parallel. This assumes that the COPY result is large and that it will benefit from the
    * additional parallelism. For smaller result sizes, the additional roundtrip for PartitionQuery
-   * adds latency, and it is better to execute the query directly. This is also the cse for queries
+   * adds latency, and it is better to execute the query directly. This is also the case for queries
    * that are known to be non-partitionable.
    */
   public boolean isCopyPartitionQuery() {

--- a/src/main/java/com/google/cloud/spanner/pgadapter/session/SessionState.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/session/SessionState.java
@@ -401,6 +401,19 @@ public class SessionState {
   }
 
   /**
+   * Returns whether COPY TO STDOUT operations should try to use PartitionQuery.
+   *
+   * <p>COPY TO STDOUT tries to use PartitionQuery by default and then execute the partitions in
+   * parallel. This assumes that the COPY result is large and that it will benefit from the
+   * additional parallelism. For smaller result sizes, the additional roundtrip for PartitionQuery
+   * adds latency, and it is better to execute the query directly. This is also the cse for queries
+   * that are known to be non-partitionable.
+   */
+  public boolean isCopyPartitionQuery() {
+    return getBoolSetting("spanner", "copy_partition_query", true);
+  }
+
+  /**
    * Returns whether transaction statements should be ignored and all statements should be executed
    * in autocommit mode.
    */

--- a/src/main/java/com/google/cloud/spanner/pgadapter/wireprotocol/ControlMessage.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/wireprotocol/ControlMessage.java
@@ -343,6 +343,7 @@ public abstract class ControlMessage extends WireMessage {
                 mode,
                 partitionQueryResult.getBatchTransactionId(),
                 partitionQueryResult.getPartitions());
+        partitionQueryResult.cleanup();
       } else {
         hasData = describedResult.isHasMoreData();
         ResultSet resultSet = describedResult.getStatementResult().getResultSet();


### PR DESCRIPTION
Adds the setting 'spanner.copy_partition_query=true|false' to enable/disable the use of PartitionQuery for COPY TO STDOUT operations. Using PartitionQuery can improve the throughput when reading large amounts of data. However, the additional roundtrips and additional complexity of partitioning a query can be less efficient for smaller queries. This option allows the user to determine whether PGAdapter should try to use PartitionQuery or not.

The default is true.

Fixes #2224