### PR TITLE
fix: wait for all connections to close before stopping

### DIFF
--- a/src/main/java/com/google/cloud/spanner/pgadapter/ProxyServer.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/ProxyServer.java
@@ -438,7 +438,7 @@ public class ProxyServer extends AbstractApiService {
 
   private void createConnectionHandlersTerminatedLatch() {
     synchronized (this.handlers) {
-      this.allHandlersTerminatedLatch.set(new CountDownLatch(1));
+      this.allHandlersTerminatedLatch.set(new CountDownLatch(handlers.isEmpty() ? 0 : 1));
     }
   }
 

--- a/src/main/java/com/google/cloud/spanner/pgadapter/ProxyServer.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/ProxyServer.java
@@ -323,6 +323,7 @@ public class ProxyServer extends AbstractApiService {
   }
 
   void setShutdownMode(ShutdownMode shutdownMode) {
+    logger.log(Level.INFO, "Setting shutdown mode to {0}", shutdownMode);
     this.shutdownMode.set(shutdownMode);
   }
 
@@ -437,7 +438,7 @@ public class ProxyServer extends AbstractApiService {
 
   private void createConnectionHandlersTerminatedLatch() {
     synchronized (this.handlers) {
-      this.allHandlersTerminatedLatch.set(new CountDownLatch(this.handlers.size()));
+      this.allHandlersTerminatedLatch.set(new CountDownLatch(1));
     }
   }
 
@@ -460,7 +461,7 @@ public class ProxyServer extends AbstractApiService {
   void deregister(ConnectionHandler handler) {
     synchronized (this.handlers) {
       this.handlers.remove(handler);
-      if (this.allHandlersTerminatedLatch.get() != null) {
+      if (this.handlers.isEmpty() && this.allHandlersTerminatedLatch.get() != null) {
         this.allHandlersTerminatedLatch.get().countDown();
       }
     }

--- a/src/main/java/com/google/cloud/spanner/pgadapter/ShutdownHandler.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/ShutdownHandler.java
@@ -46,6 +46,7 @@ public class ShutdownHandler {
 
   /** Shuts down the proxy server using the given {@link ShutdownMode}. */
   public synchronized void shutdown(@Nonnull ShutdownMode shutdownMode) {
+    Preconditions.checkNotNull(shutdownMode);
     if (this.shutdownMode.get() != null) {
       if (this.shutdownMode.get() == ShutdownMode.SMART
           && (shutdownMode == ShutdownMode.FAST || shutdownMode == ShutdownMode.IMMEDIATE)) {
@@ -55,7 +56,7 @@ public class ShutdownHandler {
       }
       return;
     }
-    this.shutdownMode.set(Preconditions.checkNotNull(shutdownMode));
+    this.shutdownMode.set(shutdownMode);
     this.shutdownThread.start();
   }
 }

--- a/src/test/java/com/google/cloud/spanner/pgadapter/ShutdownModeMockServerTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/ShutdownModeMockServerTest.java
@@ -58,7 +58,9 @@ public class ShutdownModeMockServerTest extends AbstractMockServerTest {
 
   @After
   public void stopProxyServer() {
-    proxyServer.stopServer();
+    if (proxyServer.state() != State.TERMINATED) {
+      proxyServer.stopServer();
+    }
   }
 
   private String createUrl() {


### PR DESCRIPTION
When shutting down PGAdapter using SMART mode, it was theoretically possible that PGAdapter would terminate before all connections were closed. This could happen if a new connection came in at exactly the same time as that the shutdown request was sent. This could cause the shutdown latch to be created based on the number of connections at that time, while the new connection would be created and then fail directly due to connection listener being closed. This again would de-register the new (failed) connection from the server, which would trigger a count down of the latch that the SMART shutdown was waiting for.

This is now fixed by simply creating a latch with a value of 1 whenever SMART shutdown is requested and there is at least one connection open.

Fixes #2300