### PR TITLE
perf: send responses directly without creating object

### DIFF
--- a/src/main/java/com/google/cloud/spanner/pgadapter/ConnectionHandler.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/ConnectionHandler.java
@@ -609,7 +609,8 @@ public class ConnectionHandler implements Runnable {
       new ErrorResponse(this, exception).send();
     } else {
       new ErrorResponse(this, exception).send();
-      new ReadyResponse(output, ReadyResponse.Status.IDLE).send();
+      ReadyResponse.sendIdleResponse(output);
+      output.flush();
     }
   }
 

--- a/src/main/java/com/google/cloud/spanner/pgadapter/statements/ExtendedQueryProtocolHandler.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/statements/ExtendedQueryProtocolHandler.java
@@ -218,10 +218,9 @@ public class ExtendedQueryProtocolHandler {
         throw PGExceptionFactory.newQueryCancelledException();
       }
       if (includeReadyResponse) {
-        new ReadyResponse(
-                connectionHandler.getConnectionMetadata().getOutputStream(),
-                getBackendConnection().getConnectionState().getReadyResponseStatus())
-            .send(false);
+        ReadyResponse.send(
+            connectionHandler.getConnectionMetadata().getOutputStream(),
+            getBackendConnection().getConnectionState().getReadyResponseStatus());
       }
     } catch (Throwable exception) {
       recordException(exception);

--- a/src/main/java/com/google/cloud/spanner/pgadapter/wireoutput/BindCompleteResponse.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/wireoutput/BindCompleteResponse.java
@@ -22,6 +22,12 @@ import java.text.MessageFormat;
 /** Assures to the client that a statement got bound to a portal successfully. */
 @InternalApi
 public class BindCompleteResponse extends WireOutput {
+  private static final byte[] RESPONSE = new byte[] {'2', 0, 0, 0, 4};
+
+  /** Send a standard BindComplete response message. */
+  public static void send(DataOutputStream output) throws IOException {
+    output.write(RESPONSE);
+  }
 
   public BindCompleteResponse(DataOutputStream output) {
     super(output, 4);

--- a/src/main/java/com/google/cloud/spanner/pgadapter/wireoutput/CloseCompleteResponse.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/wireoutput/CloseCompleteResponse.java
@@ -16,11 +16,18 @@ package com.google.cloud.spanner.pgadapter.wireoutput;
 
 import com.google.api.core.InternalApi;
 import java.io.DataOutputStream;
+import java.io.IOException;
 import java.text.MessageFormat;
 
 /** Assures to the client that a portal got closed successfully. */
 @InternalApi
 public class CloseCompleteResponse extends WireOutput {
+  private static final byte[] RESPONSE = new byte[] {'3', 0, 0, 0, 4};
+
+  /** Send a standard CloseResponse message. */
+  public static void send(DataOutputStream output) throws IOException {
+    output.write(RESPONSE);
+  }
 
   public CloseCompleteResponse(DataOutputStream output) {
     super(output, 4);

--- a/src/main/java/com/google/cloud/spanner/pgadapter/wireoutput/CommandCompleteResponse.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/wireoutput/CommandCompleteResponse.java
@@ -17,22 +17,40 @@ package com.google.cloud.spanner.pgadapter.wireoutput;
 import com.google.api.core.InternalApi;
 import java.io.DataOutputStream;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.text.MessageFormat;
 
 /** Signals to a client that an issued query is complete. */
 @InternalApi
 public class CommandCompleteResponse extends WireOutput {
-
+  private static final byte IDENTIFIER = 'C';
   private static final int HEADER_LENGTH = 4;
   private static final int NULL_TERMINATOR_LENGTH = 1;
 
   private static final byte NULL_TERMINATOR = 0;
 
+  /** Send a CommandComplete response. */
+  public static void send(DataOutputStream output, String command) throws IOException {
+    byte[] commandBytes = command.getBytes(StandardCharsets.UTF_8);
+    output.writeByte(IDENTIFIER);
+    output.writeInt(calculateLength(commandBytes));
+    output.write(commandBytes);
+    output.write(NULL_TERMINATOR);
+  }
+
+  private static int calculateLength(byte[] command) {
+    return HEADER_LENGTH + command.length + NULL_TERMINATOR_LENGTH;
+  }
+
   private final byte[] command;
 
   public CommandCompleteResponse(DataOutputStream output, String command) {
-    super(output, HEADER_LENGTH + command.getBytes(UTF8).length + NULL_TERMINATOR_LENGTH);
-    this.command = command.getBytes(UTF8);
+    this(output, command.getBytes(UTF8));
+  }
+
+  private CommandCompleteResponse(DataOutputStream output, byte[] command) {
+    super(output, HEADER_LENGTH + command.length + NULL_TERMINATOR_LENGTH);
+    this.command = command;
   }
 
   @Override
@@ -43,7 +61,7 @@ public class CommandCompleteResponse extends WireOutput {
 
   @Override
   public byte getIdentifier() {
-    return 'C';
+    return IDENTIFIER;
   }
 
   @Override

--- a/src/main/java/com/google/cloud/spanner/pgadapter/wireoutput/ParseCompleteResponse.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/wireoutput/ParseCompleteResponse.java
@@ -22,6 +22,12 @@ import java.text.MessageFormat;
 /** Signals the end of a parse transaction. */
 @InternalApi
 public class ParseCompleteResponse extends WireOutput {
+  private static final byte[] RESPONSE = new byte[] {'1', 0, 0, 0, 4};
+
+  /** Send a standard ParseComplete response. */
+  public static void send(DataOutputStream output) throws IOException {
+    output.write(RESPONSE);
+  }
 
   public ParseCompleteResponse(DataOutputStream output) {
     super(output, 4);

--- a/src/main/java/com/google/cloud/spanner/pgadapter/wireoutput/PortalSuspendedResponse.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/wireoutput/PortalSuspendedResponse.java
@@ -16,11 +16,18 @@ package com.google.cloud.spanner.pgadapter.wireoutput;
 
 import com.google.api.core.InternalApi;
 import java.io.DataOutputStream;
+import java.io.IOException;
 import java.text.MessageFormat;
 
 /** Signals that there are more rows available. */
 @InternalApi
 public class PortalSuspendedResponse extends WireOutput {
+  private static final byte[] RESPONSE = new byte[] {'s', 0, 0, 0, 4};
+
+  /** Send a standard PortalSuspended response. */
+  public static void send(DataOutputStream output) throws IOException {
+    output.write(RESPONSE);
+  }
 
   public PortalSuspendedResponse(DataOutputStream output) {
     super(output, 4);

--- a/src/main/java/com/google/cloud/spanner/pgadapter/wireoutput/ReadyResponse.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/wireoutput/ReadyResponse.java
@@ -21,10 +21,44 @@ import java.io.IOException;
 import java.text.MessageFormat;
 
 /**
- * Signals readiness status to receieve messages (here we only tend to send Idle, which means ready)
+ * Signals readiness status to receive messages (here we only tend to send Idle, which means ready)
  */
 @InternalApi
 public class ReadyResponse extends WireOutput {
+  private static final byte[] IDLE_RESPONSE = new byte[] {'Z', 0, 0, 0, 5, (byte) Status.IDLE.c};
+  private static final byte[] TRANSACTION_RESPONSE =
+      new byte[] {'Z', 0, 0, 0, 5, (byte) Status.TRANSACTION.c};
+  private static final byte[] FAILED_RESPONSE =
+      new byte[] {'Z', 0, 0, 0, 5, (byte) Status.FAILED.c};
+
+  /** Send a ReadyResponse with the given status. */
+  public static void send(DataOutputStream output, Status status) throws IOException {
+    switch (status) {
+      case IDLE:
+        sendIdleResponse(output);
+        break;
+      case TRANSACTION:
+        sendTransactionResponse(output);
+        break;
+      case FAILED:
+        sendFailedResponse(output);
+        break;
+      default:
+        throw new IllegalArgumentException();
+    }
+  }
+
+  public static void sendIdleResponse(DataOutputStream output) throws IOException {
+    output.write(IDLE_RESPONSE);
+  }
+
+  public static void sendTransactionResponse(DataOutputStream output) throws IOException {
+    output.write(TRANSACTION_RESPONSE);
+  }
+
+  public static void sendFailedResponse(DataOutputStream output) throws IOException {
+    output.write(FAILED_RESPONSE);
+  }
 
   private final Status status;
 

--- a/src/main/java/com/google/cloud/spanner/pgadapter/wireprotocol/BindMessage.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/wireprotocol/BindMessage.java
@@ -107,7 +107,7 @@ public class BindMessage extends AbstractQueryProtocolMessage {
   public void flush() throws Exception {
     if (isExtendedProtocol()) {
       // The simple query protocol does not expect a BindComplete response.
-      new BindCompleteResponse(this.outputStream).send(false);
+      BindCompleteResponse.send(this.outputStream);
     }
   }
 

--- a/src/main/java/com/google/cloud/spanner/pgadapter/wireprotocol/BootstrapMessage.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/wireprotocol/BootstrapMessage.java
@@ -22,7 +22,6 @@ import com.google.cloud.spanner.pgadapter.wireoutput.KeyDataResponse;
 import com.google.cloud.spanner.pgadapter.wireoutput.NoticeResponse;
 import com.google.cloud.spanner.pgadapter.wireoutput.ParameterStatusResponse;
 import com.google.cloud.spanner.pgadapter.wireoutput.ReadyResponse;
-import com.google.cloud.spanner.pgadapter.wireoutput.ReadyResponse.Status;
 import java.io.DataOutputStream;
 import java.nio.charset.StandardCharsets;
 import java.time.ZoneId;
@@ -171,6 +170,7 @@ public abstract class BootstrapMessage extends WireMessage {
     for (NoticeResponse noticeResponse : startupNotices) {
       noticeResponse.send(false);
     }
-    new ReadyResponse(output, Status.IDLE).send();
+    ReadyResponse.sendIdleResponse(output);
+    output.flush();
   }
 }

--- a/src/main/java/com/google/cloud/spanner/pgadapter/wireprotocol/CloseMessage.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/wireprotocol/CloseMessage.java
@@ -51,7 +51,7 @@ public class CloseMessage extends ControlMessage {
     this.statement = statement;
   }
 
-  /** Close the statement server-side and clean up by deleting their metdata locally. */
+  /** Close the statement server-side and clean up by deleting their metadata locally. */
   @Override
   protected void sendPayload() throws Exception {
     if (this.statement != null) {
@@ -62,7 +62,8 @@ public class CloseMessage extends ControlMessage {
         this.connection.closeStatement(this.name);
       }
     }
-    new CloseCompleteResponse(this.outputStream).send();
+    CloseCompleteResponse.send(this.outputStream);
+    this.outputStream.flush();
   }
 
   @Override

--- a/src/main/java/com/google/cloud/spanner/pgadapter/wireprotocol/ControlMessage.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/wireprotocol/ControlMessage.java
@@ -266,11 +266,11 @@ public abstract class ControlMessage extends WireMessage {
       switch (statement.getStatementType()) {
         case DDL:
         case UNKNOWN:
-          new CommandCompleteResponse(this.outputStream, command).send(false);
+          CommandCompleteResponse.send(this.outputStream, command);
           break;
         case CLIENT_SIDE:
           if (statement.getStatementResult().getResultType() != ResultType.RESULT_SET) {
-            new CommandCompleteResponse(this.outputStream, command).send(false);
+            CommandCompleteResponse.send(this.outputStream, command);
             break;
           }
           // fallthrough to QUERY
@@ -280,13 +280,12 @@ public abstract class ControlMessage extends WireMessage {
             SendResultSetState state = sendResultSet(statement, mode, maxRows);
             statement.setHasMoreData(state.hasMoreRows());
             if (state.hasMoreRows() && mode == QueryMode.EXTENDED) {
-              new PortalSuspendedResponse(this.outputStream).send(false);
+              PortalSuspendedResponse.send(this.outputStream);
             } else {
               if (!state.hasMoreRows() && mode == QueryMode.EXTENDED) {
                 statement.close();
               }
-              new CommandCompleteResponse(this.outputStream, state.getCommandAndNumRows())
-                  .send(false);
+              CommandCompleteResponse.send(this.outputStream, state.getCommandAndNumRows());
             }
           } else {
             // For an INSERT command, the tag is INSERT oid rows, where rows is the number of rows
@@ -294,7 +293,7 @@ public abstract class ControlMessage extends WireMessage {
             // target table had OIDs, but OIDs system columns are not supported anymore; therefore
             // oid is always 0.
             command += ("INSERT".equals(command) ? " 0 " : " ") + statement.getUpdateCount();
-            new CommandCompleteResponse(this.outputStream, command).send(false);
+            CommandCompleteResponse.send(this.outputStream, command);
           }
           break;
         default:

--- a/src/main/java/com/google/cloud/spanner/pgadapter/wireprotocol/ParseMessage.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/wireprotocol/ParseMessage.java
@@ -297,7 +297,7 @@ public class ParseMessage extends AbstractQueryProtocolMessage {
       handleError(statement.getException());
     } else if (isExtendedProtocol()) {
       // The simple query protocol does not need the ParseComplete response.
-      new ParseCompleteResponse(this.outputStream).send(false);
+      ParseCompleteResponse.send(this.outputStream);
     }
   }
 


### PR DESCRIPTION
Reduce the number of objects that are being created by just sending simple responses directly, instead of first creating a response object and then sending that.