### PR TITLE
fix: skip credentials check when using emulator

### DIFF
--- a/src/main/java/com/google/cloud/spanner/pgadapter/metadata/OptionsMetadata.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/metadata/OptionsMetadata.java
@@ -1041,8 +1041,7 @@ public class OptionsMetadata {
     // Note that Credentials here is the credentials file, not the actual credentials
     String url = String.format("%s%s;userAgent=%s", endpoint, databaseName, DEFAULT_USER_AGENT);
 
-    if (!shouldAuthenticate()
-        && Strings.isNullOrEmpty(environment.get(SPANNER_EMULATOR_HOST_ENV_VAR))) {
+    if (!shouldAuthenticate() && !usesEmulator()) {
       String credentials = buildCredentialsFile();
       if (!Strings.isNullOrEmpty(credentials)) {
         url = String.format("%s;credentials=%s", url, credentials);
@@ -1053,6 +1052,16 @@ public class OptionsMetadata {
     }
 
     return url;
+  }
+
+  private boolean isAutoConfigEmulator() {
+    return getPropertyMap() != null
+        && Boolean.parseBoolean(getPropertyMap().getOrDefault("autoConfigEmulator", "false"));
+  }
+
+  private boolean usesEmulator() {
+    return !Strings.isNullOrEmpty(environment.get(SPANNER_EMULATOR_HOST_ENV_VAR))
+        || isAutoConfigEmulator();
   }
 
   /** Returns the fully qualified database name based on the given database id or name. */


### PR DESCRIPTION
PGAdapter would check whether a credentials file or other credentials had been specified, and fail if not, when it had been manually configured to run against the emulator. This change removes that check in such a case, as we don't need any credentials for the emulator.