### PR TITLE
feat: add session variable for batch_dml_update_count

### DIFF
--- a/src/main/java/com/google/cloud/spanner/pgadapter/session/SessionState.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/session/SessionState.java
@@ -525,6 +525,26 @@ public class SessionState {
     return getIntegerSetting("spanner", "string_conversion_buffer_size", 0);
   }
 
+  /**
+   * Returns the update count that PGAdapter should return for DML statements that are executed
+   * during a DML batch. The default is 0.
+   *
+   * <p>Example:
+   *
+   * <pre>{@code
+   * begin;
+   * set local spanner.dml_batch_update_count=1;
+   * start batch dml;
+   * insert into my_table (id, value) values (1, 'one'); -- This returns update count 1
+   * insert into my_table (id, value) values (2, 'two'); -- This returns update count 1
+   * run batch; -- This actually executes the DML statements.
+   * commit;
+   * }</pre>
+   */
+  public int getDmlBatchUpdateCount() {
+    return getIntegerSetting("spanner", "dml_batch_update_count", 0);
+  }
+
   private ZoneId cachedZoneId;
 
   /** Returns the {@link ZoneId} of the current timezone for this session. */


### PR DESCRIPTION
PGAdapter by default returns update count 0 for DML statements that are executed during a DML batch. The reason for this is that the DML statement is at that moment only buffered in PGAdapter, and PGAdapter does not know what the actual update count will be once it is executed. The PostgreSQL wire-protocol expects the value to be non-negative, meaning that a negative value as a placeholder is not possible.

The default update count of 0 can cause problems with frameworks that expect the update count to be non-zero or a specific value. Hibernate for example expects each insert to insert exactly one row, and has a hard-coded check that verifies that the insert statemnent actually returned an update count of 1. This change adds a session variable `spanner.dml_batch_update_count` that determines the update count that PGAdapter returns for DML statements that are executed/buffered during a DML batch. This can be used to execute batches of DML statements in for example Hibernate.

PGAdpater still returns the actual update counts when the DML batch is executed on Spanner. This information is however not something that Hibernate and other frameworks use, as it is not part of the standard JDBC API or other standards.