### PR TITLE
perf: use array of primitive short for format codes

### DIFF
--- a/src/main/java/com/google/cloud/spanner/pgadapter/statements/AbstractFetchOrMoveStatement.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/statements/AbstractFetchOrMoveStatement.java
@@ -25,7 +25,6 @@ import com.google.cloud.spanner.pgadapter.statements.SimpleParser.TableOrIndexNa
 import com.google.common.base.Preconditions;
 import com.google.common.util.concurrent.Futures;
 import java.util.Arrays;
-import java.util.List;
 import java.util.concurrent.Future;
 
 abstract class AbstractFetchOrMoveStatement extends IntermediatePortalStatement {
@@ -129,8 +128,8 @@ abstract class AbstractFetchOrMoveStatement extends IntermediatePortalStatement 
       String name,
       IntermediatePreparedStatement preparedStatement,
       byte[][] parameters,
-      List<Short> parameterFormatCodes,
-      List<Short> resultFormatCodes,
+      short[] parameterFormatCodes,
+      short[] resultFormatCodes,
       ParsedFetchOrMoveStatement fetchOrMoveStatement) {
     super(name, preparedStatement, parameters, parameterFormatCodes, resultFormatCodes);
     this.fetchOrMoveStatement = fetchOrMoveStatement;
@@ -186,10 +185,7 @@ abstract class AbstractFetchOrMoveStatement extends IntermediatePortalStatement 
 
   @Override
   public IntermediatePortalStatement createPortal(
-      String name,
-      byte[][] parameters,
-      List<Short> parameterFormatCodes,
-      List<Short> resultFormatCodes) {
+      String name, byte[][] parameters, short[] parameterFormatCodes, short[] resultFormatCodes) {
     // FETCH and MOVE do not support binding any parameters, so we just return the same statement.
     return this;
   }

--- a/src/main/java/com/google/cloud/spanner/pgadapter/statements/CloseStatement.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/statements/CloseStatement.java
@@ -26,9 +26,7 @@ import com.google.cloud.spanner.pgadapter.metadata.OptionsMetadata;
 import com.google.cloud.spanner.pgadapter.statements.BackendConnection.NoResult;
 import com.google.cloud.spanner.pgadapter.statements.SimpleParser.TableOrIndexName;
 import com.google.common.base.Preconditions;
-import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.Futures;
-import java.util.List;
 import java.util.concurrent.Future;
 
 public class CloseStatement extends IntermediatePortalStatement {
@@ -58,8 +56,8 @@ public class CloseStatement extends IntermediatePortalStatement {
             parsedStatement,
             originalStatement),
         NO_PARAMS,
-        ImmutableList.of(),
-        ImmutableList.of());
+        NO_FORMAT_CODES,
+        NO_FORMAT_CODES);
     this.closeStatement = parse(originalStatement.getSql());
   }
 
@@ -98,10 +96,7 @@ public class CloseStatement extends IntermediatePortalStatement {
 
   @Override
   public IntermediatePortalStatement createPortal(
-      String name,
-      byte[][] parameters,
-      List<Short> parameterFormatCodes,
-      List<Short> resultFormatCodes) {
+      String name, byte[][] parameters, short[] parameterFormatCodes, short[] resultFormatCodes) {
     // CLOSE does not support binding any parameters, so we just return the same statement.
     return this;
   }

--- a/src/main/java/com/google/cloud/spanner/pgadapter/statements/CopyStatement.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/statements/CopyStatement.java
@@ -129,8 +129,8 @@ public class CopyStatement extends IntermediatePortalStatement {
             parsedStatement,
             originalStatement),
         NO_PARAMS,
-        ImmutableList.of(),
-        ImmutableList.of());
+        NO_FORMAT_CODES,
+        NO_FORMAT_CODES);
     this.parsedCopyStatement = parsedCopyStatement;
   }
 
@@ -404,10 +404,7 @@ public class CopyStatement extends IntermediatePortalStatement {
 
   @Override
   public IntermediatePortalStatement createPortal(
-      String name,
-      byte[][] parameters,
-      List<Short> parameterFormatCodes,
-      List<Short> resultFormatCodes) {
+      String name, byte[][] parameters, short[] parameterFormatCodes, short[] resultFormatCodes) {
     // COPY does not support binding any parameters, so we just return the same statement.
     return this;
   }

--- a/src/main/java/com/google/cloud/spanner/pgadapter/statements/CopyToStatement.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/statements/CopyToStatement.java
@@ -37,9 +37,7 @@ import com.google.cloud.spanner.pgadapter.wireoutput.CopyDoneResponse;
 import com.google.cloud.spanner.pgadapter.wireoutput.CopyOutResponse;
 import com.google.cloud.spanner.pgadapter.wireoutput.WireOutput;
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.Futures;
-import java.util.List;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
@@ -75,8 +73,8 @@ public class CopyToStatement extends IntermediatePortalStatement {
             createParsedStatement(parsedCopyStatement),
             createSelectStatement(parsedCopyStatement)),
         NO_PARAMS,
-        ImmutableList.of(),
-        ImmutableList.of());
+        NO_FORMAT_CODES,
+        NO_FORMAT_CODES);
     this.parsedCopyStatement = parsedCopyStatement;
     if (parsedCopyStatement.format == CopyStatement.Format.BINARY) {
       this.csvFormat = null;
@@ -215,10 +213,7 @@ public class CopyToStatement extends IntermediatePortalStatement {
 
   @Override
   public IntermediatePortalStatement createPortal(
-      String name,
-      byte[][] parameters,
-      List<Short> parameterFormatCodes,
-      List<Short> resultFormatCodes) {
+      String name, byte[][] parameters, short[] parameterFormatCodes, short[] resultFormatCodes) {
     // COPY does not support binding any parameters, so we just return the same statement.
     return this;
   }

--- a/src/main/java/com/google/cloud/spanner/pgadapter/statements/DeallocateStatement.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/statements/DeallocateStatement.java
@@ -26,9 +26,7 @@ import com.google.cloud.spanner.pgadapter.metadata.OptionsMetadata;
 import com.google.cloud.spanner.pgadapter.statements.BackendConnection.NoResult;
 import com.google.cloud.spanner.pgadapter.statements.SimpleParser.TableOrIndexName;
 import com.google.common.base.Preconditions;
-import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.Futures;
-import java.util.List;
 import java.util.concurrent.Future;
 
 public class DeallocateStatement extends IntermediatePortalStatement {
@@ -58,8 +56,8 @@ public class DeallocateStatement extends IntermediatePortalStatement {
             parsedStatement,
             originalStatement),
         NO_PARAMS,
-        ImmutableList.of(),
-        ImmutableList.of());
+        NO_FORMAT_CODES,
+        NO_FORMAT_CODES);
     this.deallocateStatement = parse(originalStatement.getSql());
   }
 
@@ -98,10 +96,7 @@ public class DeallocateStatement extends IntermediatePortalStatement {
 
   @Override
   public IntermediatePortalStatement createPortal(
-      String name,
-      byte[][] parameters,
-      List<Short> parameterFormatCodes,
-      List<Short> resultFormatCodes) {
+      String name, byte[][] parameters, short[] parameterFormatCodes, short[] resultFormatCodes) {
     // EXECUTE does not support binding any parameters, so we just return the same statement.
     return this;
   }

--- a/src/main/java/com/google/cloud/spanner/pgadapter/statements/DeclareStatement.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/statements/DeclareStatement.java
@@ -35,9 +35,7 @@ import com.google.cloud.spanner.pgadapter.wireprotocol.BindMessage;
 import com.google.cloud.spanner.pgadapter.wireprotocol.ControlMessage.ManuallyCreatedToken;
 import com.google.cloud.spanner.pgadapter.wireprotocol.ParseMessage;
 import com.google.common.base.Preconditions;
-import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.Futures;
-import java.util.List;
 import java.util.concurrent.Future;
 
 @InternalApi
@@ -105,8 +103,8 @@ public class DeclareStatement extends IntermediatePortalStatement {
             parsedStatement,
             originalStatement),
         NO_PARAMS,
-        ImmutableList.of(),
-        ImmutableList.of());
+        NO_FORMAT_CODES,
+        NO_FORMAT_CODES);
     this.declareStatement = parse(originalStatement.getSql());
   }
 
@@ -176,10 +174,7 @@ public class DeclareStatement extends IntermediatePortalStatement {
 
   @Override
   public IntermediatePortalStatement createPortal(
-      String name,
-      byte[][] parameters,
-      List<Short> parameterFormatCodes,
-      List<Short> resultFormatCodes) {
+      String name, byte[][] parameters, short[] parameterFormatCodes, short[] resultFormatCodes) {
     // DECLARE does not support binding any parameters, so we just return the same statement.
     return this;
   }

--- a/src/main/java/com/google/cloud/spanner/pgadapter/statements/DiscardStatement.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/statements/DiscardStatement.java
@@ -26,9 +26,7 @@ import com.google.cloud.spanner.pgadapter.statements.BackendConnection.Connectio
 import com.google.cloud.spanner.pgadapter.statements.BackendConnection.NoResult;
 import com.google.cloud.spanner.pgadapter.statements.DiscardStatement.ParsedDiscardStatement.DiscardType;
 import com.google.common.base.Preconditions;
-import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.Futures;
-import java.util.List;
 import java.util.concurrent.Future;
 
 public class DiscardStatement extends IntermediatePortalStatement {
@@ -65,8 +63,8 @@ public class DiscardStatement extends IntermediatePortalStatement {
             parsedStatement,
             originalStatement),
         NO_PARAMS,
-        ImmutableList.of(),
-        ImmutableList.of());
+        NO_FORMAT_CODES,
+        NO_FORMAT_CODES);
     this.discardStatement = parse(originalStatement.getSql());
   }
 
@@ -120,10 +118,7 @@ public class DiscardStatement extends IntermediatePortalStatement {
 
   @Override
   public IntermediatePortalStatement createPortal(
-      String name,
-      byte[][] parameters,
-      List<Short> parameterFormatCodes,
-      List<Short> resultFormatCodes) {
+      String name, byte[][] parameters, short[] parameterFormatCodes, short[] resultFormatCodes) {
     // DISCARD does not support binding any parameters, so we just return the same statement.
     return this;
   }

--- a/src/main/java/com/google/cloud/spanner/pgadapter/statements/ExecuteStatement.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/statements/ExecuteStatement.java
@@ -31,7 +31,6 @@ import com.google.cloud.spanner.pgadapter.wireprotocol.ControlMessage.PreparedTy
 import com.google.cloud.spanner.pgadapter.wireprotocol.DescribeMessage;
 import com.google.cloud.spanner.pgadapter.wireprotocol.ExecuteMessage;
 import com.google.common.base.Preconditions;
-import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.Futures;
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
@@ -69,8 +68,8 @@ public class ExecuteStatement extends IntermediatePortalStatement {
             parsedStatement,
             originalStatement),
         NO_PARAMS,
-        ImmutableList.of(),
-        ImmutableList.of());
+        NO_FORMAT_CODES,
+        NO_FORMAT_CODES);
     this.executeStatement = parse(originalStatement.getSql());
   }
 
@@ -119,10 +118,7 @@ public class ExecuteStatement extends IntermediatePortalStatement {
 
   @Override
   public IntermediatePortalStatement createPortal(
-      String name,
-      byte[][] parameters,
-      List<Short> parameterFormatCodes,
-      List<Short> resultFormatCodes) {
+      String name, byte[][] parameters, short[] parameterFormatCodes, short[] resultFormatCodes) {
     // EXECUTE does not support binding any parameters, so we just return the same statement.
     return this;
   }

--- a/src/main/java/com/google/cloud/spanner/pgadapter/statements/FetchStatement.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/statements/FetchStatement.java
@@ -22,7 +22,6 @@ import com.google.cloud.spanner.pgadapter.wireprotocol.ControlMessage.ManuallyCr
 import com.google.cloud.spanner.pgadapter.wireprotocol.ControlMessage.PreparedType;
 import com.google.cloud.spanner.pgadapter.wireprotocol.DescribeMessage;
 import com.google.cloud.spanner.pgadapter.wireprotocol.ExecuteMessage;
-import com.google.common.collect.ImmutableList;
 
 public class FetchStatement extends AbstractFetchOrMoveStatement {
 
@@ -42,8 +41,8 @@ public class FetchStatement extends AbstractFetchOrMoveStatement {
             parsedStatement,
             originalStatement),
         NO_PARAMS,
-        ImmutableList.of(),
-        ImmutableList.of(),
+        NO_FORMAT_CODES,
+        NO_FORMAT_CODES,
         parse(originalStatement.getSql(), "fetch", ParsedFetchStatement.class));
   }
 

--- a/src/main/java/com/google/cloud/spanner/pgadapter/statements/IntermediatePortalStatement.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/statements/IntermediatePortalStatement.java
@@ -22,7 +22,6 @@ import com.google.cloud.spanner.pgadapter.parsers.Parser;
 import com.google.cloud.spanner.pgadapter.parsers.Parser.FormatCode;
 import com.google.cloud.spanner.pgadapter.statements.BackendConnection.NoResult;
 import com.google.common.util.concurrent.Futures;
-import java.util.List;
 import java.util.concurrent.Future;
 
 /**
@@ -32,18 +31,19 @@ import java.util.concurrent.Future;
 @InternalApi
 public class IntermediatePortalStatement extends IntermediatePreparedStatement {
   static final byte[][] NO_PARAMS = new byte[0][];
+  public static final short[] NO_FORMAT_CODES = new short[0];
 
   private final IntermediatePreparedStatement preparedStatement;
   private final byte[][] parameters;
-  protected final List<Short> parameterFormatCodes;
-  protected final List<Short> resultFormatCodes;
+  protected final short[] parameterFormatCodes;
+  protected final short[] resultFormatCodes;
 
   public IntermediatePortalStatement(
       String name,
       IntermediatePreparedStatement preparedStatement,
       byte[][] parameters,
-      List<Short> parameterFormatCodes,
-      List<Short> resultFormatCodes) {
+      short[] parameterFormatCodes,
+      short[] resultFormatCodes) {
     super(
         preparedStatement.connectionHandler,
         preparedStatement.options,
@@ -62,23 +62,23 @@ public class IntermediatePortalStatement extends IntermediatePreparedStatement {
   }
 
   public short getParameterFormatCode(int index) {
-    if (this.parameterFormatCodes.size() == 0) {
+    if (this.parameterFormatCodes.length == 0) {
       return 0;
-    } else if (index >= this.parameterFormatCodes.size()) {
-      return this.parameterFormatCodes.get(0);
+    } else if (index >= this.parameterFormatCodes.length) {
+      return this.parameterFormatCodes[0];
     } else {
-      return this.parameterFormatCodes.get(index);
+      return this.parameterFormatCodes[index];
     }
   }
 
   @Override
   public short getResultFormatCode(int index) {
-    if (this.resultFormatCodes == null || this.resultFormatCodes.isEmpty()) {
+    if (this.resultFormatCodes == null || this.resultFormatCodes.length == 0) {
       return super.getResultFormatCode(index);
-    } else if (this.resultFormatCodes.size() == 1) {
-      return this.resultFormatCodes.get(0);
+    } else if (this.resultFormatCodes.length == 1) {
+      return this.resultFormatCodes[0];
     } else {
-      return this.resultFormatCodes.get(index);
+      return this.resultFormatCodes[index];
     }
   }
 

--- a/src/main/java/com/google/cloud/spanner/pgadapter/statements/IntermediatePreparedStatement.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/statements/IntermediatePreparedStatement.java
@@ -27,7 +27,6 @@ import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.MoreExecutors;
 import java.util.Arrays;
-import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import org.postgresql.core.Oid;
@@ -89,10 +88,7 @@ public class IntermediatePreparedStatement extends IntermediateStatement {
    * @return An Intermediate Portal Statement (or rather a bound version of this statement)
    */
   public IntermediatePortalStatement createPortal(
-      String name,
-      byte[][] parameters,
-      List<Short> parameterFormatCodes,
-      List<Short> resultFormatCodes) {
+      String name, byte[][] parameters, short[] parameterFormatCodes, short[] resultFormatCodes) {
     return new IntermediatePortalStatement(
         name, this, parameters, parameterFormatCodes, resultFormatCodes);
   }

--- a/src/main/java/com/google/cloud/spanner/pgadapter/statements/InvalidStatement.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/statements/InvalidStatement.java
@@ -19,7 +19,6 @@ import com.google.cloud.spanner.connection.AbstractStatementParser.ParsedStateme
 import com.google.cloud.spanner.pgadapter.ConnectionHandler;
 import com.google.cloud.spanner.pgadapter.error.PGExceptionFactory;
 import com.google.cloud.spanner.pgadapter.metadata.OptionsMetadata;
-import com.google.common.collect.ImmutableList;
 
 public class InvalidStatement extends IntermediatePortalStatement {
 
@@ -40,8 +39,8 @@ public class InvalidStatement extends IntermediatePortalStatement {
             parsedStatement,
             originalStatement),
         NO_PARAMS,
-        ImmutableList.of(),
-        ImmutableList.of());
+        NO_FORMAT_CODES,
+        NO_FORMAT_CODES);
     setException(PGExceptionFactory.toPGException(exception));
   }
 }

--- a/src/main/java/com/google/cloud/spanner/pgadapter/statements/MoveStatement.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/statements/MoveStatement.java
@@ -20,7 +20,6 @@ import com.google.cloud.spanner.pgadapter.ConnectionHandler;
 import com.google.cloud.spanner.pgadapter.metadata.OptionsMetadata;
 import com.google.cloud.spanner.pgadapter.wireprotocol.ControlMessage.ManuallyCreatedToken;
 import com.google.cloud.spanner.pgadapter.wireprotocol.ExecuteMessage;
-import com.google.common.collect.ImmutableList;
 
 /**
  * MOVE is the same as FETCH, except it just skips the results instead of actually sending the rows
@@ -45,8 +44,8 @@ public class MoveStatement extends AbstractFetchOrMoveStatement {
             parsedStatement,
             originalStatement),
         NO_PARAMS,
-        ImmutableList.of(),
-        ImmutableList.of(),
+        NO_FORMAT_CODES,
+        NO_FORMAT_CODES,
         parse(originalStatement.getSql(), "move", ParsedMoveStatement.class));
   }
 

--- a/src/main/java/com/google/cloud/spanner/pgadapter/statements/PrepareStatement.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/statements/PrepareStatement.java
@@ -124,8 +124,8 @@ public class PrepareStatement extends IntermediatePortalStatement {
             parsedStatement,
             originalStatement),
         NO_PARAMS,
-        ImmutableList.of(),
-        ImmutableList.of());
+        NO_FORMAT_CODES,
+        NO_FORMAT_CODES);
     this.preparedStatement = parse(originalStatement.getSql());
   }
 
@@ -174,10 +174,7 @@ public class PrepareStatement extends IntermediatePortalStatement {
 
   @Override
   public IntermediatePortalStatement createPortal(
-      String name,
-      byte[][] parameters,
-      List<Short> parameterFormatCodes,
-      List<Short> resultFormatCodes) {
+      String name, byte[][] parameters, short[] parameterFormatCodes, short[] resultFormatCodes) {
     // PREPARE does not support binding any parameters, so we just return the same statement.
     return this;
   }

--- a/src/main/java/com/google/cloud/spanner/pgadapter/statements/ReleaseStatement.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/statements/ReleaseStatement.java
@@ -26,9 +26,7 @@ import com.google.cloud.spanner.pgadapter.error.SQLState;
 import com.google.cloud.spanner.pgadapter.metadata.OptionsMetadata;
 import com.google.cloud.spanner.pgadapter.statements.SimpleParser.TableOrIndexName;
 import com.google.common.base.Preconditions;
-import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.Futures;
-import java.util.List;
 import java.util.concurrent.Future;
 
 public class ReleaseStatement extends IntermediatePortalStatement {
@@ -58,8 +56,8 @@ public class ReleaseStatement extends IntermediatePortalStatement {
             parsedStatement,
             originalStatement),
         NO_PARAMS,
-        ImmutableList.of(),
-        ImmutableList.of());
+        NO_FORMAT_CODES,
+        NO_FORMAT_CODES);
     this.parsedReleaseStatement = parse(originalStatement.getSql());
   }
 
@@ -112,10 +110,7 @@ public class ReleaseStatement extends IntermediatePortalStatement {
 
   @Override
   public IntermediatePortalStatement createPortal(
-      String name,
-      byte[][] parameters,
-      List<Short> parameterFormatCodes,
-      List<Short> resultFormatCodes) {
+      String name, byte[][] parameters, short[] parameterFormatCodes, short[] resultFormatCodes) {
     // RELEASE does not support binding any parameters, so we just return the same statement.
     return this;
   }

--- a/src/main/java/com/google/cloud/spanner/pgadapter/statements/RollbackToStatement.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/statements/RollbackToStatement.java
@@ -26,9 +26,7 @@ import com.google.cloud.spanner.pgadapter.error.SQLState;
 import com.google.cloud.spanner.pgadapter.metadata.OptionsMetadata;
 import com.google.cloud.spanner.pgadapter.statements.SimpleParser.TableOrIndexName;
 import com.google.common.base.Preconditions;
-import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.Futures;
-import java.util.List;
 import java.util.concurrent.Future;
 
 public class RollbackToStatement extends IntermediatePortalStatement {
@@ -58,8 +56,8 @@ public class RollbackToStatement extends IntermediatePortalStatement {
             parsedStatement,
             originalStatement),
         NO_PARAMS,
-        ImmutableList.of(),
-        ImmutableList.of());
+        NO_FORMAT_CODES,
+        NO_FORMAT_CODES);
     this.parsedRollbackToStatement = parse(originalStatement.getSql());
   }
 
@@ -123,10 +121,7 @@ public class RollbackToStatement extends IntermediatePortalStatement {
 
   @Override
   public IntermediatePortalStatement createPortal(
-      String name,
-      byte[][] parameters,
-      List<Short> parameterFormatCodes,
-      List<Short> resultFormatCodes) {
+      String name, byte[][] parameters, short[] parameterFormatCodes, short[] resultFormatCodes) {
     // ROLLBACK does not support binding any parameters, so we just return the same statement.
     return this;
   }

--- a/src/main/java/com/google/cloud/spanner/pgadapter/statements/SavepointStatement.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/statements/SavepointStatement.java
@@ -26,9 +26,7 @@ import com.google.cloud.spanner.pgadapter.error.SQLState;
 import com.google.cloud.spanner.pgadapter.metadata.OptionsMetadata;
 import com.google.cloud.spanner.pgadapter.statements.SimpleParser.TableOrIndexName;
 import com.google.common.base.Preconditions;
-import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.Futures;
-import java.util.List;
 import java.util.concurrent.Future;
 
 public class SavepointStatement extends IntermediatePortalStatement {
@@ -58,8 +56,8 @@ public class SavepointStatement extends IntermediatePortalStatement {
             parsedStatement,
             originalStatement),
         NO_PARAMS,
-        ImmutableList.of(),
-        ImmutableList.of());
+        NO_FORMAT_CODES,
+        NO_FORMAT_CODES);
     this.parsedSavepointStatement = parse(originalStatement.getSql());
   }
 
@@ -111,10 +109,7 @@ public class SavepointStatement extends IntermediatePortalStatement {
 
   @Override
   public IntermediatePortalStatement createPortal(
-      String name,
-      byte[][] parameters,
-      List<Short> parameterFormatCodes,
-      List<Short> resultFormatCodes) {
+      String name, byte[][] parameters, short[] parameterFormatCodes, short[] resultFormatCodes) {
     // SAVEPOINT does not support binding any parameters, so we just return the same statement.
     return this;
   }

--- a/src/main/java/com/google/cloud/spanner/pgadapter/statements/SelectCurrentSettingStatement.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/statements/SelectCurrentSettingStatement.java
@@ -33,7 +33,6 @@ import com.google.cloud.spanner.pgadapter.statements.SimpleParser.TableOrIndexNa
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.Futures;
-import java.util.List;
 import java.util.Locale;
 import java.util.concurrent.Future;
 
@@ -60,8 +59,8 @@ public class SelectCurrentSettingStatement extends IntermediatePortalStatement {
             parsedStatement,
             originalStatement),
         NO_PARAMS,
-        ImmutableList.of(),
-        ImmutableList.of());
+        NO_FORMAT_CODES,
+        NO_FORMAT_CODES);
     this.showStatement = parse(originalStatement.getSql());
   }
 
@@ -128,10 +127,7 @@ public class SelectCurrentSettingStatement extends IntermediatePortalStatement {
 
   @Override
   public IntermediatePortalStatement createPortal(
-      String name,
-      byte[][] parameters,
-      List<Short> parameterFormatCodes,
-      List<Short> resultFormatCodes) {
+      String name, byte[][] parameters, short[] parameterFormatCodes, short[] resultFormatCodes) {
     return this;
   }
 }

--- a/src/main/java/com/google/cloud/spanner/pgadapter/statements/SelectSetConfigStatement.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/statements/SelectSetConfigStatement.java
@@ -34,7 +34,6 @@ import com.google.cloud.spanner.pgadapter.statements.SimpleParser.TableOrIndexNa
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.Futures;
-import java.util.List;
 import java.util.Locale;
 import java.util.concurrent.Future;
 
@@ -61,8 +60,8 @@ public class SelectSetConfigStatement extends IntermediatePortalStatement {
             parsedStatement,
             originalStatement),
         NO_PARAMS,
-        ImmutableList.of(),
-        ImmutableList.of());
+        NO_FORMAT_CODES,
+        NO_FORMAT_CODES);
     this.setStatement = parse(originalStatement.getSql());
   }
 
@@ -143,10 +142,7 @@ public class SelectSetConfigStatement extends IntermediatePortalStatement {
 
   @Override
   public IntermediatePortalStatement createPortal(
-      String name,
-      byte[][] parameters,
-      List<Short> parameterFormatCodes,
-      List<Short> resultFormatCodes) {
+      String name, byte[][] parameters, short[] parameterFormatCodes, short[] resultFormatCodes) {
     return this;
   }
 }

--- a/src/main/java/com/google/cloud/spanner/pgadapter/statements/ShowDatabaseDdlStatement.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/statements/ShowDatabaseDdlStatement.java
@@ -70,8 +70,8 @@ public class ShowDatabaseDdlStatement extends IntermediatePortalStatement {
             parsedStatement,
             originalStatement),
         NO_PARAMS,
-        ImmutableList.of(),
-        ImmutableList.of());
+        NO_FORMAT_CODES,
+        NO_FORMAT_CODES);
     this.parsedShowDatabaseDdlStatement = parse(originalStatement.getSql());
   }
 
@@ -150,10 +150,7 @@ public class ShowDatabaseDdlStatement extends IntermediatePortalStatement {
 
   @Override
   public IntermediatePortalStatement createPortal(
-      String name,
-      byte[][] parameters,
-      List<Short> parameterFormatCodes,
-      List<Short> resultFormatCodes) {
+      String name, byte[][] parameters, short[] parameterFormatCodes, short[] resultFormatCodes) {
     // SHOW DATABASE DDL does not support binding any parameters, so we just return the same
     // statement.
     return this;

--- a/src/main/java/com/google/cloud/spanner/pgadapter/statements/ShutdownStatement.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/statements/ShutdownStatement.java
@@ -28,9 +28,7 @@ import com.google.cloud.spanner.pgadapter.metadata.OptionsMetadata;
 import com.google.cloud.spanner.pgadapter.statements.BackendConnection.NoResult;
 import com.google.cloud.spanner.pgadapter.statements.ShutdownStatement.ParsedShutdownStatement.Builder;
 import com.google.common.base.Preconditions;
-import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.Futures;
-import java.util.List;
 import java.util.concurrent.Future;
 
 /**
@@ -76,8 +74,8 @@ public class ShutdownStatement extends IntermediatePortalStatement {
             parsedStatement,
             originalStatement),
         NO_PARAMS,
-        ImmutableList.of(),
-        ImmutableList.of());
+        NO_FORMAT_CODES,
+        NO_FORMAT_CODES);
     this.parsedShutdownStatement = parse(originalStatement.getSql(), connectionHandler.getServer());
   }
 
@@ -125,10 +123,7 @@ public class ShutdownStatement extends IntermediatePortalStatement {
 
   @Override
   public IntermediatePortalStatement createPortal(
-      String name,
-      byte[][] parameters,
-      List<Short> parameterFormatCodes,
-      List<Short> resultFormatCodes) {
+      String name, byte[][] parameters, short[] parameterFormatCodes, short[] resultFormatCodes) {
     // SHUTDOWN does not support binding any parameters, so we just return the same statement.
     return this;
   }

--- a/src/main/java/com/google/cloud/spanner/pgadapter/statements/TruncateStatement.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/statements/TruncateStatement.java
@@ -73,8 +73,8 @@ public class TruncateStatement extends IntermediatePortalStatement {
             parsedStatement,
             originalStatement),
         NO_PARAMS,
-        ImmutableList.of(),
-        ImmutableList.of());
+        NO_FORMAT_CODES,
+        NO_FORMAT_CODES);
     this.truncateStatement = parse(originalStatement.getSql());
   }
 
@@ -111,10 +111,7 @@ public class TruncateStatement extends IntermediatePortalStatement {
 
   @Override
   public IntermediatePortalStatement createPortal(
-      String name,
-      byte[][] parameters,
-      List<Short> parameterFormatCodes,
-      List<Short> resultFormatCodes) {
+      String name, byte[][] parameters, short[] parameterFormatCodes, short[] resultFormatCodes) {
     // TRUNCATE does not support binding any parameters, so we just return the same statement.
     return this;
   }

--- a/src/main/java/com/google/cloud/spanner/pgadapter/statements/VacuumStatement.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/statements/VacuumStatement.java
@@ -110,8 +110,8 @@ public class VacuumStatement extends IntermediatePortalStatement {
             parsedStatement,
             originalStatement),
         NO_PARAMS,
-        ImmutableList.of(),
-        ImmutableList.of());
+        NO_FORMAT_CODES,
+        NO_FORMAT_CODES);
     this.parsedVacuumStatement = parse(originalStatement.getSql());
   }
 
@@ -148,10 +148,7 @@ public class VacuumStatement extends IntermediatePortalStatement {
 
   @Override
   public IntermediatePortalStatement createPortal(
-      String name,
-      byte[][] parameters,
-      List<Short> parameterFormatCodes,
-      List<Short> resultFormatCodes) {
+      String name, byte[][] parameters, short[] parameterFormatCodes, short[] resultFormatCodes) {
     // VACUUM does not support binding any parameters, so we just return the same statement.
     return this;
   }

--- a/src/main/java/com/google/cloud/spanner/pgadapter/wireprotocol/BindMessage.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/wireprotocol/BindMessage.java
@@ -14,6 +14,8 @@
 
 package com.google.cloud.spanner.pgadapter.wireprotocol;
 
+import static com.google.cloud.spanner.pgadapter.statements.IntermediatePortalStatement.NO_FORMAT_CODES;
+
 import com.google.api.core.InternalApi;
 import com.google.cloud.spanner.pgadapter.ConnectionHandler;
 import com.google.cloud.spanner.pgadapter.statements.BackendConnection;
@@ -21,10 +23,8 @@ import com.google.cloud.spanner.pgadapter.statements.IntermediatePortalStatement
 import com.google.cloud.spanner.pgadapter.statements.IntermediatePreparedStatement;
 import com.google.cloud.spanner.pgadapter.wireoutput.BindCompleteResponse;
 import com.google.common.base.Preconditions;
-import com.google.common.collect.ImmutableList;
 import java.text.MessageFormat;
 import java.util.Arrays;
-import java.util.List;
 
 /**
  * Message of type bind (meaning that it is a message called to a prepared statement to complete it
@@ -37,8 +37,8 @@ public class BindMessage extends AbstractQueryProtocolMessage {
 
   private final String portalName;
   private final String statementName;
-  private final List<Short> formatCodes;
-  private final List<Short> resultFormatCodes;
+  private final short[] formatCodes;
+  private final short[] resultFormatCodes;
   private final byte[][] parameters;
   private final IntermediatePortalStatement statement;
 
@@ -72,8 +72,8 @@ public class BindMessage extends AbstractQueryProtocolMessage {
     super(connection, 4, manuallyCreatedToken);
     this.portalName = portalName;
     this.statementName = statementName;
-    this.formatCodes = ImmutableList.of();
-    this.resultFormatCodes = ImmutableList.of();
+    this.formatCodes = NO_FORMAT_CODES;
+    this.resultFormatCodes = NO_FORMAT_CODES;
     this.parameters = Preconditions.checkNotNull(parameters);
     IntermediatePreparedStatement statement = connection.getStatement(statementName);
     this.statement =
@@ -158,11 +158,11 @@ public class BindMessage extends AbstractQueryProtocolMessage {
     return this.parameters;
   }
 
-  public List<Short> getFormatCodes() {
+  public short[] getFormatCodes() {
     return this.formatCodes;
   }
 
-  public List<Short> getResultFormatCodes() {
+  public short[] getResultFormatCodes() {
     return this.resultFormatCodes;
   }
 }

--- a/src/main/java/com/google/cloud/spanner/pgadapter/wireprotocol/ControlMessage.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/wireprotocol/ControlMessage.java
@@ -15,6 +15,7 @@
 package com.google.cloud.spanner.pgadapter.wireprotocol;
 
 import static com.google.cloud.spanner.pgadapter.statements.BackendConnection.DB_STATEMENT;
+import static com.google.cloud.spanner.pgadapter.statements.IntermediatePortalStatement.NO_FORMAT_CODES;
 
 import com.google.api.core.InternalApi;
 import com.google.api.gax.grpc.GrpcCallContext;
@@ -207,11 +208,14 @@ public abstract class ControlMessage extends WireMessage {
    * @return A list of format codes.
    * @throws Exception If reading fails in any way.
    */
-  protected static List<Short> getFormatCodes(DataInputStream input) throws Exception {
-    List<Short> formatCodes = new ArrayList<>();
+  protected static short[] getFormatCodes(DataInputStream input) throws Exception {
     short numberOfFormatCodes = input.readShort();
+    if (numberOfFormatCodes == 0) {
+      return NO_FORMAT_CODES;
+    }
+    short[] formatCodes = new short[numberOfFormatCodes];
     for (int i = 0; i < numberOfFormatCodes; i++) {
-      formatCodes.add(input.readShort());
+      formatCodes[i] = input.readShort();
     }
     return formatCodes;
   }

--- a/src/main/java/com/google/cloud/spanner/pgadapter/wireprotocol/FunctionCallMessage.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/wireprotocol/FunctionCallMessage.java
@@ -17,7 +17,6 @@ package com.google.cloud.spanner.pgadapter.wireprotocol;
 import com.google.api.core.InternalApi;
 import com.google.cloud.spanner.pgadapter.ConnectionHandler;
 import java.text.MessageFormat;
-import java.util.List;
 
 /**
  * Normally used to send a function call the back-end. Spanner does not currently support this, so
@@ -31,7 +30,7 @@ public class FunctionCallMessage extends ControlMessage {
   protected static final char IDENTIFIER = 'F';
 
   private final int functionID;
-  private final List<Short> argumentFormatCodes;
+  private final short[] argumentFormatCodes;
   private final byte[][] arguments;
   private final Short resultFormatCode;
 

--- a/src/test/java/com/google/cloud/spanner/pgadapter/python/psycopg3/Psycopg3MockServerTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/python/psycopg3/Psycopg3MockServerTest.java
@@ -424,8 +424,8 @@ public class Psycopg3MockServerTest extends AbstractMockServerTest {
             .collect(Collectors.toList());
     assertEquals(1, bindMessages.size());
     BindMessage bindMessage = bindMessages.get(0);
-    assertEquals(1, bindMessage.getResultFormatCodes().size());
-    assertEquals(format.getCode(), bindMessage.getResultFormatCodes().get(0).shortValue());
+    assertEquals(1, bindMessage.getResultFormatCodes().length);
+    assertEquals(format.getCode(), bindMessage.getResultFormatCodes()[0]);
   }
 
   @Test
@@ -622,10 +622,8 @@ public class Psycopg3MockServerTest extends AbstractMockServerTest {
             .collect(Collectors.toList());
     assertEquals(1, bindMessages.size());
     BindMessage bindMessage = bindMessages.get(0);
-    assertEquals(11, bindMessage.getFormatCodes().size());
-    assertArrayEquals(
-        new Short[] {1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1},
-        bindMessage.getFormatCodes().toArray(new Short[0]));
+    assertEquals(11, bindMessage.getFormatCodes().length);
+    assertArrayEquals(new short[] {1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1}, bindMessage.getFormatCodes());
   }
 
   @Test
@@ -690,10 +688,8 @@ public class Psycopg3MockServerTest extends AbstractMockServerTest {
             .collect(Collectors.toList());
     assertEquals(1, bindMessages.size());
     BindMessage bindMessage = bindMessages.get(0);
-    assertEquals(11, bindMessage.getFormatCodes().size());
-    assertArrayEquals(
-        new Short[] {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
-        bindMessage.getFormatCodes().toArray(new Short[0]));
+    assertEquals(11, bindMessage.getFormatCodes().length);
+    assertArrayEquals(new short[] {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, bindMessage.getFormatCodes());
   }
 
   @Test

--- a/src/test/java/com/google/cloud/spanner/pgadapter/statements/StatementTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/statements/StatementTest.java
@@ -14,6 +14,7 @@
 
 package com.google.cloud.spanner.pgadapter.statements;
 
+import static com.google.cloud.spanner.pgadapter.statements.IntermediatePortalStatement.NO_FORMAT_CODES;
 import static com.google.cloud.spanner.pgadapter.statements.IntermediatePortalStatement.NO_PARAMS;
 import static com.google.cloud.spanner.pgadapter.statements.IntermediatePreparedStatement.NO_PARAMETER_TYPES;
 import static com.google.cloud.spanner.pgadapter.utils.ClientAutoDetector.EMPTY_LOCAL_STATEMENTS;
@@ -69,7 +70,6 @@ import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.nio.file.Files;
 import java.nio.file.Paths;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.UUID;
 import java.util.concurrent.ExecutorService;
@@ -126,8 +126,8 @@ public class StatementTest {
             new IntermediatePreparedStatement(
                 connectionHandler, options, "", NO_PARAMETER_TYPES, parse(sql), Statement.of(sql)),
             NO_PARAMS,
-            ImmutableList.of(),
-            ImmutableList.of());
+            NO_FORMAT_CODES,
+            NO_FORMAT_CODES);
 
     assertFalse(intermediateStatement.isExecuted());
     assertEquals("SELECT", intermediateStatement.getCommand());
@@ -155,8 +155,8 @@ public class StatementTest {
             new IntermediatePreparedStatement(
                 connectionHandler, options, "", NO_PARAMETER_TYPES, parse(sql), Statement.of(sql)),
             NO_PARAMS,
-            ImmutableList.of(),
-            ImmutableList.of());
+            NO_FORMAT_CODES,
+            NO_FORMAT_CODES);
 
     assertFalse(intermediateStatement.isExecuted());
     assertEquals("UPDATE", intermediateStatement.getCommand());
@@ -190,8 +190,8 @@ public class StatementTest {
             new IntermediatePreparedStatement(
                 connectionHandler, options, "", NO_PARAMETER_TYPES, parse(sql), Statement.of(sql)),
             NO_PARAMS,
-            ImmutableList.of(),
-            ImmutableList.of());
+            NO_FORMAT_CODES,
+            NO_FORMAT_CODES);
     BackendConnection backendConnection =
         new BackendConnection(
             NOOP_OTEL,
@@ -237,8 +237,8 @@ public class StatementTest {
             new IntermediatePreparedStatement(
                 connectionHandler, options, "", NO_PARAMETER_TYPES, parse(sql), Statement.of(sql)),
             NO_PARAMS,
-            ImmutableList.of(),
-            ImmutableList.of());
+            NO_FORMAT_CODES,
+            NO_FORMAT_CODES);
 
     assertFalse(intermediateStatement.isExecuted());
     assertEquals("CREATE", intermediateStatement.getCommand());
@@ -285,8 +285,8 @@ public class StatementTest {
             new IntermediatePreparedStatement(
                 connectionHandler, options, "", NO_PARAMETER_TYPES, parse(sql), Statement.of(sql)),
             NO_PARAMS,
-            ImmutableList.of(),
-            ImmutableList.of());
+            NO_FORMAT_CODES,
+            NO_FORMAT_CODES);
     BackendConnection backendConnection =
         new BackendConnection(
             NOOP_OTEL,
@@ -358,7 +358,7 @@ public class StatementTest {
     byte[][] parameters = {"userName".getBytes(), "20".getBytes(), "30".getBytes()};
     IntermediatePortalStatement intermediatePortalStatement =
         intermediateStatement.createPortal(
-            "", parameters, Arrays.asList((short) 0, (short) 0, (short) 0), new ArrayList<>());
+            "", parameters, new short[] {(short) 0, (short) 0, (short) 0}, NO_FORMAT_CODES);
     intermediatePortalStatement.bind(Statement.of(sqlStatement));
     intermediatePortalStatement.executeAsync(backendConnection);
     backendConnection.flush();
@@ -397,7 +397,7 @@ public class StatementTest {
     byte[][] parameters = {"{}".getBytes()};
 
     IntermediatePortalStatement portalStatement =
-        intermediateStatement.createPortal("", parameters, new ArrayList<>(), new ArrayList<>());
+        intermediateStatement.createPortal("", parameters, NO_FORMAT_CODES, NO_FORMAT_CODES);
     Statement boundStatement = portalStatement.bind(Statement.of(sqlStatement));
     assertEquals(
         Value.untyped(com.google.protobuf.Value.newBuilder().setStringValue("{}").build()),
@@ -441,8 +441,8 @@ public class StatementTest {
                 parse(sqlStatement),
                 Statement.of(sqlStatement)),
             NO_PARAMS,
-            ImmutableList.of(),
-            ImmutableList.of());
+            NO_FORMAT_CODES,
+            NO_FORMAT_CODES);
     BackendConnection backendConnection =
         new BackendConnection(
             NOOP_OTEL,
@@ -592,8 +592,8 @@ public class StatementTest {
             new IntermediatePreparedStatement(
                 connectionHandler, options, "", NO_PARAMETER_TYPES, parse(sql), Statement.of(sql)),
             NO_PARAMS,
-            ImmutableList.of(),
-            ImmutableList.of());
+            NO_FORMAT_CODES,
+            NO_FORMAT_CODES);
     BackendConnection backendConnection =
         new BackendConnection(
             NOOP_OTEL,

--- a/src/test/java/com/google/cloud/spanner/pgadapter/wireprotocol/ProtocolTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/wireprotocol/ProtocolTest.java
@@ -14,6 +14,7 @@
 
 package com.google.cloud.spanner.pgadapter.wireprotocol;
 
+import static com.google.cloud.spanner.pgadapter.statements.IntermediatePortalStatement.NO_FORMAT_CODES;
 import static com.google.cloud.spanner.pgadapter.wireprotocol.ControlMessage.MAX_INVALID_MESSAGE_COUNT;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
@@ -72,11 +73,7 @@ import java.io.DataOutputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.time.ZoneId;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import org.junit.Rule;
@@ -632,7 +629,7 @@ public class ProtocolTest {
         .thenReturn(intermediatePreparedStatement);
 
     byte[][] expectedParameters = {parameter};
-    List<Short> expectedFormatCodes = new ArrayList<>();
+    short[] expectedFormatCodes = NO_FORMAT_CODES;
     String expectedPortalName = "some portal";
     String expectedStatementName = "some statement";
 
@@ -651,8 +648,8 @@ public class ProtocolTest {
     assertEquals(expectedPortalName, ((BindMessage) message).getPortalName());
     assertEquals(expectedStatementName, ((BindMessage) message).getStatementName());
     assertArrayEquals(expectedParameters, ((BindMessage) message).getParameters());
-    assertEquals(expectedFormatCodes, ((BindMessage) message).getFormatCodes());
-    assertEquals(expectedFormatCodes, ((BindMessage) message).getResultFormatCodes());
+    assertArrayEquals(expectedFormatCodes, ((BindMessage) message).getFormatCodes());
+    assertArrayEquals(expectedFormatCodes, ((BindMessage) message).getResultFormatCodes());
     assertEquals("select * from foo", ((BindMessage) message).getSql());
     assertTrue(((BindMessage) message).hasParameterValues());
 
@@ -716,8 +713,8 @@ public class ProtocolTest {
             resultCodes);
 
     byte[][] expectedParameters = {firstParameter, secondParameter};
-    List<Short> expectedFormatCodes = Arrays.asList((short) 0, (short) 1);
-    List<Short> expectedResultFormatCodes = Collections.singletonList((short) 1);
+    short[] expectedFormatCodes = new short[] {(short) 0, (short) 1};
+    short[] expectedResultFormatCodes = new short[] {(short) 1};
     String expectedPortalName = "some portal";
     String expectedStatementName = "some statement";
 
@@ -737,8 +734,8 @@ public class ProtocolTest {
     assertEquals(expectedPortalName, ((BindMessage) message).getPortalName());
     assertEquals(expectedStatementName, ((BindMessage) message).getStatementName());
     assertArrayEquals(expectedParameters, ((BindMessage) message).getParameters());
-    assertEquals(expectedFormatCodes, ((BindMessage) message).getFormatCodes());
-    assertEquals(expectedResultFormatCodes, ((BindMessage) message).getResultFormatCodes());
+    assertArrayEquals(expectedFormatCodes, ((BindMessage) message).getFormatCodes());
+    assertArrayEquals(expectedResultFormatCodes, ((BindMessage) message).getResultFormatCodes());
   }
 
   @Test
@@ -791,8 +788,8 @@ public class ProtocolTest {
             resultCodes);
 
     byte[][] expectedParameters = {firstParameter, secondParameter};
-    List<Short> expectedFormatCodes = Collections.singletonList((short) 1);
-    List<Short> expectedResultFormatCodes = Collections.singletonList((short) 1);
+    short[] expectedFormatCodes = new short[] {(short) 1};
+    short[] expectedResultFormatCodes = new short[] {(short) 1};
     String expectedPortalName = "some portal";
     String expectedStatementName = "some statement";
 
@@ -812,8 +809,8 @@ public class ProtocolTest {
     assertEquals(expectedPortalName, ((BindMessage) message).getPortalName());
     assertEquals(expectedStatementName, ((BindMessage) message).getStatementName());
     assertArrayEquals(expectedParameters, ((BindMessage) message).getParameters());
-    assertEquals(expectedFormatCodes, ((BindMessage) message).getFormatCodes());
-    assertEquals(expectedResultFormatCodes, ((BindMessage) message).getResultFormatCodes());
+    assertArrayEquals(expectedFormatCodes, ((BindMessage) message).getFormatCodes());
+    assertArrayEquals(expectedResultFormatCodes, ((BindMessage) message).getResultFormatCodes());
   }
 
   @Test


### PR DESCRIPTION
Use an array of primitive shorts instead of a list of boxed Shorts for format codes to reduce memory usage and the amount of boxing/unboxing.