### PR TITLE
docs: use standard startsWith query for JPA sample

### DIFF
--- a/samples/java/spring-data-jpa/src/main/java/com/google/cloud/spanner/pgadapter/sample/repository/SingerRepository.java
+++ b/samples/java/spring-data-jpa/src/main/java/com/google/cloud/spanner/pgadapter/sample/repository/SingerRepository.java
@@ -23,6 +23,5 @@ import org.springframework.data.repository.query.Param;
 public interface SingerRepository extends JpaRepository<Singer, String> {
 
   /** Get all singers that have a last name that starts with the given prefix. */
-  @Query("SELECT s FROM Singer s WHERE cast(starts_with(s.lastName, :lastName) as boolean)")
   List<Singer> searchByLastNameStartsWith(@Param("lastName") String lastName);
 }


### PR DESCRIPTION
Update the Spring Data JPA sample so it uses the standard startsWith implementation. This implementation uses a LIKE clause with a default '\' ESCAPE clause. The latter is automatically removed by PGAdapter.

Updates #1386