### PR TITLE
fix: translate _prisma_migrations to prisma_migrations

### DIFF
--- a/src/main/java/com/google/cloud/spanner/pgadapter/utils/ClientAutoDetector.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/utils/ClientAutoDetector.java
@@ -549,6 +549,15 @@ public class ClientAutoDetector {
             RegexQueryPartReplacer.replace(Pattern.compile("ON\\s+DELETE\\s+RESTRICT"), ""),
             RegexQueryPartReplacer.replace(Pattern.compile("ON\\s+UPDATE\\s+CASCADE"), ""));
       }
+
+      @Override
+      public ImmutableList<QueryPartReplacer> getQueryPartReplacements() {
+        // This ensures that Prisma sees the 'prisma_migrations" table as '_prisma_migrations'.
+        return ImmutableList.of(
+            RegexQueryPartReplacer.replace(
+                Pattern.compile("SELECT\\s+" + "tbl\\.relname\\s+AS\\s+table_name"),
+                "SELECT replace(tbl.relname, 'prisma_migrations', '_prisma_migrations') AS table_name"));
+      }
     },
     GOLANG_MIGRATE {
       @Override

--- a/src/test/java/com/google/cloud/spanner/pgadapter/nodejs/PrismaMockServerTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/nodejs/PrismaMockServerTest.java
@@ -29,6 +29,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.protobuf.ListValue;
 import com.google.protobuf.NullValue;
 import com.google.protobuf.Value;
+import com.google.spanner.admin.database.v1.UpdateDatabaseDdlRequest;
 import com.google.spanner.v1.BeginTransactionRequest;
 import com.google.spanner.v1.CommitRequest;
 import com.google.spanner.v1.ExecuteSqlRequest;
@@ -1724,6 +1725,289 @@ public class PrismaMockServerTest extends AbstractMockServerTest {
         output,
         output.contains(
             "current transaction is aborted, commands ignored until end of transaction block"));
+  }
+
+  @Test
+  public void testMigrateStatus() throws Exception {
+    setupPrismaMigrateQueries();
+
+    String output = runTest("testMigrateStatus", getHost(), pgServer.getLocalPort());
+    assertTrue(output, output.contains("Running npx prisma migrate status on"));
+  }
+
+  @Test
+  public void testMigrateDeploy() throws Exception {
+    setupPrismaMigrateQueries();
+    addDdlResponseToSpannerAdmin();
+
+    String tableSql =
+        "with pg_class as (\n"
+            + "  select\n"
+            + "  '''\"' || t.table_schema || '\".\"' || t.table_name || '\"''' as oid,\n"
+            + "  table_name as relname,\n"
+            + "  case table_schema when 'pg_catalog' then 11 when 'public' then 2200 else 0 end as relnamespace,\n"
+            + "  0 as reltype,\n"
+            + "  0 as reloftype,\n"
+            + "  0 as relowner,\n"
+            + "  1 as relam,\n"
+            + "  0 as relfilenode,\n"
+            + "  0 as reltablespace,\n"
+            + "  0 as relpages,\n"
+            + "  0.0::float8 as reltuples,\n"
+            + "  0 as relallvisible,\n"
+            + "  0 as reltoastrelid,\n"
+            + "  false as relhasindex,\n"
+            + "  false as relisshared,\n"
+            + "  'p' as relpersistence,\n"
+            + "  CASE table_type WHEN 'BASE TABLE' THEN 'r' WHEN 'VIEW' THEN 'v' ELSE '' END as relkind,\n"
+            + "  count(*) as relnatts,\n"
+            + "  0 as relchecks,\n"
+            + "  false as relhasrules,\n"
+            + "  false as relhastriggers,\n"
+            + "  false as relhassubclass,\n"
+            + "  false as relrowsecurity,\n"
+            + "  false as relforcerowsecurity,\n"
+            + "  true as relispopulated,\n"
+            + "  'n' as relreplident,\n"
+            + "  false as relispartition,\n"
+            + "  0 as relrewrite,\n"
+            + "  0 as relfrozenxid,\n"
+            + "  0 as relminmxid,\n"
+            + "  '{}'::bigint[] as relacl,\n"
+            + "  '{}'::text[] as reloptions,\n"
+            + "  0 as relpartbound\n"
+            + "from information_schema.tables t\n"
+            + "inner join information_schema.columns using (table_catalog, table_schema, table_name)\n"
+            + "group by t.table_name, t.table_schema, t.table_type\n"
+            + "union all\n"
+            + "select\n"
+            + "    '''\"' || i.table_schema || '\".\"' || i.table_name || '\".\"' || i.index_name || '\"''' as oid,\n"
+            + "    i.index_name as relname,\n"
+            + "    case table_schema when 'pg_catalog' then 11 when 'public' then 2200 else 0 end as relnamespace,\n"
+            + "    0 as reltype,\n"
+            + "    0 as reloftype,\n"
+            + "    0 as relowner,\n"
+            + "    1 as relam,\n"
+            + "    0 as relfilenode,\n"
+            + "    0 as reltablespace,\n"
+            + "    0 as relpages,\n"
+            + "    0.0::float8 as reltuples,\n"
+            + "    0 as relallvisible,\n"
+            + "    0 as reltoastrelid,\n"
+            + "    false as relhasindex,\n"
+            + "    false as relisshared,\n"
+            + "    'p' as relpersistence,\n"
+            + "    'i' as relkind,\n"
+            + "    count(*) as relnatts,\n"
+            + "    0 as relchecks,\n"
+            + "    false as relhasrules,\n"
+            + "    false as relhastriggers,\n"
+            + "    false as relhassubclass,\n"
+            + "    false as relrowsecurity,\n"
+            + "    false as relforcerowsecurity,\n"
+            + "    true as relispopulated,\n"
+            + "    'n' as relreplident,\n"
+            + "    false as relispartition,\n"
+            + "    0 as relrewrite,\n"
+            + "    0 as relfrozenxid,\n"
+            + "    0 as relminmxid,\n"
+            + "    '{}'::bigint[] as relacl,\n"
+            + "    '{}'::text[] as reloptions,\n"
+            + "    0 as relpartbound\n"
+            + "from information_schema.indexes i\n"
+            + "inner join information_schema.index_columns using (table_catalog, table_schema, table_name, index_name)\n"
+            + "group by i.index_name, i.table_name, i.table_schema\n"
+            + "),\n"
+            + "pg_namespace as (\n"
+            + "  select case schema_name when 'pg_catalog' then 11 when 'public' then 2200 else 0 end as oid,\n"
+            + "        schema_name as nspname, null as nspowner, null as nspacl\n"
+            + "  from information_schema.schemata\n"
+            + ")\n"
+            + "\n"
+            + "                SELECT replace(tbl.relname, 'prisma_migrations', '_prisma_migrations') AS table_name\n"
+            + "                FROM pg_class AS tbl\n"
+            + "                INNER JOIN pg_namespace AS namespace ON namespace.oid = tbl.relnamespace\n"
+            + "                WHERE tbl.relkind = 'r' AND namespace.nspname = ANY ( $1 )\n"
+            + "            ";
+    ResultSetMetadata metadata =
+        ResultSetMetadata.newBuilder()
+            .setRowType(
+                StructType.newBuilder()
+                    .addFields(
+                        Field.newBuilder()
+                            .setName("table_name")
+                            .setType(Type.newBuilder().setCode(TypeCode.STRING).build())
+                            .build())
+                    .build())
+            .setUndeclaredParameters(
+                StructType.newBuilder()
+                    .addFields(
+                        Field.newBuilder()
+                            .setName("p1")
+                            .setType(
+                                Type.newBuilder()
+                                    .setCode(TypeCode.ARRAY)
+                                    .setArrayElementType(
+                                        Type.newBuilder().setCode(TypeCode.STRING).build())
+                                    .build())
+                            .build())
+                    .build())
+            .build();
+    mockSpanner.putStatementResult(
+        StatementResult.query(
+            Statement.of(tableSql), ResultSet.newBuilder().setMetadata(metadata).build()));
+    mockSpanner.putStatementResult(
+        StatementResult.query(
+            Statement.newBuilder(tableSql)
+                .bind("p1")
+                .toStringArray(ImmutableList.of("public"))
+                .build(),
+            ResultSet.newBuilder().setMetadata(metadata).build()));
+
+    String output = runTest("testMigrateDeploy", getHost(), pgServer.getLocalPort());
+
+    assertTrue(output, output.contains("Running npx prisma migrate deploy"));
+    assertEquals(1, mockDatabaseAdmin.getRequests().size());
+    assertEquals(UpdateDatabaseDdlRequest.class, mockDatabaseAdmin.getRequests().get(0).getClass());
+    UpdateDatabaseDdlRequest request =
+        (UpdateDatabaseDdlRequest) mockDatabaseAdmin.getRequests().get(0);
+    assertEquals(1, request.getStatementsCount());
+    assertEquals(
+        "CREATE TABLE prisma_migrations (\n"
+            + "    id                      VARCHAR(36) PRIMARY KEY NOT NULL,\n"
+            + "    checksum                VARCHAR(64) NOT NULL,\n"
+            + "    finished_at             TIMESTAMPTZ,\n"
+            + "    migration_name          VARCHAR(255) NOT NULL,\n"
+            + "    logs                    TEXT,\n"
+            + "    rolled_back_at          TIMESTAMPTZ,\n"
+            + "    started_at              TIMESTAMPTZ NOT NULL DEFAULT now(),\n"
+            + "    applied_steps_count     INTEGER NOT NULL DEFAULT 0\n"
+            + ")",
+        request.getStatements(0));
+  }
+
+  private void setupPrismaMigrateQueries() {
+    String versionSql =
+        "with pg_namespace as (\n"
+            + "  select case schema_name when 'pg_catalog' then 11 when 'public' then 2200 else 0 end as oid,\n"
+            + "        schema_name as nspname, null as nspowner, null as nspacl\n"
+            + "  from information_schema.schemata\n"
+            + ")\n"
+            + "SELECT EXISTS(SELECT 1 FROM pg_namespace WHERE nspname = $1), '14.1', '140001'::integer as numeric_version;";
+    ResultSetMetadata metadata =
+        ResultSetMetadata.newBuilder()
+            .setRowType(
+                StructType.newBuilder()
+                    .addFields(
+                        Field.newBuilder()
+                            .setName("exists")
+                            .setType(Type.newBuilder().setCode(TypeCode.BOOL).build())
+                            .build())
+                    .addFields(
+                        Field.newBuilder()
+                            .setName("c1")
+                            .setType(Type.newBuilder().setCode(TypeCode.STRING).build())
+                            .build())
+                    .addFields(
+                        Field.newBuilder()
+                            .setName("numeric_version")
+                            .setType(Type.newBuilder().setCode(TypeCode.INT64).build())
+                            .build())
+                    .build())
+            .setUndeclaredParameters(
+                StructType.newBuilder()
+                    .addFields(
+                        Field.newBuilder()
+                            .setName("p1")
+                            .setType(Type.newBuilder().setCode(TypeCode.STRING).build())
+                            .build())
+                    .build())
+            .build();
+    mockSpanner.putStatementResult(
+        StatementResult.query(
+            Statement.of(versionSql), ResultSet.newBuilder().setMetadata(metadata).build()));
+    mockSpanner.putStatementResult(
+        StatementResult.query(
+            Statement.newBuilder(versionSql).bind("p1").to("public").build(),
+            ResultSet.newBuilder()
+                .setMetadata(metadata)
+                .addRows(
+                    ListValue.newBuilder()
+                        .addValues(Value.newBuilder().setBoolValue(true).build())
+                        .addValues(Value.newBuilder().setStringValue("14.1").build())
+                        .addValues(Value.newBuilder().setStringValue("14001").build())
+                        .build())
+                .build()));
+
+    String migrationsSql =
+        "SELECT \"id\", \"checksum\", \"finished_at\", \"migration_name\", \"logs\", \"rolled_back_at\", \"started_at\", \"applied_steps_count\" FROM prisma_migrations ORDER BY \"started_at\" ASC";
+    mockSpanner.putStatementResult(
+        StatementResult.query(
+            Statement.of(migrationsSql),
+            ResultSet.newBuilder()
+                .setMetadata(
+                    ResultSetMetadata.newBuilder()
+                        .setRowType(
+                            StructType.newBuilder()
+                                .addFields(
+                                    Field.newBuilder()
+                                        .setName("id")
+                                        .setType(Type.newBuilder().setCode(TypeCode.STRING).build())
+                                        .build())
+                                .addFields(
+                                    Field.newBuilder()
+                                        .setName("checksum")
+                                        .setType(Type.newBuilder().setCode(TypeCode.STRING).build())
+                                        .build())
+                                .addFields(
+                                    Field.newBuilder()
+                                        .setName("finished_at")
+                                        .setType(
+                                            Type.newBuilder().setCode(TypeCode.TIMESTAMP).build())
+                                        .build())
+                                .addFields(
+                                    Field.newBuilder()
+                                        .setName("migration_name")
+                                        .setType(Type.newBuilder().setCode(TypeCode.STRING).build())
+                                        .build())
+                                .addFields(
+                                    Field.newBuilder()
+                                        .setName("logs")
+                                        .setType(Type.newBuilder().setCode(TypeCode.STRING).build())
+                                        .build())
+                                .addFields(
+                                    Field.newBuilder()
+                                        .setName("rolled_back_at")
+                                        .setType(
+                                            Type.newBuilder().setCode(TypeCode.TIMESTAMP).build())
+                                        .build())
+                                .addFields(
+                                    Field.newBuilder()
+                                        .setName("started_at")
+                                        .setType(
+                                            Type.newBuilder().setCode(TypeCode.TIMESTAMP).build())
+                                        .build())
+                                .addFields(
+                                    Field.newBuilder()
+                                        .setName("applied_steps_count")
+                                        .setType(Type.newBuilder().setCode(TypeCode.INT64).build())
+                                        .build())
+                                .build())
+                        .build())
+                .addRows(
+                    ListValue.newBuilder()
+                        .addValues(Value.newBuilder().setStringValue("1").build())
+                        .addValues(Value.newBuilder().setStringValue("foo").build())
+                        .addValues(
+                            Value.newBuilder().setStringValue("2025-03-22T10:00:00Z").build())
+                        .addValues(Value.newBuilder().setStringValue("v1").build())
+                        .addValues(Value.newBuilder().setNullValue(NullValue.NULL_VALUE).build())
+                        .addValues(Value.newBuilder().setNullValue(NullValue.NULL_VALUE).build())
+                        .addValues(
+                            Value.newBuilder().setStringValue("2025-03-22T10:00:00Z").build())
+                        .addValues(Value.newBuilder().setStringValue("1").build())
+                        .build())
+                .build()));
   }
 
   static String runTest(String testName, String host, int port)

--- a/src/test/nodejs/prisma-tests/src/index.ts
+++ b/src/test/nodejs/prisma-tests/src/index.ts
@@ -13,6 +13,8 @@
 // limitations under the License.
 
 import {Prisma, PrismaClient, User} from '@prisma/client'
+import {exec} from "child_process";
+import {promisify} from "util";
 
 function runTest(host: string, port: number, database: string, test: (client) => Promise<void>, options?: string) {
   if (host.charAt(0) == '/') {
@@ -69,6 +71,21 @@ async function testPgAdvisoryLock(client: PrismaClient) {
   } catch (e) {
     console.error(`Query error: ${e}`);
   }
+}
+
+const execAsync = promisify(exec);
+async function testMigrateStatus() {
+  console.log(`Running npx prisma migrate status on ${process.env.DATABASE_URL}`);
+  await execAsync("npx prisma migrate status", {
+    env: process.env,
+  });
+}
+
+async function testMigrateDeploy() {
+  console.log(`Running npx prisma migrate deploy on ${process.env.DATABASE_URL}`);
+  await execAsync("npx prisma migrate deploy", {
+    env: process.env,
+  });
 }
 
 async function testShowAutoAddLimitClause(client: PrismaClient) {
@@ -374,6 +391,18 @@ require('yargs')
     'Locks/unlocks the specific advisory lock for Prisma',
     {},
     opts => runTest(opts.host, opts.port, opts.database, testPgAdvisoryLock)
+)
+.command(
+    'testMigrateStatus <host> <port> <database>',
+    'Runs npx prisma migrate status',
+    {},
+    opts => runTest(opts.host, opts.port, opts.database, testMigrateStatus)
+)
+.command(
+    'testMigrateDeploy <host> <port> <database>',
+    'Runs npx prisma migrate deploy',
+    {},
+    opts => runTest(opts.host, opts.port, opts.database, testMigrateDeploy)
 )
 .command(
     'testShowAutoAddLimitClause <host> <port> <database>',


### PR DESCRIPTION
Translate the table name _prisma_migrations to prisma_migrations when Prisma is checking which tables already exist in the database.