### PR TITLE
fix: replace FOR UPDATE clauses on the emulator

### DIFF
--- a/src/main/java/com/google/cloud/spanner/pgadapter/ConnectionHandler.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/ConnectionHandler.java
@@ -273,6 +273,13 @@ public class ConnectionHandler implements Runnable {
     this.spannerConnection = spannerConnection;
     this.databaseId = connectionOptions.getDatabaseId();
     this.extendedQueryProtocolHandler = new ExtendedQueryProtocolHandler(this);
+    // TODO: Remove when the emulator supports FOR UPDATE clauses.
+    if (Boolean.parseBoolean(server.getProperties().getProperty("autoConfigEmulator", "false"))) {
+      this.extendedQueryProtocolHandler
+          .getBackendConnection()
+          .getSessionState()
+          .setConnectionStartupValue("spanner", "replace_for_update", "true");
+    }
   }
 
   @VisibleForTesting


### PR DESCRIPTION
Spanner supports FOR UPDATE clauses, but the emulator does not yet support this. PGAdapter should therefore by default replace FOR UPDATE clauses with a hint when it is connected to the emulator.