### PR TITLE
fix: remove 'for update of' clauses

### DIFF
--- a/src/main/java/com/google/cloud/spanner/pgadapter/statements/BackendConnection.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/statements/BackendConnection.java
@@ -364,7 +364,11 @@ public class BackendConnection {
           //       feature is able to detect FOR UPDATE clauses as a write.
           if (sessionState.isReplaceForUpdateClause()
               && !spannerConnection.isDelayTransactionStartUntilFirstWrite()) {
-            updatedStatement = replaceForUpdate(updatedStatement, sqlLowerCase);
+            updatedStatement =
+                replaceForUpdate(updatedStatement, sqlLowerCase, /*replaceWithHint=*/ true);
+          } else {
+            updatedStatement =
+                replaceForUpdate(updatedStatement, sqlLowerCase, /*replaceWithHint=*/ false);
           }
           updatedStatement = bindStatement(updatedStatement, sqlLowerCase);
           result.set(analyzeOrExecute(updatedStatement));

--- a/src/main/java/com/google/cloud/spanner/pgadapter/statements/SimpleParser.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/statements/SimpleParser.java
@@ -226,8 +226,9 @@ public class SimpleParser {
   }
 
   /**
-   * Replaces any 'for update' clause with a LOCK_SCANNED_RANGES=exclusive hint. This method only
-   * replaces the 'for update' clause if it fulfills these criteria:
+   * Replaces any 'for update' clause with a LOCK_SCANNED_RANGES=exclusive hint and/or removes any
+   * 'of table1[, table2[,...]]' clauses. This method only replaces the 'for update' clause if it
+   * fulfills these criteria:
    *
    * <ol>
    *   <li>The 'for update' clause is on the outermost expression
@@ -237,7 +238,8 @@ public class SimpleParser {
    *
    * Any 'OF table_name[, ...]' clauses in the expression are ignored.
    */
-  static Statement replaceForUpdate(Statement statement, String lowerCaseSql) {
+  static Statement replaceForUpdate(
+      Statement statement, String lowerCaseSql, boolean replaceWithHint) {
     // If there is no 'for' clause, then we know that we don't have to analyze any further.
     if (!lowerCaseSql.contains("for")) {
       return statement;
@@ -249,6 +251,9 @@ public class SimpleParser {
     }
     int startPos = parser.pos;
     if (parser.eatKeyword("for") && parser.eatKeyword("update")) {
+      if (!replaceWithHint) {
+        startPos = parser.pos;
+      }
       int endPos = parser.pos;
       // Skip 'of table1[, table2[, ...]] clauses
       if (parser.eatKeyword("of")) {
@@ -257,6 +262,9 @@ public class SimpleParser {
           return statement;
         }
         endPos = parser.pos;
+      } else if (!replaceWithHint) {
+        // Stop here if the statement does not contain an 'of table' clause.
+        return statement;
       }
       // 'nowait' and 'skip locked' clauses are not supported.
       if (parser.eatKeyword("nowait") || parser.eatKeyword("skip")) {
@@ -266,11 +274,16 @@ public class SimpleParser {
         return statement;
       }
       // This is a simple 'for update' clause. Replace it with a 'LOCK_SCANNED_RANGES=exclusive'
-      // hint.
-      return Statement.of(
-          "/*@ LOCK_SCANNED_RANGES=exclusive */"
-              + statement.getSql().substring(0, startPos)
-              + statement.getSql().substring(endPos));
+      // hint and/or remove the 'of table' clause.
+      if (replaceWithHint) {
+        return Statement.of(
+            "/*@ LOCK_SCANNED_RANGES=exclusive */"
+                + statement.getSql().substring(0, startPos)
+                + statement.getSql().substring(endPos));
+      } else {
+        return Statement.of(
+            statement.getSql().substring(0, startPos) + statement.getSql().substring(endPos));
+      }
     }
     return statement;
   }

--- a/src/test/java/com/google/cloud/spanner/pgadapter/statements/SelectForUpdateTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/statements/SelectForUpdateTest.java
@@ -67,14 +67,35 @@ public class SelectForUpdateTest {
             "select col1 from my_table for update of my_table, /*comment*/ my_other_table"));
   }
 
+  @Test
+  public void testReplaceForUpdateOf() {
+    assertEquals(
+        Statement.of("select col1 from foo for update"),
+        internalReplaceForUpdate("select col1 from foo for update", false));
+    assertEquals(
+        Statement.of("select col1 from foo for update"),
+        internalReplaceForUpdate("select col1 from foo for update of foo", false));
+    assertEquals(
+        Statement.of("select col1 from foo for update"),
+        internalReplaceForUpdate("select col1 from foo for update of foo, bar", false));
+    assertEquals(
+        Statement.of("select col1 from foo for update"),
+        internalReplaceForUpdate("select col1 from foo for update of foo, bar, \"baz\"", false));
+  }
+
   private void assertSameAfterRemoveForUpdate(String sql) {
     Statement statement = Statement.of(sql);
     assertSame(
-        statement, replaceForUpdate(statement, statement.getSql().toLowerCase(Locale.ENGLISH)));
+        statement,
+        replaceForUpdate(statement, statement.getSql().toLowerCase(Locale.ENGLISH), true));
   }
 
   private Statement internalReplaceForUpdate(String sql) {
-    return replaceForUpdate(Statement.of(sql), sql.toLowerCase(Locale.ENGLISH));
+    return internalReplaceForUpdate(sql, true);
+  }
+
+  private Statement internalReplaceForUpdate(String sql, boolean replaceWithHint) {
+    return replaceForUpdate(Statement.of(sql), sql.toLowerCase(Locale.ENGLISH), replaceWithHint);
   }
 
   @Test


### PR DESCRIPTION
Spanner now supports FOR UPDATE clauses in SELECT statements. However, Spanner does not support FOR UPDATE OF tbl statements. This change re-introduces automatic replacement of those statements with a simple FOR UPDATE clause.

This fixes the build error in https://github.com/GoogleCloudPlatform/pgadapter/actions/runs/13567564731/job/37924031938?pr=2947 (once the emulator supports `for update` clauses).