### PR TITLE
chore: use existing transaction for analyze in batch

### DIFF
--- a/src/main/java/com/google/cloud/spanner/pgadapter/statements/BackendConnection.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/statements/BackendConnection.java
@@ -415,7 +415,7 @@ public class BackendConnection {
           // We handle one very specific use case here to prevent unnecessary problems: If the user
           // has started a DML batch and is then analyzing an update statement (probably a prepared
           // statement), then we use a separate transaction for that.
-          if (spannerConnection.isDmlBatchActive()) {
+          if (spannerConnection.isDmlBatchActive() && !spannerConnection.isInTransaction()) {
             final Statement statementToAnalyze = statement;
             resultSet =
                 spannerConnection

--- a/src/test/php/pdo/pdo_test.php
+++ b/src/test/php/pdo/pdo_test.php
@@ -286,6 +286,23 @@ function batch_dml($dsn): void
     $connection = null;
 }
 
+function batch_dml_in_transaction($dsn): void
+{
+    $connection = new PDO($dsn);
+    $connection->beginTransaction();
+    $connection->exec("START BATCH DML");
+    $statement = $connection->prepare("insert into my_table (id, value) values (:id, :value)");
+    $statement->execute(["id" => 1, "value" => "One"]);
+    $statement->execute(["id" => 2, "value" => "Two"]);
+    $connection->exec("RUN BATCH");
+    $connection->commit();
+
+    print("Inserted two rows\n");
+
+    $statement = null;
+    $connection = null;
+}
+
 function batch_ddl($dsn): void
 {
     $connection = new PDO($dsn);


### PR DESCRIPTION
DML batches in a transaction are allowed to execute analyzeUpdate. PGAdapter should use this transaction instead of creating a separate transaction in such cases to reduce the number of round-trips.