### PR TITLE
chore: skip timezone for timestamp tests

### DIFF
--- a/src/test/java/com/google/cloud/spanner/pgadapter/ITPsqlTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/ITPsqlTest.java
@@ -936,6 +936,7 @@ public class ITPsqlTest implements IntegrationTest {
       ImmutableSet.of(
           ZoneId.of("Atlantic/Azores"),
           // Mexico abolished DST in 2022, but not all databases contain this information.
+          ZoneId.of("America/Cancun"),
           ZoneId.of("America/Chihuahua"),
           // Jordan abolished DST in 2022, but not all databases contain this information.
           ZoneId.of("Asia/Amman"),


### PR DESCRIPTION
Fixes #2682 