### PR TITLE
perf: get int8 values directly from the protobuf value

### DIFF
--- a/src/main/java/com/google/cloud/spanner/pgadapter/parsers/LongParser.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/parsers/LongParser.java
@@ -16,14 +16,17 @@ package com.google.cloud.spanner.pgadapter.parsers;
 
 import com.google.api.core.InternalApi;
 import com.google.cloud.spanner.ErrorCode;
+import com.google.cloud.spanner.ProtobufResultSet;
 import com.google.cloud.spanner.ResultSet;
 import com.google.cloud.spanner.SpannerExceptionFactory;
 import com.google.cloud.spanner.Statement;
 import com.google.cloud.spanner.pgadapter.ProxyServer.DataFormat;
 import com.google.cloud.spanner.pgadapter.error.PGExceptionFactory;
+import com.google.cloud.spanner.pgadapter.session.SessionState;
+import java.io.DataOutputStream;
+import java.io.IOException;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
-import java.nio.charset.StandardCharsets;
 import javax.annotation.Nonnull;
 import org.postgresql.util.ByteConverter;
 
@@ -95,16 +98,45 @@ public class LongParser extends Parser<Long> {
     return result;
   }
 
-  public static byte[] convertToPG(ResultSet resultSet, int position, DataFormat format) {
+  public static byte[] convertToPG(
+      SessionState sessionState,
+      DataOutputStream outputStream,
+      ResultSet resultSet,
+      int position,
+      DataFormat format)
+      throws IOException {
+    writeToPG(sessionState, outputStream, resultSet, position, format);
+    return null;
+  }
+
+  static void writeToPG(
+      SessionState sessionState,
+      DataOutputStream outputStream,
+      ResultSet resultSet,
+      int position,
+      DataFormat format)
+      throws IOException {
     switch (format) {
       case SPANNER:
       case POSTGRESQL_TEXT:
-        return Long.toString(resultSet.getLong(position)).getBytes(StandardCharsets.UTF_8);
+        StringParser.writeToPG(sessionState, outputStream, getLongAsString(resultSet, position));
+        break;
       case POSTGRESQL_BINARY:
-        return convertToPG(resultSet.getLong(position));
+        byte[] value = convertToPG(resultSet.getLong(position));
+        outputStream.writeInt(value.length);
+        outputStream.write(value);
+        break;
       default:
         throw new IllegalArgumentException("unknown data format: " + format);
     }
+  }
+
+  static String getLongAsString(ResultSet resultSet, int column) {
+    if (resultSet instanceof ProtobufResultSet
+        && ((ProtobufResultSet) resultSet).canGetProtobufValue(column)) {
+      return ((ProtobufResultSet) resultSet).getProtobufValue(column).getStringValue();
+    }
+    return Long.toString(resultSet.getLong(column));
   }
 
   @Override

--- a/src/main/java/com/google/cloud/spanner/pgadapter/utils/Converter.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/utils/Converter.java
@@ -120,6 +120,8 @@ public class Converter implements AutoCloseable {
                 : fixedFormat;
         byte[] column =
             Converter.convertToPG(outputStream, this.resultSet, column_index, format, sessionState);
+        // TODO: Remove this if statement and write statements once all data types are written
+        // directly to the output stream.
         if (column != null) {
           outputStream.writeInt(column.length);
           outputStream.write(column);
@@ -137,22 +139,24 @@ public class Converter implements AutoCloseable {
    * Return the data of the specified column of the {@link ResultSet} as a byte array. The column
    * may not contain a null value.
    *
+   * @param outputStream The output stream to write value to if the converter supports that.
    * @param result The {@link ResultSet} to read the data from.
    * @param position The column index.
    * @param format The {@link DataFormat} format to use to encode the data.
-   * @return a byte array containing the data in the specified format.
+   * @param sessionState The {@link SessionState} that should be used to determine how to format the
+   *     data (e.g. timezone).
+   * @return a byte array containing the data in the specified format or null if the data was
+   *     written directly to the output stream.
    */
-  public static byte[] convertToPG(
-      ResultSet result, int position, DataFormat format, SessionState sessionState) {
-    return convertToPG(null, result, position, format, sessionState);
-  }
-
+  // TODO: Rename this method to writeToPG and change return type to void once all data types write
+  // directly to the output stream.
   public static byte[] convertToPG(
       DataOutputStream outputStream,
       ResultSet result,
       int position,
       DataFormat format,
-      SessionState sessionState) {
+      SessionState sessionState)
+      throws IOException {
     Preconditions.checkArgument(!result.isNull(position), "Column may not contain a null value");
     Type type = result.getColumnType(position);
     switch (type.getCode()) {
@@ -168,7 +172,7 @@ public class Converter implements AutoCloseable {
         return DoubleParser.convertToPG(result, position, format);
       case INT64:
       case PG_OID:
-        return LongParser.convertToPG(result, position, format);
+        return LongParser.convertToPG(sessionState, outputStream, result, position, format);
       case PG_NUMERIC:
         return NumericParser.convertToPG(result, position, format);
       case STRING:


### PR DESCRIPTION
Get long values directly from the protobuf value instead of first parsing and copying into a different buffer by calling ResultSet#getLong(int).