### PR TITLE
feat: support SHUTDOWN SQL command

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,6 +271,17 @@ The following list contains the most frequently used startup options for PGAdapt
     Use the -x switch to turn off the localhost check. This is required when running PGAdapter in a
     Docker container, as the connections from the host machine will not be seen as a connection from
     localhost in the container.
+
+--allow_shutdown_command
+  * Enables the use of the custom SQL command `SHUTDOWN [SMART | FAST | IMMEDIATE]`. This command can
+    be used to shut down PGAdapter by just sending it a SQL statement. This option should only be enabled
+    when PGAdapter runs in a trusted environment, for example as a side-car container. The default
+    shutdown mode is `FAST`, which terminates all existing connections and then shuts down PGAdapter.
+    Use shutdown mode `SMART` to instruct PGAdapter to wait until all existing connections have been
+    terminated by the client before shutting down. See also https://www.postgresql.org/docs/current/server-shutdown.html
+    for more information about shutdown modes.
+  * Note that `SHUTDOWN [SMART | FAST | IMMEDIATE]` only works on PGAdapter. This command is not
+    supported by PostgreSQL.
 ```
 
 * See [command line arguments](docs/command_line_arguments.md) for a list of all supported arguments.

--- a/docs/command_line_arguments.md
+++ b/docs/command_line_arguments.md
@@ -70,6 +70,17 @@
     Docker container, as the connections from the host machine will not be seen as a connection from
     localhost in the container.
 
+--allow_shutdown_command
+  * Enables the use of the custom SQL command `SHUTDOWN [SMART | FAST | IMMEDIATE]`. This command can
+    be used to shut down PGAdapter by just sending it a SQL statement. This option should only be enabled
+    when PGAdapter runs in a trusted environment, for example as a side-car container. The default
+    shutdown mode is `FAST`, which terminates all existing connections and then shuts down PGAdapter.
+    Use shutdown mode `SMART` to instruct PGAdapter to wait until all existing connections have been
+    terminated by the client before shutting down. See also https://www.postgresql.org/docs/current/server-shutdown.html
+    for more information about shutdown modes.
+  * Note that `SHUTDOWN [SMART | FAST | IMMEDIATE]` only works on PGAdapter. This command is not
+    supported by PostgreSQL.
+
 -r
   * PGAdapter internally uses the core engine of the Cloud Spanner JDBC driver. This option specifies
     additional properties that will be used with that internal JDBC connection. All connection properties

--- a/src/main/java/com/google/cloud/spanner/pgadapter/ProxyServer.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/ProxyServer.java
@@ -114,6 +114,8 @@ public class ProxyServer extends AbstractApiService {
     IMMEDIATE,
   }
 
+  private final AtomicReference<ShutdownHandler> shutdownHandler = new AtomicReference<>();
+
   private final AtomicReference<ShutdownMode> shutdownMode = new AtomicReference<>();
 
   private final AtomicReference<CountDownLatch> allHandlersTerminatedLatch =
@@ -320,6 +322,13 @@ public class ProxyServer extends AbstractApiService {
     setShutdownMode(shutdownMode);
     stopAsync();
     awaitTerminated();
+  }
+
+  public synchronized ShutdownHandler getOrCreateShutdownHandler() {
+    if (this.shutdownHandler.get() == null) {
+      this.shutdownHandler.set(ShutdownHandler.createForServer(this));
+    }
+    return this.shutdownHandler.get();
   }
 
   void setShutdownMode(ShutdownMode shutdownMode) {

--- a/src/main/java/com/google/cloud/spanner/pgadapter/Server.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/Server.java
@@ -62,7 +62,7 @@ import org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement;
 public class Server {
   private static final Logger logger = Logger.getLogger(Server.class.getName());
 
-  private static ShutdownHandler shutdownHandler;
+  private static volatile ShutdownHandler shutdownHandler;
 
   /**
    * Main method for running a Spanner PostgreSQL Adapter {@link Server} as a stand-alone
@@ -78,7 +78,7 @@ public class Server {
 
       // Create a shutdown handler and register signal handlers for the signals that should
       // terminate the server.
-      Server.shutdownHandler = ShutdownHandler.createForServer(proxyServer);
+      Server.shutdownHandler = proxyServer.getOrCreateShutdownHandler();
       registerSignalHandlers();
     } catch (Exception e) {
       printError(e, System.err, System.out);

--- a/src/main/java/com/google/cloud/spanner/pgadapter/ShutdownHandler.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/ShutdownHandler.java
@@ -30,7 +30,7 @@ public class ShutdownHandler {
   private final AtomicReference<ShutdownMode> shutdownMode = new AtomicReference<>();
 
   @InternalApi
-  public static ShutdownHandler createForServer(@Nonnull ProxyServer proxyServer) {
+  static ShutdownHandler createForServer(@Nonnull ProxyServer proxyServer) {
     return new ShutdownHandler(proxyServer);
   }
 

--- a/src/main/java/com/google/cloud/spanner/pgadapter/ShutdownHandler.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/ShutdownHandler.java
@@ -14,6 +14,7 @@
 
 package com.google.cloud.spanner.pgadapter;
 
+import com.google.api.core.InternalApi;
 import com.google.cloud.spanner.pgadapter.ProxyServer.ShutdownMode;
 import com.google.common.base.Preconditions;
 import java.util.concurrent.atomic.AtomicReference;
@@ -28,7 +29,8 @@ public class ShutdownHandler {
   private final Thread shutdownThread;
   private final AtomicReference<ShutdownMode> shutdownMode = new AtomicReference<>();
 
-  static ShutdownHandler createForServer(@Nonnull ProxyServer proxyServer) {
+  @InternalApi
+  public static ShutdownHandler createForServer(@Nonnull ProxyServer proxyServer) {
     return new ShutdownHandler(proxyServer);
   }
 

--- a/src/main/java/com/google/cloud/spanner/pgadapter/metadata/OptionsMetadata.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/metadata/OptionsMetadata.java
@@ -100,6 +100,7 @@ public class OptionsMetadata {
     private String unixDomainSocketDirectory;
     private boolean autoConfigEmulator;
     private boolean logGrpcMessages;
+    private boolean allowShutdownStatement;
     private boolean debugMode;
     private String endpoint;
     private boolean usePlainText;
@@ -369,6 +370,15 @@ public class OptionsMetadata {
       return this;
     }
 
+    /**
+     * Enables the use of the SHUTDOWN [SMART | FAST | IMMEDIATE] statement to shutdown the proxy
+     * server.
+     */
+    public Builder setAllowShutdownStatement(boolean allowShutdownStatement) {
+      this.allowShutdownStatement = allowShutdownStatement;
+      return this;
+    }
+
     Builder enableDebugMode() {
       this.debugMode = true;
       return this;
@@ -485,6 +495,9 @@ public class OptionsMetadata {
       }
       if (logGrpcMessages) {
         addOption(args, OPTION_LOG_GRPC_MESSAGES);
+      }
+      if (allowShutdownStatement) {
+        addOption(args, OPTION_ALLOW_SHUTDOWN_STATEMENT);
       }
       if (debugMode) {
         addOption(args, OPTION_INTERNAL_DEBUG_MODE);
@@ -604,6 +617,7 @@ public class OptionsMetadata {
   private static final String OPTION_DEBUG_MODE = "debug";
   private static final String OPTION_LEGACY_LOGGING = "legacy_logging";
   private static final String OPTION_LOG_GRPC_MESSAGES = "log_grpc_messages";
+  private static final String OPTION_ALLOW_SHUTDOWN_STATEMENT = "allow_shutdown_statement";
 
   private final Map<String, String> environment;
   private final String osName;
@@ -635,6 +649,7 @@ public class OptionsMetadata {
   private final boolean debugMode;
   private final Duration startupTimeout;
   private final boolean logGrpcMessages;
+  private final boolean allowShutdownStatement;
 
   /**
    * Creates a new instance of {@link OptionsMetadata} from the given arguments.
@@ -728,6 +743,7 @@ public class OptionsMetadata {
     this.serverVersion = commandLine.getOptionValue(OPTION_SERVER_VERSION, DEFAULT_SERVER_VERSION);
     this.debugMode = commandLine.hasOption(OPTION_INTERNAL_DEBUG_MODE);
     this.logGrpcMessages = commandLine.hasOption(OPTION_LOG_GRPC_MESSAGES);
+    this.allowShutdownStatement = commandLine.hasOption(OPTION_ALLOW_SHUTDOWN_STATEMENT);
     this.startupTimeout = startupTimeout;
   }
 
@@ -802,6 +818,7 @@ public class OptionsMetadata {
     this.serverVersion = DEFAULT_SERVER_VERSION;
     this.debugMode = false;
     this.logGrpcMessages = false;
+    this.allowShutdownStatement = false;
     this.startupTimeout = DEFAULT_STARTUP_TIMEOUT;
   }
 
@@ -1293,6 +1310,11 @@ public class OptionsMetadata {
             + "This option should only be enabled to debug problems and/or to determine exactly which gRPC messages\n"
             + "are being sent to Spanner. Enabling this in production will cause a large number of messages to be logged.");
     options.addOption(
+        OPTION_ALLOW_SHUTDOWN_STATEMENT,
+        "allow-shutdown-statement",
+        false,
+        "Allows the proxy server to be shutdown by executing the SHUTDOWN [SMART | FAST | IMMEDIATE] statement.");
+    options.addOption(
         OPTION_INTERNAL_DEBUG_MODE,
         "internal-debug-mode",
         false,
@@ -1390,6 +1412,10 @@ public class OptionsMetadata {
 
   public boolean isLogGrpcMessages() {
     return this.logGrpcMessages;
+  }
+
+  public boolean isAllowShutdownStatement() {
+    return this.allowShutdownStatement;
   }
 
   public boolean isDebugMode() {

--- a/src/main/java/com/google/cloud/spanner/pgadapter/statements/ShutdownStatement.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/statements/ShutdownStatement.java
@@ -1,0 +1,156 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.cloud.spanner.pgadapter.statements;
+
+import com.google.cloud.spanner.Statement;
+import com.google.cloud.spanner.connection.AbstractStatementParser.ParsedStatement;
+import com.google.cloud.spanner.connection.AbstractStatementParser.StatementType;
+import com.google.cloud.spanner.connection.StatementResult;
+import com.google.cloud.spanner.pgadapter.ConnectionHandler;
+import com.google.cloud.spanner.pgadapter.ProxyServer;
+import com.google.cloud.spanner.pgadapter.ProxyServer.ShutdownMode;
+import com.google.cloud.spanner.pgadapter.ShutdownHandler;
+import com.google.cloud.spanner.pgadapter.error.PGExceptionFactory;
+import com.google.cloud.spanner.pgadapter.error.SQLState;
+import com.google.cloud.spanner.pgadapter.metadata.OptionsMetadata;
+import com.google.cloud.spanner.pgadapter.statements.BackendConnection.NoResult;
+import com.google.cloud.spanner.pgadapter.statements.ShutdownStatement.ParsedShutdownStatement.Builder;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
+import com.google.common.util.concurrent.Futures;
+import java.util.List;
+import java.util.concurrent.Future;
+
+/**
+ * <code>SHUTDOWN [FAST | SMART | IMMEDIATE]</code>
+ *
+ * <p>Shuts down the proxy server. This statement is a PGAdapter-only statement, and is not
+ * supported on normal PostgreSQL.
+ */
+public class ShutdownStatement extends IntermediatePortalStatement {
+  static final class ParsedShutdownStatement {
+    static final class Builder {
+      ShutdownMode shutdownMode = ShutdownMode.FAST;
+    }
+
+    /** The server that will be shut down. */
+    final ProxyServer server;
+
+    final ShutdownMode shutdownMode;
+
+    private ParsedShutdownStatement(Builder builder, ProxyServer server) {
+      this.server = server;
+      this.shutdownMode = builder.shutdownMode;
+    }
+  }
+
+  private final ParsedShutdownStatement parsedShutdownStatement;
+
+  private ShutdownHandler shutdownHandler;
+
+  public ShutdownStatement(
+      ConnectionHandler connectionHandler,
+      OptionsMetadata options,
+      String name,
+      ParsedStatement parsedStatement,
+      Statement originalStatement) {
+    super(
+        name,
+        new IntermediatePreparedStatement(
+            connectionHandler,
+            options,
+            name,
+            NO_PARAMETER_TYPES,
+            parsedStatement,
+            originalStatement),
+        NO_PARAMS,
+        ImmutableList.of(),
+        ImmutableList.of());
+    this.parsedShutdownStatement = parse(originalStatement.getSql(), connectionHandler.getServer());
+  }
+
+  @Override
+  public String getCommandTag() {
+    return "SHUTDOWN";
+  }
+
+  @Override
+  public StatementType getStatementType() {
+    return StatementType.UNKNOWN;
+  }
+
+  @Override
+  public void close() throws Exception {
+    super.close();
+    if (this.executed && this.shutdownHandler != null) {
+      this.shutdownHandler.shutdown(this.parsedShutdownStatement.shutdownMode);
+    }
+  }
+
+  @Override
+  public void executeAsync(BackendConnection backendConnection) {
+    if (!this.executed) {
+      this.executed = true;
+      if (options.isAllowShutdownStatement()) {
+        this.shutdownHandler = ShutdownHandler.createForServer(this.parsedShutdownStatement.server);
+        setFutureStatementResult(Futures.immediateFuture(new NoResult(getCommandTag())));
+      } else {
+        setFutureStatementResult(
+            Futures.immediateFailedFuture(
+                PGExceptionFactory.newPGException(
+                    "SHUTDOWN [SMART | FAST | IMMEDIATE] statement is not enabled for this server. Start PGAdapter with --allow_shutdown_statement to enable the use of the SHUTDOWN statement.",
+                    SQLState.FeatureNotSupported)));
+      }
+    }
+  }
+
+  @Override
+  public Future<StatementResult> describeAsync(BackendConnection backendConnection) {
+    // Return null to indicate that this SHUTDOWN statement does not return any
+    // RowDescriptionResponse.
+    return Futures.immediateFuture(null);
+  }
+
+  @Override
+  public IntermediatePortalStatement createPortal(
+      String name,
+      byte[][] parameters,
+      List<Short> parameterFormatCodes,
+      List<Short> resultFormatCodes) {
+    // SHUTDOWN does not support binding any parameters, so we just return the same statement.
+    return this;
+  }
+
+  static ParsedShutdownStatement parse(String sql, ProxyServer server) {
+    Preconditions.checkNotNull(sql);
+    Preconditions.checkNotNull(server);
+
+    SimpleParser parser = new SimpleParser(sql);
+    ParsedShutdownStatement.Builder builder = new Builder();
+    if (!parser.eatKeyword("shutdown")) {
+      throw PGExceptionFactory.newPGException(
+          "not a valid SHUTDOWN statement: " + sql, SQLState.SyntaxError);
+    }
+    if (parser.eatKeyword("fast")) {
+      builder.shutdownMode = ShutdownMode.FAST;
+    } else if (parser.eatKeyword("smart")) {
+      builder.shutdownMode = ShutdownMode.SMART;
+    } else if (parser.eatKeyword("immediate")) {
+      builder.shutdownMode = ShutdownMode.IMMEDIATE;
+    }
+    parser.throwIfHasMoreTokens();
+    return new ParsedShutdownStatement(builder, server);
+  }
+}

--- a/src/main/java/com/google/cloud/spanner/pgadapter/statements/ShutdownStatement.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/statements/ShutdownStatement.java
@@ -104,7 +104,7 @@ public class ShutdownStatement extends IntermediatePortalStatement {
     if (!this.executed) {
       this.executed = true;
       if (options.isAllowShutdownStatement()) {
-        this.shutdownHandler = ShutdownHandler.createForServer(this.parsedShutdownStatement.server);
+        this.shutdownHandler = this.parsedShutdownStatement.server.getOrCreateShutdownHandler();
         setFutureStatementResult(Futures.immediateFuture(new NoResult(getCommandTag())));
       } else {
         setFutureStatementResult(

--- a/src/main/java/com/google/cloud/spanner/pgadapter/wireprotocol/ParseMessage.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/wireprotocol/ParseMessage.java
@@ -30,6 +30,7 @@ import static com.google.cloud.spanner.pgadapter.wireprotocol.QueryMessage.SAVEP
 import static com.google.cloud.spanner.pgadapter.wireprotocol.QueryMessage.SELECT_CURRENT_SETTING;
 import static com.google.cloud.spanner.pgadapter.wireprotocol.QueryMessage.SELECT_SET_CONFIG;
 import static com.google.cloud.spanner.pgadapter.wireprotocol.QueryMessage.SHOW_DATABASE_DDL;
+import static com.google.cloud.spanner.pgadapter.wireprotocol.QueryMessage.SHUTDOWN;
 import static com.google.cloud.spanner.pgadapter.wireprotocol.QueryMessage.TRUNCATE;
 import static com.google.cloud.spanner.pgadapter.wireprotocol.QueryMessage.VACUUM;
 
@@ -58,6 +59,7 @@ import com.google.cloud.spanner.pgadapter.statements.SavepointStatement;
 import com.google.cloud.spanner.pgadapter.statements.SelectCurrentSettingStatement;
 import com.google.cloud.spanner.pgadapter.statements.SelectSetConfigStatement;
 import com.google.cloud.spanner.pgadapter.statements.ShowDatabaseDdlStatement;
+import com.google.cloud.spanner.pgadapter.statements.ShutdownStatement;
 import com.google.cloud.spanner.pgadapter.statements.TruncateStatement;
 import com.google.cloud.spanner.pgadapter.statements.VacuumStatement;
 import com.google.cloud.spanner.pgadapter.wireoutput.ParseCompleteResponse;
@@ -239,6 +241,13 @@ public class ParseMessage extends AbstractQueryProtocolMessage {
             originalStatement);
       } else if (isCommand(SELECT_SET_CONFIG, originalStatement.getSql())) {
         return new SelectSetConfigStatement(
+            connectionHandler,
+            connectionHandler.getServer().getOptions(),
+            name,
+            parsedStatement,
+            originalStatement);
+      } else if (isCommand(SHUTDOWN, originalStatement.getSql())) {
+        return new ShutdownStatement(
             connectionHandler,
             connectionHandler.getServer().getOptions(),
             name,

--- a/src/main/java/com/google/cloud/spanner/pgadapter/wireprotocol/QueryMessage.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/wireprotocol/QueryMessage.java
@@ -41,6 +41,7 @@ public class QueryMessage extends ControlMessage {
   public static final String FETCH = "FETCH";
   public static final String MOVE = "MOVE";
   public static final String CLOSE = "CLOSE";
+  public static final String SHUTDOWN = "SHUTDOWN";
   public static final ImmutableList<String> SHOW_DATABASE_DDL =
       ImmutableList.of("SHOW", "DATABASE", "DDL");
   public static final ImmutableList<String> SELECT_CURRENT_SETTING =

--- a/src/test/java/com/google/cloud/spanner/pgadapter/JdbcMockServerTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/JdbcMockServerTest.java
@@ -5596,6 +5596,19 @@ public class JdbcMockServerTest extends AbstractMockServerTest {
         exception.getMessage().contains("The server does not support GSS Encryption"));
   }
 
+  @Test
+  public void testShutdown_failsByDefault() throws SQLException {
+    try (Connection connection = DriverManager.getConnection(createUrl());
+        java.sql.Statement statement = connection.createStatement()) {
+      PSQLException exception =
+          assertThrows(PSQLException.class, () -> statement.execute("shutdown"));
+      assertEquals(
+          "ERROR: SHUTDOWN [SMART | FAST | IMMEDIATE] statement is not enabled for this server. "
+              + "Start PGAdapter with --allow_shutdown_statement to enable the use of the SHUTDOWN statement.",
+          exception.getMessage());
+    }
+  }
+
   private void verifySelect1(java.sql.Statement statement) throws SQLException {
     try (ResultSet resultSet = statement.executeQuery("SELECT 1")) {
       assertTrue(resultSet.next());

--- a/src/test/java/com/google/cloud/spanner/pgadapter/statements/ShutdownStatementTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/statements/ShutdownStatementTest.java
@@ -32,6 +32,7 @@ import com.google.cloud.spanner.connection.AbstractStatementParser.ParsedStateme
 import com.google.cloud.spanner.pgadapter.ConnectionHandler;
 import com.google.cloud.spanner.pgadapter.ProxyServer;
 import com.google.cloud.spanner.pgadapter.ProxyServer.ShutdownMode;
+import com.google.cloud.spanner.pgadapter.ShutdownHandler;
 import com.google.cloud.spanner.pgadapter.error.PGException;
 import com.google.cloud.spanner.pgadapter.error.SQLState;
 import com.google.cloud.spanner.pgadapter.metadata.ConnectionMetadata;
@@ -80,6 +81,8 @@ public class ShutdownStatementTest {
     ProxyServer server = mock(ProxyServer.class);
     when(connectionHandler.getServer()).thenReturn(server);
     when(connectionHandler.getConnectionMetadata()).thenReturn(mock(ConnectionMetadata.class));
+    ShutdownHandler shutdownHandler = mock(ShutdownHandler.class);
+    when(server.getOrCreateShutdownHandler()).thenReturn(shutdownHandler);
 
     String sql = "shutdown";
     Statement originalStatement = Statement.of(sql);
@@ -95,7 +98,7 @@ public class ShutdownStatementTest {
     // PGAdapter uses FAST shutdown mode by default.
     // We need to use a timeout, as the shutdown handler runs async. The wait time is normally much
     // less than the 1000 milliseconds that is used as the timeout value.
-    verify(server, timeout(1000L)).stopServer(ShutdownMode.FAST);
+    verify(shutdownHandler, timeout(1000L)).shutdown(ShutdownMode.FAST);
   }
 
   @Test
@@ -106,6 +109,8 @@ public class ShutdownStatementTest {
     ProxyServer server = mock(ProxyServer.class);
     when(connectionHandler.getServer()).thenReturn(server);
     when(connectionHandler.getConnectionMetadata()).thenReturn(mock(ConnectionMetadata.class));
+    ShutdownHandler shutdownHandler = mock(ShutdownHandler.class);
+    when(server.getOrCreateShutdownHandler()).thenReturn(shutdownHandler);
 
     String sql = "shutdown smart";
     Statement originalStatement = Statement.of(sql);
@@ -121,7 +126,7 @@ public class ShutdownStatementTest {
     // The shutdown mode from the SQL statement should be used.
     // We need to use a timeout, as the shutdown handler runs async. The wait time is normally much
     // less than the 1000 milliseconds that is used as the timeout value.
-    verify(server, timeout(1000L)).stopServer(ShutdownMode.SMART);
+    verify(shutdownHandler, timeout(1000L)).shutdown(ShutdownMode.SMART);
   }
 
   @Test

--- a/src/test/java/com/google/cloud/spanner/pgadapter/statements/ShutdownStatementTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/statements/ShutdownStatementTest.java
@@ -1,0 +1,158 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.cloud.spanner.pgadapter.statements;
+
+import static com.google.cloud.spanner.pgadapter.statements.ShutdownStatement.parse;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.cloud.spanner.Dialect;
+import com.google.cloud.spanner.Statement;
+import com.google.cloud.spanner.connection.AbstractStatementParser;
+import com.google.cloud.spanner.connection.AbstractStatementParser.ParsedStatement;
+import com.google.cloud.spanner.pgadapter.ConnectionHandler;
+import com.google.cloud.spanner.pgadapter.ProxyServer;
+import com.google.cloud.spanner.pgadapter.ProxyServer.ShutdownMode;
+import com.google.cloud.spanner.pgadapter.error.PGException;
+import com.google.cloud.spanner.pgadapter.error.SQLState;
+import com.google.cloud.spanner.pgadapter.metadata.ConnectionMetadata;
+import com.google.cloud.spanner.pgadapter.metadata.OptionsMetadata;
+import com.google.cloud.spanner.pgadapter.statements.IntermediateStatement.ResultNotReadyBehavior;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class ShutdownStatementTest {
+
+  @Test
+  public void testParseShutdown() {
+    ProxyServer server = mock(ProxyServer.class);
+
+    assertEquals(ShutdownMode.FAST, parse("shutdown", server).shutdownMode);
+    assertEquals(ShutdownMode.FAST, parse("Shutdown", server).shutdownMode);
+    assertEquals(ShutdownMode.FAST, parse("SHUTDOWN", server).shutdownMode);
+    assertEquals(ShutdownMode.FAST, parse("\t shutdown \n", server).shutdownMode);
+    assertEquals(ShutdownMode.IMMEDIATE, parse("shutdown immediate", server).shutdownMode);
+    assertEquals(ShutdownMode.SMART, parse("shutdown smart", server).shutdownMode);
+    assertEquals(ShutdownMode.FAST, parse("shutdown fast", server).shutdownMode);
+    assertEquals(ShutdownMode.FAST, parse("shutdown\tfast", server).shutdownMode);
+    assertEquals(ShutdownMode.FAST, parse("shutdown\nfast", server).shutdownMode);
+    assertEquals(ShutdownMode.FAST, parse("shutdown\n\t   fast", server).shutdownMode);
+
+    PGException exception;
+    exception = assertThrows(PGException.class, () -> parse("shutdown fast immediate", server));
+    assertEquals(SQLState.SyntaxError, exception.getSQLState());
+    exception = assertThrows(PGException.class, () -> parse("shutdown foo", server));
+    assertEquals(SQLState.SyntaxError, exception.getSQLState());
+    exception = assertThrows(PGException.class, () -> parse("shutdown foo fast", server));
+    assertEquals(SQLState.SyntaxError, exception.getSQLState());
+    exception = assertThrows(PGException.class, () -> parse("shutdown fast,", server));
+    assertEquals(SQLState.SyntaxError, exception.getSQLState());
+    exception = assertThrows(PGException.class, () -> parse("fast shutdown", server));
+    assertEquals(SQLState.SyntaxError, exception.getSQLState());
+  }
+
+  @Test
+  public void testShutdownStatement_usesDefaultShutdownMode() throws Exception {
+    OptionsMetadata options = mock(OptionsMetadata.class);
+    when(options.isAllowShutdownStatement()).thenReturn(true);
+    ConnectionHandler connectionHandler = mock(ConnectionHandler.class);
+    ProxyServer server = mock(ProxyServer.class);
+    when(connectionHandler.getServer()).thenReturn(server);
+    when(connectionHandler.getConnectionMetadata()).thenReturn(mock(ConnectionMetadata.class));
+
+    String sql = "shutdown";
+    Statement originalStatement = Statement.of(sql);
+    ParsedStatement parsedStatement =
+        AbstractStatementParser.getInstance(Dialect.POSTGRESQL).parse(originalStatement);
+    ShutdownStatement statement =
+        new ShutdownStatement(
+            connectionHandler, options, /* name= */ "", parsedStatement, originalStatement);
+
+    statement.executeAsync(mock(BackendConnection.class));
+    statement.close();
+
+    // PGAdapter uses FAST shutdown mode by default.
+    // We need to use a timeout, as the shutdown handler runs async. The wait time is normally much
+    // less than the 1000 milliseconds that is used as the timeout value.
+    verify(server, timeout(1000L)).stopServer(ShutdownMode.FAST);
+  }
+
+  @Test
+  public void testShutdownStatement_usesParsedShutdownMode() throws Exception {
+    OptionsMetadata options = mock(OptionsMetadata.class);
+    when(options.isAllowShutdownStatement()).thenReturn(true);
+    ConnectionHandler connectionHandler = mock(ConnectionHandler.class);
+    ProxyServer server = mock(ProxyServer.class);
+    when(connectionHandler.getServer()).thenReturn(server);
+    when(connectionHandler.getConnectionMetadata()).thenReturn(mock(ConnectionMetadata.class));
+
+    String sql = "shutdown smart";
+    Statement originalStatement = Statement.of(sql);
+    ParsedStatement parsedStatement =
+        AbstractStatementParser.getInstance(Dialect.POSTGRESQL).parse(originalStatement);
+    ShutdownStatement statement =
+        new ShutdownStatement(
+            connectionHandler, options, /* name= */ "", parsedStatement, originalStatement);
+
+    statement.executeAsync(mock(BackendConnection.class));
+    statement.close();
+
+    // The shutdown mode from the SQL statement should be used.
+    // We need to use a timeout, as the shutdown handler runs async. The wait time is normally much
+    // less than the 1000 milliseconds that is used as the timeout value.
+    verify(server, timeout(1000L)).stopServer(ShutdownMode.SMART);
+  }
+
+  @Test
+  public void testShutdownStatement_returnsErrorIfNotEnabled() throws Exception {
+    OptionsMetadata options = mock(OptionsMetadata.class);
+    when(options.isAllowShutdownStatement()).thenReturn(false);
+    ConnectionHandler connectionHandler = mock(ConnectionHandler.class);
+    ProxyServer server = mock(ProxyServer.class);
+    when(connectionHandler.getServer()).thenReturn(server);
+    when(connectionHandler.getConnectionMetadata()).thenReturn(mock(ConnectionMetadata.class));
+
+    String sql = "shutdown";
+    Statement originalStatement = Statement.of(sql);
+    ParsedStatement parsedStatement =
+        AbstractStatementParser.getInstance(Dialect.POSTGRESQL).parse(originalStatement);
+    ShutdownStatement statement =
+        new ShutdownStatement(
+            connectionHandler, options, /* name= */ "", parsedStatement, originalStatement);
+
+    // Execute the statement and then get the result.
+    statement.executeAsync(mock(BackendConnection.class));
+    statement.close();
+    // The result should be an exception.
+    statement.initFutureResult(ResultNotReadyBehavior.FAIL);
+    assertNotNull(statement.getException());
+    assertEquals(
+        "SHUTDOWN [SMART | FAST | IMMEDIATE] statement is not enabled for this server. "
+            + "Start PGAdapter with --allow_shutdown_statement to enable the use of the SHUTDOWN statement.",
+        statement.getException().getMessage());
+
+    // The server should not be shut down.
+    verify(server, never()).stopServer(any(ShutdownMode.class));
+  }
+}


### PR DESCRIPTION
Adds support for a custom SQL command to shut down the server:

```
SHUTDOWN [SMART | FAST | IMMEDIATE]
```

This command only shuts down the server if PGAdapter has been started with the command line argument `--allow_shutdown_command`. This argument should only be used when PGAdapter runs in a trusted environment, for example as a side-car container. The SQL statement can be used to shut down PGAdapter after finishing a batch job, or when the client application knows that the cluster / pod / VM / ... it is running in is shutting down.

Fixes #2040