### PR TITLE
feat: add option for logging gRPC messages

### DIFF
--- a/src/main/java/com/google/cloud/spanner/connection/ConnectionOptionsHelper.java
+++ b/src/main/java/com/google/cloud/spanner/connection/ConnectionOptionsHelper.java
@@ -17,6 +17,9 @@ package com.google.cloud.spanner.connection;
 import com.google.api.core.InternalApi;
 import com.google.auth.Credentials;
 import com.google.cloud.spanner.connection.ConnectionOptions.Builder;
+import com.google.cloud.spanner.pgadapter.logging.GrpcLogInterceptor;
+import com.google.common.collect.ImmutableList;
+import java.util.logging.Level;
 
 /** Simple helper class to get access to a package-private method in the ConnectionOptions. */
 @InternalApi
@@ -27,5 +30,23 @@ public class ConnectionOptionsHelper {
   // TODO: Remove when Builder.setCredentials(..) has been made public.
   public static Builder setCredentials(Builder connectionOptionsBuilder, Credentials credentials) {
     return connectionOptionsBuilder.setCredentials(credentials);
+  }
+
+  /** Adds a gRPC log interceptor if the log level has been set to FINEST. */
+  public static Builder maybeAddGrpcLogInterceptor(
+      Builder connectionOptionsBuilder, boolean logGrpcMessagesAsInfo) {
+    if (GrpcLogInterceptor.isGrpcFinestLogEnabled()) {
+      return connectionOptionsBuilder.setConfigurator(
+          options ->
+              options.setInterceptorProvider(
+                  () -> ImmutableList.of(new GrpcLogInterceptor(Level.FINEST))));
+    }
+    if (logGrpcMessagesAsInfo) {
+      return connectionOptionsBuilder.setConfigurator(
+          options ->
+              options.setInterceptorProvider(
+                  () -> ImmutableList.of(new GrpcLogInterceptor(Level.INFO))));
+    }
+    return connectionOptionsBuilder;
   }
 }

--- a/src/main/java/com/google/cloud/spanner/pgadapter/ConnectionHandler.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/ConnectionHandler.java
@@ -201,6 +201,9 @@ public class ConnectionHandler implements Runnable {
     OptionsMetadata options = getServer().getOptions();
     String uri = buildConnectionURL(database, options, getServer().getProperties());
     ConnectionOptions.Builder connectionOptionsBuilder = ConnectionOptions.newBuilder().setUri(uri);
+    connectionOptionsBuilder =
+        ConnectionOptionsHelper.maybeAddGrpcLogInterceptor(
+            connectionOptionsBuilder, options.isLogGrpcMessages());
     if (credentials != null) {
       connectionOptionsBuilder =
           ConnectionOptionsHelper.setCredentials(connectionOptionsBuilder, credentials);

--- a/src/main/java/com/google/cloud/spanner/pgadapter/logging/GrpcLogInterceptor.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/logging/GrpcLogInterceptor.java
@@ -1,0 +1,67 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.cloud.spanner.pgadapter.logging;
+
+import com.google.api.core.InternalApi;
+import com.google.protobuf.InvalidProtocolBufferException;
+import com.google.protobuf.MessageOrBuilder;
+import com.google.protobuf.util.JsonFormat;
+import com.google.protobuf.util.JsonFormat.Printer;
+import io.grpc.CallOptions;
+import io.grpc.Channel;
+import io.grpc.ClientCall;
+import io.grpc.ClientInterceptor;
+import io.grpc.ForwardingClientCall.SimpleForwardingClientCall;
+import io.grpc.MethodDescriptor;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/** gRPC interceptor for logging all messages that are sent by PGAdapter. */
+@InternalApi
+public class GrpcLogInterceptor implements ClientInterceptor {
+  private static final Logger logger = Logger.getLogger(GrpcLogInterceptor.class.getName());
+
+  private static final Printer PRINTER = JsonFormat.printer();
+
+  private final Level level;
+
+  public GrpcLogInterceptor(Level level) {
+    this.level = level;
+  }
+
+  public static boolean isGrpcFinestLogEnabled() {
+    return logger.isLoggable(Level.FINEST);
+  }
+
+  @Override
+  public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(
+      MethodDescriptor<ReqT, RespT> method, CallOptions callOptions, Channel next) {
+    return new SimpleForwardingClientCall<ReqT, RespT>(next.newCall(method, callOptions)) {
+      @Override
+      public void sendMessage(ReqT message) {
+        logger.log(level, () -> GrpcLogInterceptor.printMessage((MessageOrBuilder) message));
+        super.sendMessage(message);
+      }
+    };
+  }
+
+  private static String printMessage(MessageOrBuilder message) {
+    try {
+      return message.getClass().getSimpleName() + " " + PRINTER.print(message);
+    } catch (InvalidProtocolBufferException ignore) {
+      return "(unknown message)";
+    }
+  }
+}


### PR DESCRIPTION
Adds an option for logging all gRPC messages that are sent by PGAdapter to Spanner to make it easier to get insights into what exactly PGAdapter and/or an application does. This option should only be used for debugging, and is not recommended for production use, as it will produce a large amount of log lines.