### PR TITLE
chore: remove remove_for_update on emulator

### DIFF
--- a/src/main/java/com/google/cloud/spanner/pgadapter/ConnectionHandler.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/ConnectionHandler.java
@@ -274,13 +274,6 @@ public class ConnectionHandler implements Runnable {
     this.spannerConnection = spannerConnection;
     this.databaseId = connectionOptions.getDatabaseId();
     this.extendedQueryProtocolHandler = new ExtendedQueryProtocolHandler(this);
-    // TODO: Remove when the emulator supports FOR UPDATE clauses.
-    if (Boolean.parseBoolean(server.getProperties().getProperty("autoConfigEmulator", "false"))) {
-      this.extendedQueryProtocolHandler
-          .getBackendConnection()
-          .getSessionState()
-          .setConnectionStartupValue("spanner", "replace_for_update", "true");
-    }
   }
 
   @VisibleForTesting


### PR DESCRIPTION
Remove the default to remove for update clauses on the emulator, as the emulator now also supports FOR UPDATE clauses.