### PR TITLE
fix: JDBC getCatalogs did not work on the emulator

### DIFF
--- a/src/main/java/com/google/cloud/spanner/pgadapter/statements/PgCatalog.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/statements/PgCatalog.java
@@ -366,8 +366,9 @@ public class PgCatalog {
             + "         null as daticulocale,\n"
             + "         null as daticurules,\n"
             + "         null as datcollversion,\n"
-            + "         null as datacl"
-            + "  from information_schema.information_schema_catalog_name\n"
+            + "         null as datacl\n"
+            + "  /* Preferably, this should use information_schema.information_schema_catalog_name, but that does not exist on the emulator. */\n"
+            + "  from (select distinct catalog_name from information_schema.schemata) catalogs\n"
             + ")";
 
     @Override

--- a/src/test/java/com/google/cloud/spanner/pgadapter/ITJdbcMetadataTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/ITJdbcMetadataTest.java
@@ -1035,9 +1035,6 @@ public class ITJdbcMetadataTest implements IntegrationTest {
 
   @Test
   public void testDatabaseMetaDataCatalogs() throws Exception {
-    IntegrationTest.skipOnEmulator(
-        "information_schema.information_schema_catalog_name is not supported on the emulator");
-
     runForAllVersions(
         (connection, version) -> {
           try {

--- a/src/test/java/com/google/cloud/spanner/pgadapter/JdbcMockServerTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/JdbcMockServerTest.java
@@ -514,7 +514,9 @@ public class JdbcMockServerTest extends AbstractMockServerTest {
                     + "         null as daticulocale,\n"
                     + "         null as daticurules,\n"
                     + "         null as datcollversion,\n"
-                    + "         null as datacl  from information_schema.information_schema_catalog_name\n"
+                    + "         null as datacl\n"
+                    + "  /* Preferably, this should use information_schema.information_schema_catalog_name, but that does not exist on the emulator. */\n"
+                    + "  from (select distinct catalog_name from information_schema.schemata) catalogs\n"
                     + ")\n"
                     + "SELECT datname AS TABLE_CAT FROM pg_database WHERE datallowconn = true ORDER BY datname"),
             com.google.spanner.v1.ResultSet.newBuilder()


### PR DESCRIPTION
The DatabaseMetaData#getCatalogs() method did not work on the emulator, because the emulated pg_database common table expression used the table information_schema_catalog_name, which is not supported on the emulator.

This is worked around by using a different table.