### PR TITLE
docs: remove composite primary key dependency from Ruby sample

### DIFF
--- a/samples/ruby/activerecord/db/migrate/01_create_tables.rb
+++ b/samples/ruby/activerecord/db/migrate/01_create_tables.rb
@@ -41,7 +41,6 @@ class CreateTables < ActiveRecord::Migration[7.0]
     # The ActiveRecord PostgreSQL provider does not know how to create an interleaved table.
     # These tables must therefore be created using a hand-written SQL script.
     # Note that interleaved tables require you to use a composite primary key.
-    # This also requires "gem 'composite_primary_keys', '~> 14'" to be part of your project.
     execute "create table tracks (
         album_id     varchar(36) not null,
         track_number bigint not null,


### PR DESCRIPTION
Ruby ActiveRecord 8.0 supports primary keys natively, and there is no need for a third-party dependency for this anymore. Remove this from the documentation.