### PR TITLE
fix: update secret project to new release kokoro release project

### DIFF
--- a/.kokoro/populate-secrets.sh
+++ b/.kokoro/populate-secrets.sh
@@ -32,7 +32,7 @@ do
     --volume=${KOKORO_GFILE_DIR}:${KOKORO_GFILE_DIR} \
     gcr.io/google.com/cloudsdktool/cloud-sdk \
     secrets versions access latest \
-    --project cloud-devrel-kokoro-resources \
+    --project cloud-sdk-release-custom-pool \
     --secret ${key} > \
     "${SECRET_LOCATION}/${key}"
   if [[ $? == 0 ]]; then


### PR DESCRIPTION
This was missed during the initial migration of all release jobs to new GCP project