### PR TITLE
fix: empty username/password can cause NullPointerException in Liquibase

### DIFF
--- a/samples/java/liquibase/liquibase.properties
+++ b/samples/java/liquibase/liquibase.properties
@@ -8,3 +8,8 @@ changeLogFile: dbchangelog.xml
 # See https://github.com/GoogleCloudPlatform/pgadapter/blob/postgresql-dialect/docs/ddl.md for more
 # information.
 url: jdbc:postgresql://localhost:5432/liquibase-test?options=-c%20spanner.ddl_transaction_mode=AutocommitExplicitTransaction
+
+# Liquibase can throw a NullPointerException if no username/password is specified.
+# The username/password is ignored by PGAdapter, so we can set it to anything here.
+username: ignored
+password: ignored

--- a/src/test/java/com/google/cloud/spanner/pgadapter/liquibase/ITLiquibaseTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/liquibase/ITLiquibaseTest.java
@@ -80,7 +80,9 @@ public class ITLiquibaseTest {
           String.format(
               "changeLogFile: dbchangelog.xml\n"
                   + "url: jdbc:postgresql://localhost:%d/%s"
-                  + "?options=-c%%20spanner.ddl_transaction_mode=AutocommitExplicitTransaction\n",
+                  + "?options=-c%%20spanner.ddl_transaction_mode=AutocommitExplicitTransaction\n"
+                  + "username: ignored\n"
+                  + "password: ignored\n",
               testEnv.getPGAdapterPort(), database.getId().getDatabase());
       LOGGER.info("Using Liquibase properties:\n" + properties);
       writer.write(properties);


### PR DESCRIPTION
Add a default username/password for the Liquibase sample, as Liquibase can throw a NullPointerException if no username/password has been specified. The username and password is ignored by PGAdapter, so the actual value that is set is unimportant, as long as there is a value.