### PR TITLE
test: require logger for Ruby ActiveRecord

### DIFF
--- a/samples/ruby/activerecord/config/environment.rb
+++ b/samples/ruby/activerecord/config/environment.rb
@@ -6,6 +6,7 @@
 # license that can be found in the LICENSE file or at
 # https://opensource.org/licenses/MIT.
 
+require "logger" # https://github.com/rails/rails/issues/54260
 require 'active_record'
 require 'bundler'
 

--- a/src/test/ruby/activerecord/application.rb
+++ b/src/test/ruby/activerecord/application.rb
@@ -6,6 +6,7 @@
 # license that can be found in the LICENSE file or at
 # https://opensource.org/licenses/MIT.
 
+require "logger" # https://github.com/rails/rails/issues/54260
 require 'active_record'
 require 'io/console'
 require_relative 'config/environment'

--- a/src/test/ruby/activerecord/config/environment.rb
+++ b/src/test/ruby/activerecord/config/environment.rb
@@ -6,6 +6,7 @@
 # license that can be found in the LICENSE file or at
 # https://opensource.org/licenses/MIT.
 
+require "logger" # https://github.com/rails/rails/issues/54260
 require 'active_record'
 require 'bundler'
 


### PR DESCRIPTION
Many existing Ruby ActiveRecord applications have been broken by https://github.com/rails/rails/issues/54260. This also includes the tests and samples for PGAdapter. This workaround makes sure that Logger is required before running the test/sample.

Fixes #2763 