### PR TITLE
fix: drop table if exists .. cascade did not work

### DIFF
--- a/src/main/java/com/google/cloud/spanner/pgadapter/statements/DdlExecutor.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/statements/DdlExecutor.java
@@ -202,8 +202,8 @@ class DdlExecutor {
     if (!parser.eatKeyword("drop")) {
       return defaultResult;
     }
-    parser.eatKeyword("if", "exists");
     if (parser.eatKeyword("table")) {
+      parser.eatKeyword("if", "exists");
       TableOrIndexName tableName = parser.readTableOrIndexName();
       if (tableName == null) {
         return defaultResult;
@@ -228,6 +228,7 @@ class DdlExecutor {
       builder.add(cascade ? Statement.of(sqlWithoutCascade) : statement);
       return builder.build();
     } else if (parser.eatKeyword("schema")) {
+      parser.eatKeyword("if", "exists");
       TableOrIndexName schemaName = parser.readTableOrIndexName();
       if (schemaName == null || schemaName.schema != null) {
         return defaultResult;

--- a/src/test/java/com/google/cloud/spanner/pgadapter/ITDdlTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/ITDdlTest.java
@@ -101,7 +101,28 @@ public class ITDdlTest implements IntegrationTest {
         connection.createStatement().execute("set spanner.support_drop_cascade to on");
         // Dropping the table should now work.
         assertEquals(0, connection.createStatement().executeUpdate(dropStatement));
+        // Verify that the table was really dropped.
+        PSQLException psqlException =
+            assertThrows(
+                PSQLException.class,
+                () ->
+                    connection
+                        .createStatement()
+                        .execute("update " + tableName + " set value='' where true"));
+        assertEquals(SQLState.UndefinedTable.toString(), psqlException.getSQLState());
       }
+      // Dropping a table that does not exist with an 'if exists' clause also succeeds.
+      connection.createStatement().execute("set spanner.support_drop_cascade to on");
+      assertEquals(
+          0,
+          connection
+              .createStatement()
+              .executeUpdate("drop table if exists this_table_does_not_exist"));
+      assertEquals(
+          0,
+          connection
+              .createStatement()
+              .executeUpdate("drop table if exists this_table_does_not_exist cascade"));
     }
   }
 

--- a/src/test/java/com/google/cloud/spanner/pgadapter/ITDdlTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/ITDdlTest.java
@@ -72,25 +72,36 @@ public class ITDdlTest implements IntegrationTest {
     try (Connection connection = DriverManager.getConnection(getConnectionUrl())) {
       // First create a table with a secondary index.
       try (Statement statement = connection.createStatement()) {
-        statement.addBatch("create table test (id bigint primary key, value varchar)");
-        statement.addBatch("create index idx_text on test (value)");
-        assertArrayEquals(new int[] {0, 0}, statement.executeBatch());
+        statement.addBatch("create table test1 (id bigint primary key, value varchar)");
+        statement.addBatch("create table test2 (id bigint primary key, value varchar)");
+        statement.addBatch("create index idx_text1 on test1 (value)");
+        statement.addBatch("create index idx_text2 on test2 (value)");
+        assertArrayEquals(new int[] {0, 0, 0, 0}, statement.executeBatch());
       }
 
-      // Try to drop the table with an index. This will fail.
-      PSQLException exception =
-          assertThrows(
-              PSQLException.class, () -> connection.createStatement().execute("drop table test"));
-      assertEquals(SQLState.FeatureNotSupported.toString(), exception.getSQLState());
-      assertNotNull(exception.getServerErrorMessage());
-      assertEquals(
-          "Execute 'set spanner.support_drop_cascade=true' to enable dropping tables with indices",
-          exception.getServerErrorMessage().getHint());
+      for (int index = 1; index <= 2; index++) {
+        connection.createStatement().execute("set spanner.support_drop_cascade to off");
 
-      // Now enable drop_cascade.
-      connection.createStatement().execute("set spanner.support_drop_cascade to on");
-      // Dropping the table should now work.
-      assertEquals(0, connection.createStatement().executeUpdate("drop table test"));
+        String tableName = "test" + index;
+        boolean useIfExists = index == 2;
+        String dropStatement = "drop table " + (useIfExists ? "if exists " : "") + tableName;
+        // Try to drop the table with an index. This will fail.
+        PSQLException exception =
+            assertThrows(
+                dropStatement,
+                PSQLException.class,
+                () -> connection.createStatement().execute(dropStatement));
+        assertEquals(SQLState.FeatureNotSupported.toString(), exception.getSQLState());
+        assertNotNull(exception.getServerErrorMessage());
+        assertEquals(
+            "Execute 'set spanner.support_drop_cascade=true' to enable dropping tables with indices",
+            exception.getServerErrorMessage().getHint());
+
+        // Now enable drop_cascade.
+        connection.createStatement().execute("set spanner.support_drop_cascade to on");
+        // Dropping the table should now work.
+        assertEquals(0, connection.createStatement().executeUpdate(dropStatement));
+      }
     }
   }
 

--- a/src/test/java/com/google/cloud/spanner/pgadapter/statements/DdlExecutorTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/statements/DdlExecutorTest.java
@@ -177,9 +177,20 @@ public class DdlExecutorTest {
     assertEquals(
         ImmutableList.of(
             Statement.of("drop dependent indexes of foo"),
+            Statement.of("drop table if exists foo")),
+        ddlExecutor.getDependentStatements(Statement.of("drop table if exists foo")));
+    assertEquals(
+        ImmutableList.of(
+            Statement.of("drop dependent indexes of foo"),
             Statement.of("drop dependent foreign keys of foo"),
             Statement.of("drop table foo")),
         ddlExecutor.getDependentStatements(Statement.of("drop table foo cascade")));
+    assertEquals(
+        ImmutableList.of(
+            Statement.of("drop dependent indexes of foo"),
+            Statement.of("drop dependent foreign keys of foo"),
+            Statement.of("drop table if exists foo")),
+        ddlExecutor.getDependentStatements(Statement.of("drop table if exists foo cascade")));
     assertEquals(
         ImmutableList.of(
             Statement.of("drop all indexes in schema foo"),
@@ -187,6 +198,13 @@ public class DdlExecutorTest {
             Statement.of("drop all views in schema foo"),
             Statement.of("drop all tables in schema foo")),
         ddlExecutor.getDependentStatements(Statement.of("drop schema foo cascade")));
+    assertEquals(
+        ImmutableList.of(
+            Statement.of("drop all indexes in schema foo"),
+            Statement.of("drop all foreign keys in schema foo"),
+            Statement.of("drop all views in schema foo"),
+            Statement.of("drop all tables in schema foo")),
+        ddlExecutor.getDependentStatements(Statement.of("drop schema if exists foo cascade")));
   }
 
   private void assertGetDependentStatementsReturnsSame(


### PR DESCRIPTION
Dropping a table with an IF EXISTS clause did not work when support_drop_cascade had been enabled.