### PR TITLE
chore: do not use virtual threads for the backend connection

### DIFF
--- a/src/main/java/com/google/cloud/spanner/pgadapter/metadata/OptionsMetadata.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/metadata/OptionsMetadata.java
@@ -483,7 +483,6 @@ public class OptionsMetadata {
           || numChannels != null
           || databaseRole != null
           || autoConfigEmulator
-          || useVirtualThreads
           || useVirtualGrpcTransportThreads
           || enableEndToEndTracing) {
         StringBuilder jdbcOptionBuilder = new StringBuilder();
@@ -498,11 +497,6 @@ public class OptionsMetadata {
         }
         if (autoConfigEmulator) {
           jdbcOptionBuilder.append("autoConfigEmulator=true;");
-        }
-        if (useVirtualThreads) {
-          jdbcOptionBuilder
-              .append(ConnectionOptions.USE_VIRTUAL_THREADS_PROPERTY_NAME)
-              .append("=true;");
         }
         if (useVirtualGrpcTransportThreads) {
           jdbcOptionBuilder

--- a/src/test/java/com/google/cloud/spanner/pgadapter/metadata/OptionsMetadataTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/metadata/OptionsMetadataTest.java
@@ -429,8 +429,9 @@ public class OptionsMetadataTest {
             .build()
             .getPropertyMap()
             .get("useVirtualThreads"));
-    assertEquals(
-        "true",
+    // Virtual threads should not be carried over to the underlying connection. Instead, this
+    // option only determines the type of thread that is used for a connection handler.
+    assertNull(
         OptionsMetadata.newBuilder()
             .useVirtualThreads()
             .setCredentials(NoCredentials.getInstance())


### PR DESCRIPTION
When virtual threads have been enabled, we should only use them for the ConnectionHandler, and not for the backend Spanner connection. Instead, the backend connection should just use a DirectExecutor that re-uses the (virtual) thread from the ConnectionHandler.