### PR TITLE
chore: rename helper classes to prevent clashes

### DIFF
--- a/src/main/java/com/google/cloud/spanner/connection/PGAdapterConnectionOptionsHelper.java
+++ b/src/main/java/com/google/cloud/spanner/connection/PGAdapterConnectionOptionsHelper.java
@@ -24,9 +24,9 @@ import java.util.logging.Level;
 
 /** Simple helper class to get access to a package-private method in the ConnectionOptions. */
 @InternalApi
-public class ConnectionOptionsHelper {
+public class PGAdapterConnectionOptionsHelper {
   /** Private constructor to prevent instantiation. */
-  private ConnectionOptionsHelper() {}
+  private PGAdapterConnectionOptionsHelper() {}
 
   // TODO: Remove when Builder.setCredentials(..) has been made public.
   public static Builder setCredentials(Builder connectionOptionsBuilder, Credentials credentials) {

--- a/src/main/java/com/google/cloud/spanner/connection/PGAdapterResultSetHelper.java
+++ b/src/main/java/com/google/cloud/spanner/connection/PGAdapterResultSetHelper.java
@@ -18,10 +18,10 @@ import com.google.api.core.InternalApi;
 import com.google.cloud.spanner.ResultSet;
 
 @InternalApi
-public class ResultSetHelper {
+public class PGAdapterResultSetHelper {
 
   /** Private constructor to prevent instantiation. */
-  private ResultSetHelper() {}
+  private PGAdapterResultSetHelper() {}
 
   /**
    * Converts the given {@link ResultSet} to a {@link DirectExecuteResultSet}. A {@link

--- a/src/main/java/com/google/cloud/spanner/pgadapter/ConnectionHandler.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/ConnectionHandler.java
@@ -38,7 +38,7 @@ import com.google.cloud.spanner.connection.AbstractStatementParser.ParsedStateme
 import com.google.cloud.spanner.connection.AbstractStatementParser.StatementType;
 import com.google.cloud.spanner.connection.Connection;
 import com.google.cloud.spanner.connection.ConnectionOptions;
-import com.google.cloud.spanner.connection.ConnectionOptionsHelper;
+import com.google.cloud.spanner.connection.PGAdapterConnectionOptionsHelper;
 import com.google.cloud.spanner.connection.SavepointSupport;
 import com.google.cloud.spanner.pgadapter.error.PGException;
 import com.google.cloud.spanner.pgadapter.error.PGExceptionFactory;
@@ -203,15 +203,16 @@ public class ConnectionHandler implements Runnable {
     String uri = buildConnectionURL(database, options, getServer().getProperties());
     ConnectionOptions.Builder connectionOptionsBuilder = ConnectionOptions.newBuilder().setUri(uri);
     connectionOptionsBuilder =
-        ConnectionOptionsHelper.maybeAddGrpcLogInterceptor(
+        PGAdapterConnectionOptionsHelper.maybeAddGrpcLogInterceptor(
             connectionOptionsBuilder, options.isLogGrpcMessages());
-    connectionOptionsBuilder = ConnectionOptionsHelper.useDirectExecutor(connectionOptionsBuilder);
+    connectionOptionsBuilder =
+        PGAdapterConnectionOptionsHelper.useDirectExecutor(connectionOptionsBuilder);
     if (credentials != null) {
       connectionOptionsBuilder =
-          ConnectionOptionsHelper.setCredentials(connectionOptionsBuilder, credentials);
+          PGAdapterConnectionOptionsHelper.setCredentials(connectionOptionsBuilder, credentials);
     } else if (options.getCredentials() != null) {
       connectionOptionsBuilder =
-          ConnectionOptionsHelper.setCredentials(
+          PGAdapterConnectionOptionsHelper.setCredentials(
               connectionOptionsBuilder, options.getCredentials());
     }
     SessionPoolOptions sessionPoolOptions =

--- a/src/main/java/com/google/cloud/spanner/pgadapter/statements/BackendConnection.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/statements/BackendConnection.java
@@ -48,7 +48,7 @@ import com.google.cloud.spanner.connection.AbstractStatementParser.ParsedStateme
 import com.google.cloud.spanner.connection.AbstractStatementParser.StatementType;
 import com.google.cloud.spanner.connection.AutocommitDmlMode;
 import com.google.cloud.spanner.connection.Connection;
-import com.google.cloud.spanner.connection.ResultSetHelper;
+import com.google.cloud.spanner.connection.PGAdapterResultSetHelper;
 import com.google.cloud.spanner.connection.StatementResult;
 import com.google.cloud.spanner.connection.StatementResult.ClientSideStatementType;
 import com.google.cloud.spanner.connection.TransactionRetryListener;
@@ -374,7 +374,7 @@ public class BackendConnection {
           try {
             result.set(
                 new QueryResult(
-                    ResultSetHelper.toDirectExecuteResultSet(
+                    PGAdapterResultSetHelper.toDirectExecuteResultSet(
                         spannerConnection
                             .getDatabaseClient()
                             .singleUse()

--- a/src/test/java/com/google/cloud/spanner/connection/ConnectionOptionsHelperTest.java
+++ b/src/test/java/com/google/cloud/spanner/connection/ConnectionOptionsHelperTest.java
@@ -39,7 +39,7 @@ public class ConnectionOptionsHelperTest {
     ConnectionOptions.Builder builder = mock(ConnectionOptions.Builder.class);
     GoogleCredentials credentials = mock(GoogleCredentials.class);
 
-    ConnectionOptionsHelper.setCredentials(builder, credentials);
+    PGAdapterConnectionOptionsHelper.setCredentials(builder, credentials);
 
     verify(builder).setCredentials(credentials);
   }

--- a/src/test/java/com/google/cloud/spanner/connection/ResultSetHelperTest.java
+++ b/src/test/java/com/google/cloud/spanner/connection/ResultSetHelperTest.java
@@ -14,7 +14,7 @@
 
 package com.google.cloud.spanner.connection;
 
-import static com.google.cloud.spanner.connection.ResultSetHelper.toDirectExecuteResultSet;
+import static com.google.cloud.spanner.connection.PGAdapterResultSetHelper.toDirectExecuteResultSet;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;


### PR DESCRIPTION
Rename the helper classes that are added to the .connection package to prevent potential name clashes in other tools that use the same trick.