### PR TITLE
fix: replace current_database() = '..' clauses

### DIFF
--- a/src/main/java/com/google/cloud/spanner/pgadapter/statements/JdbcMetadataStatementHelper.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/statements/JdbcMetadataStatementHelper.java
@@ -251,6 +251,7 @@ class JdbcMetadataStatementHelper {
     }
     replacedSql += " WHERE TRUE " + sql.substring(startIndex);
     return replacedSql
+        .replaceFirst(" AND current_database\\(\\) = '.*?'", "")
         .replace(" AND n.nspname LIKE ", " AND TABLE_SCHEMA LIKE ")
         .replace(" AND c.relname LIKE ", " AND TABLE_NAME LIKE ")
         .replace(


### PR DESCRIPTION
Replace `current_database() = '...' clauses in JDBC system queries. This is generated by (among others) Liquibase.

Fixes the build error in https://github.com/GoogleCloudPlatform/pgadapter/pull/2752