### PR TITLE
feat: add option for end-to-end tracing

### DIFF
--- a/src/test/java/com/google/cloud/spanner/pgadapter/AbortedMockServerTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/AbortedMockServerTest.java
@@ -879,6 +879,7 @@ public class AbortedMockServerTest extends AbstractMockServerTest {
               .setCredentials(NoCredentials.getInstance())
               .setChannelConfigurator(ManagedChannelBuilder::usePlaintext)
               .setClientLibToken("pg-adapter")
+              .setEnableEndToEndTracing(true)
               .build()
               .getService();
       DatabaseClient client = spanner.getDatabaseClient(DatabaseId.of("p", "i", "d"));

--- a/src/test/java/com/google/cloud/spanner/pgadapter/AbstractMockServerTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/AbstractMockServerTest.java
@@ -16,6 +16,7 @@ package com.google.cloud.spanner.pgadapter;
 
 import static com.google.cloud.spanner.pgadapter.statements.PgCatalog.PG_TYPE_CTE_EMULATED;
 import static com.google.cloud.spanner.pgadapter.statements.PgCatalog.PgNamespace.PG_NAMESPACE_CTE;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
@@ -1280,6 +1281,13 @@ public abstract class AbstractMockServerTest {
                       assertTrue(userAgent.contains("pg-adapter"));
                       assertTrue(
                           userAgent.contains(ServiceOptions.getGoogApiClientLibName() + "/"));
+
+                      String endToEndTracing =
+                          metadata.get(
+                              Metadata.Key.of(
+                                  "x-goog-spanner-end-to-end-tracing",
+                                  Metadata.ASCII_STRING_MARSHALLER));
+                      assertEquals("true", endToEndTracing);
                     }
                     return Contexts.interceptCall(
                         Context.current(), serverCall, metadata, serverCallHandler);
@@ -1297,7 +1305,8 @@ public abstract class AbstractMockServerTest {
         .enableDebugMode()
         .setUsePlainText()
         .setEndpoint(String.format("localhost:%d", spannerServer.getPort()))
-        .setCredentials(NoCredentials.getInstance());
+        .setCredentials(NoCredentials.getInstance())
+        .setEnableEndToEndTracing(true);
     optionsConfigurator.accept(builder);
     pgServer = new ProxyServer(builder.build(), openTelemetry);
     pgServer.startServer();

--- a/src/test/java/com/google/cloud/spanner/pgadapter/JdbcMockServerTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/JdbcMockServerTest.java
@@ -3249,6 +3249,7 @@ public class JdbcMockServerTest extends AbstractMockServerTest {
                 .setCredentials(NoCredentials.getInstance())
                 .setChannelConfigurator(ManagedChannelBuilder::usePlaintext)
                 .setClientLibToken("pg-adapter")
+                .setEnableEndToEndTracing(true)
                 .build()
                 .getService();
         DatabaseClient client = spanner.getDatabaseClient(DatabaseId.of("p", "i", "d"));

--- a/src/test/java/com/google/cloud/spanner/pgadapter/ShutdownModeMockServerTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/ShutdownModeMockServerTest.java
@@ -63,7 +63,8 @@ public class ShutdownModeMockServerTest extends AbstractMockServerTest {
         .setUsePlainText()
         .setEndpoint(String.format("localhost:%d", spannerServer.getPort()))
         .setCredentials(NoCredentials.getInstance())
-        .setAllowShutdownStatement(true);
+        .setAllowShutdownStatement(true)
+        .setEnableEndToEndTracing(true);
     proxyServer = new ProxyServer(builder.build(), OpenTelemetry.noop());
     proxyServer.startServer();
   }

--- a/src/test/java/com/google/cloud/spanner/pgadapter/metadata/OptionsMetadataTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/metadata/OptionsMetadataTest.java
@@ -457,6 +457,31 @@ public class OptionsMetadataTest {
             .useVirtualGrpcTransportThreads()
             .build()
             .isUseGrpcTransportVirtualThreads());
+    assertNull(
+        OptionsMetadata.newBuilder()
+            .setCredentials(NoCredentials.getInstance())
+            .build()
+            .getPropertyMap()
+            .get("enableEndToEndTracing"));
+    assertEquals(
+        "true",
+        OptionsMetadata.newBuilder()
+            .setEnableEndToEndTracing(true)
+            .setCredentials(NoCredentials.getInstance())
+            .build()
+            .getPropertyMap()
+            .get("enableEndToEndTracing"));
+    assertFalse(OptionsMetadata.newBuilder().build().isEnableEndToEndTracing());
+    assertTrue(
+        OptionsMetadata.newBuilder()
+            .setEnableEndToEndTracing(true)
+            .build()
+            .isEnableEndToEndTracing());
+    assertFalse(
+        OptionsMetadata.newBuilder()
+            .setEnableEndToEndTracing(false)
+            .build()
+            .isEnableEndToEndTracing());
 
     assertEquals(
         DdlTransactionMode.Batch,


### PR DESCRIPTION
Add a command line argument and option for enabling end-to-end tracing when running PGAdapter. This will propagate the current trace context to the Spanner server, and collect server-side traces together with the traces that are collected by PGAdapter.

The server-side traces can only be exported to Google Cloud Trace. Make sure that you have set up an OpenTelemetry instance that exports traces to Google Cloud Trace to use this feature.