### PR TITLE
deps: bump Spanner client library to 6.90.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,6 +76,13 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
+        <groupId>com.google.cloud</groupId>
+        <artifactId>google-cloud-spanner-bom</artifactId>
+        <version>6.90.0</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
         <groupId>io.opentelemetry</groupId>
         <artifactId>opentelemetry-bom</artifactId>
         <version>1.48.0</version>

--- a/src/test/golang/pgadapter_pgx5_tests/pgx.go
+++ b/src/test/golang/pgadapter_pgx5_tests/pgx.go
@@ -977,12 +977,22 @@ func TestReadWriteTransactionIsolationLevelRepeatableRead(connString string) *C.
 	}
 	defer conn.Close(ctx)
 
-	_, err = conn.BeginTx(ctx, pgx.TxOptions{IsoLevel: pgx.RepeatableRead})
-	if err == nil {
-		return C.CString("missing expected error for BeginTx with isolation level RepeatableRead")
+	tx, err := conn.BeginTx(ctx, pgx.TxOptions{IsoLevel: pgx.RepeatableRead})
+	if err != nil {
+		return C.CString(fmt.Sprintf("failed to begin transaction: %v", err.Error()))
 	}
-	if g, w := err.Error(), "ERROR: Unknown statement: begin isolation level repeatable read (SQLSTATE P0001)"; g != w {
-		return C.CString(fmt.Sprintf("error mismatch\nGot:  %v\nWant: %v", g, w))
+
+	var value int64
+	err = tx.QueryRow(ctx, "SELECT 1").Scan(&value)
+	if err != nil {
+		return C.CString(err.Error())
+	}
+	if g, w := value, int64(1); g != w {
+		return C.CString(fmt.Sprintf("value mismatch\n Got: %v\nWant: %v", g, w))
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return C.CString(fmt.Sprintf("failed to commit transaction: %v", err))
 	}
 
 	return nil

--- a/src/test/golang/pgadapter_pgx_tests/pgx.go
+++ b/src/test/golang/pgadapter_pgx_tests/pgx.go
@@ -997,12 +997,22 @@ func TestReadWriteTransactionIsolationLevelRepeatableRead(connString string) *C.
 	}
 	defer conn.Close(ctx)
 
-	_, err = conn.BeginTx(ctx, pgx.TxOptions{IsoLevel: pgx.RepeatableRead})
-	if err == nil {
-		return C.CString("missing expected error for BeginTx with isolation level RepeatableRead")
+	tx, err := conn.BeginTx(ctx, pgx.TxOptions{IsoLevel: pgx.RepeatableRead})
+	if err != nil {
+		return C.CString(fmt.Sprintf("failed to begin transaction: %v", err.Error()))
 	}
-	if g, w := err.Error(), "ERROR: Unknown statement: begin isolation level repeatable read (SQLSTATE P0001)"; g != w {
-		return C.CString(fmt.Sprintf("error mismatch\nGot:  %v\nWant: %v", g, w))
+
+	var value int64
+	err = tx.QueryRow(ctx, "SELECT 1").Scan(&value)
+	if err != nil {
+		return C.CString(err.Error())
+	}
+	if g, w := value, int64(1); g != w {
+		return C.CString(fmt.Sprintf("value mismatch\n Got: %v\nWant: %v", g, w))
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return C.CString(fmt.Sprintf("failed to commit transaction: %v", err))
 	}
 
 	return nil

--- a/src/test/java/com/google/cloud/spanner/pgadapter/JdbcMockServerTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/JdbcMockServerTest.java
@@ -71,6 +71,7 @@ import com.google.spanner.v1.RollbackRequest;
 import com.google.spanner.v1.Session;
 import com.google.spanner.v1.StructType;
 import com.google.spanner.v1.StructType.Field;
+import com.google.spanner.v1.TransactionOptions.IsolationLevel;
 import com.google.spanner.v1.Type;
 import com.google.spanner.v1.TypeAnnotationCode;
 import com.google.spanner.v1.TypeCode;
@@ -5777,6 +5778,120 @@ public class JdbcMockServerTest extends AbstractMockServerTest {
       mockSpanner.unfreeze();
       executor.shutdown();
     }
+  }
+
+  @Test
+  public void testDefaultIsolationLevel() throws SQLException {
+    try (Connection connection = DriverManager.getConnection(createUrl())) {
+      connection.setAutoCommit(false);
+      try (java.sql.Statement statement = connection.createStatement()) {
+        assertEquals(UPDATE_COUNT, statement.executeUpdate(UPDATE_STATEMENT.getSql()));
+        connection.commit();
+
+        assertEquals(1, mockSpanner.countRequestsOfType(ExecuteSqlRequest.class));
+        ExecuteSqlRequest request = mockSpanner.getRequestsOfType(ExecuteSqlRequest.class).get(0);
+        assertTrue(request.hasTransaction());
+        assertTrue(request.getTransaction().hasBegin());
+        assertEquals(
+            IsolationLevel.ISOLATION_LEVEL_UNSPECIFIED,
+            request.getTransaction().getBegin().getIsolationLevel());
+      }
+    }
+  }
+
+  @Test
+  public void testIsolationLevel() throws SQLException {
+    try (Connection connection = DriverManager.getConnection(createUrl())) {
+      connection.setAutoCommit(false);
+      for (int isolation :
+          new int[] {Connection.TRANSACTION_SERIALIZABLE, Connection.TRANSACTION_REPEATABLE_READ}) {
+        connection.setTransactionIsolation(isolation);
+        try (java.sql.Statement statement = connection.createStatement()) {
+          assertEquals(UPDATE_COUNT, statement.executeUpdate(UPDATE_STATEMENT.getSql()));
+          connection.commit();
+
+          assertEquals(1, mockSpanner.countRequestsOfType(ExecuteSqlRequest.class));
+          ExecuteSqlRequest request = mockSpanner.getRequestsOfType(ExecuteSqlRequest.class).get(0);
+          assertTrue(request.hasTransaction());
+          assertTrue(request.getTransaction().hasBegin());
+          assertEquals(
+              translationIsolationLevel(isolation),
+              request.getTransaction().getBegin().getIsolationLevel());
+
+          mockSpanner.clearRequests();
+        }
+      }
+    }
+  }
+
+  @Test
+  public void testIsolationLevelAutoCommit() throws SQLException {
+    try (Connection connection = DriverManager.getConnection(createUrl())) {
+      for (int isolation :
+          new int[] {Connection.TRANSACTION_SERIALIZABLE, Connection.TRANSACTION_REPEATABLE_READ}) {
+        connection.setTransactionIsolation(isolation);
+        try (java.sql.Statement statement = connection.createStatement()) {
+          assertEquals(UPDATE_COUNT, statement.executeUpdate(UPDATE_STATEMENT.getSql()));
+
+          assertEquals(1, mockSpanner.countRequestsOfType(ExecuteSqlRequest.class));
+          ExecuteSqlRequest request = mockSpanner.getRequestsOfType(ExecuteSqlRequest.class).get(0);
+          assertTrue(request.hasTransaction());
+          assertTrue(request.getTransaction().hasBegin());
+          assertEquals(
+              translationIsolationLevel(isolation),
+              request.getTransaction().getBegin().getIsolationLevel());
+
+          mockSpanner.clearRequests();
+        }
+      }
+    }
+  }
+
+  @Test
+  public void testIsolationLevelForOneTransaction() throws SQLException {
+    try (Connection connection = DriverManager.getConnection(createUrl())) {
+      connection.setAutoCommit(false);
+      for (int isolation :
+          new int[] {Connection.TRANSACTION_SERIALIZABLE, Connection.TRANSACTION_REPEATABLE_READ}) {
+        try (java.sql.Statement statement = connection.createStatement()) {
+          statement.execute("set transaction isolation level " + getIsolationLevelName(isolation));
+          assertEquals(UPDATE_COUNT, statement.executeUpdate(UPDATE_STATEMENT.getSql()));
+          connection.commit();
+
+          assertEquals(1, mockSpanner.countRequestsOfType(ExecuteSqlRequest.class));
+          ExecuteSqlRequest request = mockSpanner.getRequestsOfType(ExecuteSqlRequest.class).get(0);
+          assertTrue(request.hasTransaction());
+          assertTrue(request.getTransaction().hasBegin());
+          // TODO: Change this when https://github.com/googleapis/java-spanner/pull/3718 has been
+          // released and merged into PGAdapter.
+          assertEquals(
+              IsolationLevel.ISOLATION_LEVEL_UNSPECIFIED,
+              request.getTransaction().getBegin().getIsolationLevel());
+
+          mockSpanner.clearRequests();
+        }
+      }
+    }
+  }
+
+  private static IsolationLevel translationIsolationLevel(int jdbcLevel) {
+    switch (jdbcLevel) {
+      case Connection.TRANSACTION_SERIALIZABLE:
+        return IsolationLevel.SERIALIZABLE;
+      case Connection.TRANSACTION_REPEATABLE_READ:
+        return IsolationLevel.REPEATABLE_READ;
+    }
+    throw new IllegalArgumentException();
+  }
+
+  private static String getIsolationLevelName(int jdbcLevel) {
+    switch (jdbcLevel) {
+      case Connection.TRANSACTION_SERIALIZABLE:
+        return "serializable";
+      case Connection.TRANSACTION_REPEATABLE_READ:
+        return "repeatable read";
+    }
+    throw new IllegalArgumentException();
   }
 
   private void verifySelect1(java.sql.Statement statement) throws SQLException {

--- a/src/test/java/com/google/cloud/spanner/pgadapter/golang/Pgx5MockServerTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/golang/Pgx5MockServerTest.java
@@ -51,6 +51,7 @@ import com.google.spanner.v1.ResultSetStats;
 import com.google.spanner.v1.RollbackRequest;
 import com.google.spanner.v1.StructType;
 import com.google.spanner.v1.StructType.Field;
+import com.google.spanner.v1.TransactionOptions.IsolationLevel;
 import com.google.spanner.v1.Type;
 import com.google.spanner.v1.TypeCode;
 import io.grpc.Status;
@@ -1315,6 +1316,9 @@ public class Pgx5MockServerTest extends AbstractMockServerTest {
 
     assertTrue(describeRequest.getTransaction().hasBegin());
     assertTrue(describeRequest.getTransaction().getBegin().hasReadWrite());
+    assertEquals(
+        IsolationLevel.SERIALIZABLE,
+        describeRequest.getTransaction().getBegin().getIsolationLevel());
     assertTrue(executeRequest.getTransaction().hasId());
 
     assertEquals(1, mockSpanner.countRequestsOfType(CommitRequest.class));
@@ -1326,7 +1330,20 @@ public class Pgx5MockServerTest extends AbstractMockServerTest {
 
     assertNull(res);
 
-    assertEquals(0, mockSpanner.countRequestsOfType(ExecuteSqlRequest.class));
+    assertEquals(2, mockSpanner.countRequestsOfType(ExecuteSqlRequest.class));
+    ExecuteSqlRequest describeRequest =
+        mockSpanner.getRequestsOfType(ExecuteSqlRequest.class).get(0);
+    ExecuteSqlRequest executeRequest =
+        mockSpanner.getRequestsOfType(ExecuteSqlRequest.class).get(1);
+
+    assertTrue(describeRequest.getTransaction().hasBegin());
+    assertTrue(describeRequest.getTransaction().getBegin().hasReadWrite());
+    assertEquals(
+        IsolationLevel.REPEATABLE_READ,
+        describeRequest.getTransaction().getBegin().getIsolationLevel());
+    assertTrue(executeRequest.getTransaction().hasId());
+
+    assertEquals(1, mockSpanner.countRequestsOfType(CommitRequest.class));
   }
 
   @Test

--- a/src/test/java/com/google/cloud/spanner/pgadapter/golang/PgxMockServerTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/golang/PgxMockServerTest.java
@@ -27,6 +27,7 @@ import com.google.cloud.spanner.Dialect;
 import com.google.cloud.spanner.ErrorCode;
 import com.google.cloud.spanner.MockSpannerServiceImpl.StatementResult;
 import com.google.cloud.spanner.SpannerExceptionFactory;
+import com.google.cloud.spanner.SpannerOptions;
 import com.google.cloud.spanner.Statement;
 import com.google.cloud.spanner.pgadapter.AbstractMockServerTest;
 import com.google.cloud.spanner.pgadapter.CopyInMockServerTest;
@@ -49,6 +50,7 @@ import com.google.spanner.v1.ResultSetStats;
 import com.google.spanner.v1.RollbackRequest;
 import com.google.spanner.v1.StructType;
 import com.google.spanner.v1.StructType.Field;
+import com.google.spanner.v1.TransactionOptions.IsolationLevel;
 import com.google.spanner.v1.Type;
 import com.google.spanner.v1.TypeCode;
 import io.grpc.Status;
@@ -1301,6 +1303,9 @@ public class PgxMockServerTest extends AbstractMockServerTest {
 
     assertTrue(describeRequest.getTransaction().hasBegin());
     assertTrue(describeRequest.getTransaction().getBegin().hasReadWrite());
+    assertEquals(
+        IsolationLevel.SERIALIZABLE,
+        describeRequest.getTransaction().getBegin().getIsolationLevel());
     assertTrue(executeRequest.getTransaction().hasId());
 
     assertEquals(1, mockSpanner.countRequestsOfType(CommitRequest.class));
@@ -1309,10 +1314,24 @@ public class PgxMockServerTest extends AbstractMockServerTest {
   @Test
   public void testReadWriteTransactionIsolationLevelRepeatableRead() {
     String res = pgxTest.TestReadWriteTransactionIsolationLevelRepeatableRead(createConnString());
+    SpannerOptions.enableOpenTelemetryMetrics();
 
     assertNull(res);
 
-    assertEquals(0, mockSpanner.countRequestsOfType(ExecuteSqlRequest.class));
+    assertEquals(2, mockSpanner.countRequestsOfType(ExecuteSqlRequest.class));
+    ExecuteSqlRequest describeRequest =
+        mockSpanner.getRequestsOfType(ExecuteSqlRequest.class).get(0);
+    ExecuteSqlRequest executeRequest =
+        mockSpanner.getRequestsOfType(ExecuteSqlRequest.class).get(1);
+
+    assertTrue(describeRequest.getTransaction().hasBegin());
+    assertTrue(describeRequest.getTransaction().getBegin().hasReadWrite());
+    assertEquals(
+        IsolationLevel.REPEATABLE_READ,
+        describeRequest.getTransaction().getBegin().getIsolationLevel());
+    assertTrue(executeRequest.getTransaction().hasId());
+
+    assertEquals(1, mockSpanner.countRequestsOfType(CommitRequest.class));
   }
 
   @Test

--- a/src/test/java/com/google/cloud/spanner/pgadapter/python/psycopg2/PythonTransactionTests.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/python/psycopg2/PythonTransactionTests.java
@@ -740,104 +740,6 @@ public class PythonTransactionTests extends AbstractPsycopg2Test {
   }
 
   @Test
-  public void testUnsupportedIsolationLevelsSessionInTransactions() throws Exception {
-    // tests isolation_level settings for unsupported isolation levels using set_session function
-    List<String> unsupportedIsolationLevels = Arrays.asList("1", "2", "4");
-
-    String sql1 = "Select * from some_table";
-    String sql2 = "insert into some_table(col1, col2) values(value1, value2)";
-    String sql3 = "Select * from some_table3";
-    String sql4 = "insert into some_table3(col1, col2) values(value1, value2)";
-
-    mockSpanner.putStatementResult(
-        StatementResult.query(Statement.of(sql1), createResultSet(1, "abcd")));
-    mockSpanner.putStatementResult(StatementResult.update(Statement.of(sql2), 1));
-    mockSpanner.putStatementResult(
-        StatementResult.query(Statement.of(sql3), createResultSet(2, "pqrs")));
-    mockSpanner.putStatementResult(StatementResult.update(Statement.of(sql4), 2));
-
-    for (String unsupportedIsolationLevel : unsupportedIsolationLevels) {
-      List<String> statements = new ArrayList<>();
-
-      // query will be executed as expected
-      statements.add("query");
-      statements.add(sql1);
-
-      // update will be executed as expected
-      statements.add("update");
-      statements.add(sql2);
-
-      // 1 commit request will be sent
-      statements.add("transaction");
-      statements.add("commit");
-
-      statements.add("transaction");
-      statements.add("set session isolation_level " + unsupportedIsolationLevel);
-
-      // query won't be executed because the previous setting would've thrown error, except for
-      // pgVersion=1.0 and isolationLevel=2.
-      statements.add("query");
-      statements.add(sql3);
-
-      String isolationLevel;
-      switch (unsupportedIsolationLevel) {
-        case "1":
-          isolationLevel = "READ COMMITTED";
-          break;
-        case "2":
-          isolationLevel = "REPEATABLE READ";
-          break;
-        case "4":
-          isolationLevel = "READ UNCOMMITTED";
-          // psycopg2 auto-converts READ UNCOMMITTED to READ COMMITTED for old PG versions.
-          if (pgVersion.equals("1.0")) {
-            isolationLevel = "READ COMMITTED";
-          }
-          break;
-        default:
-          isolationLevel = unsupportedIsolationLevel;
-      }
-      String expectedOutput =
-          "(1, 'abcd')\n"
-              + "1\n"
-              + (unsupportedIsolationLevel.equals("2")
-                  ? "(2, 'pqrs')\n"
-                  : String.format(
-                      "Unknown value for TRANSACTION: ISOLATION LEVEL %s\n", isolationLevel));
-
-      String actualOutput =
-          executeTransactions(pgVersion, host, pgServer.getLocalPort(), statements);
-      assertEquals(expectedOutput, actualOutput);
-
-      List<AbstractMessage> requests = mockSpanner.getRequests();
-      requests =
-          requests.stream()
-              .filter(
-                  request ->
-                      !request.getClass().equals(BatchCreateSessionsRequest.class)
-                          && !request.getClass().equals(RollbackRequest.class))
-              .collect(Collectors.toList());
-      if (pgVersion.equals("1.0") && unsupportedIsolationLevel.equals("2")) {
-        assertEquals(1, mockSpanner.countRequestsOfType(CommitRequest.class));
-        assertEquals(3, mockSpanner.countRequestsOfType(ExecuteSqlRequest.class));
-      } else {
-        assertEquals(1, mockSpanner.countRequestsOfType(CommitRequest.class));
-        assertEquals(2, mockSpanner.countRequestsOfType(ExecuteSqlRequest.class));
-      }
-
-      assertEquals(ExecuteSqlRequest.class, requests.get(0).getClass());
-      assertEquals(sql1, ((ExecuteSqlRequest) requests.get(0)).getSql());
-
-      assertEquals(ExecuteSqlRequest.class, requests.get(1).getClass());
-      assertEquals(sql2, ((ExecuteSqlRequest) requests.get(1)).getSql());
-
-      assertEquals(CommitRequest.class, requests.get(2).getClass());
-
-      mockSpanner.clearRequests();
-    }
-  }
-
-  @Test
   public void testSupportedIsolationLevelInTransactions() throws Exception {
     // tests supported isolation_level settings using connection.isolation_level variable
     List<String> statements = new ArrayList<>();
@@ -1218,9 +1120,9 @@ public class PythonTransactionTests extends AbstractPsycopg2Test {
 
     int expectedCommits = "14.1".equals(pgVersion) ? 1 : 2;
     int expectedExecuteRequests = "14.1".equals(pgVersion) ? 3 : 4;
-    assertEquals(expectedCommits, mockSpanner.countRequestsOfType(CommitRequest.class));
+    assertEquals(2, mockSpanner.countRequestsOfType(CommitRequest.class));
     assertEquals(0, mockSpanner.countRequestsOfType(RollbackRequest.class));
-    assertEquals(expectedExecuteRequests, mockSpanner.countRequestsOfType(ExecuteSqlRequest.class));
+    assertEquals(4, mockSpanner.countRequestsOfType(ExecuteSqlRequest.class));
 
     List<AbstractMessage> requests = mockSpanner.getRequests();
     requests =
@@ -1228,7 +1130,7 @@ public class PythonTransactionTests extends AbstractPsycopg2Test {
             .filter(request -> !request.getClass().equals(BatchCreateSessionsRequest.class))
             .collect(Collectors.toList());
 
-    assertEquals(expectedCommits + expectedExecuteRequests, requests.size());
+    assertEquals(6, requests.size());
 
     assertEquals(ExecuteSqlRequest.class, requests.get(0).getClass());
     assertEquals(sql1, ((ExecuteSqlRequest) requests.get(0)).getSql());
@@ -1312,9 +1214,9 @@ public class PythonTransactionTests extends AbstractPsycopg2Test {
 
     int expectedCommits = "14.1".equals(pgVersion) ? 1 : 2;
     int expectedExecuteRequests = "14.1".equals(pgVersion) ? 3 : 4;
-    assertEquals(expectedCommits, mockSpanner.countRequestsOfType(CommitRequest.class));
+    assertEquals(2, mockSpanner.countRequestsOfType(CommitRequest.class));
     assertEquals(0, mockSpanner.countRequestsOfType(RollbackRequest.class));
-    assertEquals(expectedExecuteRequests, mockSpanner.countRequestsOfType(ExecuteSqlRequest.class));
+    assertEquals(4, mockSpanner.countRequestsOfType(ExecuteSqlRequest.class));
 
     List<AbstractMessage> requests = mockSpanner.getRequests();
     requests =
@@ -1322,7 +1224,7 @@ public class PythonTransactionTests extends AbstractPsycopg2Test {
             .filter(request -> !request.getClass().equals(BatchCreateSessionsRequest.class))
             .collect(Collectors.toList());
 
-    assertEquals(expectedCommits + expectedExecuteRequests, requests.size());
+    assertEquals(6, requests.size());
 
     assertEquals(ExecuteSqlRequest.class, requests.get(0).getClass());
     assertEquals(sql1, ((ExecuteSqlRequest) requests.get(0)).getSql());

--- a/src/test/java/com/google/cloud/spanner/pgadapter/python/psycopg2/PythonTransactionTests.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/python/psycopg2/PythonTransactionTests.java
@@ -800,12 +800,10 @@ public class PythonTransactionTests extends AbstractPsycopg2Test {
       String expectedOutput =
           "(1, 'abcd')\n"
               + "1\n"
-              + ("14.1".equals(pgVersion)
-                  ? String.format("Unknown statement: BEGIN ISOLATION LEVEL %s\n", isolationLevel)
-                  : unsupportedIsolationLevel.equals("2")
-                      ? "(2, 'pqrs')\n" // 2 == READ COMMITTED is translated if version < 9.1
-                      : String.format(
-                          "Unknown value for TRANSACTION: ISOLATION LEVEL %s\n", isolationLevel));
+              + (unsupportedIsolationLevel.equals("2")
+                  ? "(2, 'pqrs')\n"
+                  : String.format(
+                      "Unknown value for TRANSACTION: ISOLATION LEVEL %s\n", isolationLevel));
 
       String actualOutput =
           executeTransactions(pgVersion, host, pgServer.getLocalPort(), statements);
@@ -1214,13 +1212,7 @@ public class PythonTransactionTests extends AbstractPsycopg2Test {
         StatementResult.query(Statement.of(sql3), createResultSet(2, "pqrs")));
     mockSpanner.putStatementResult(StatementResult.update(Statement.of(sql4), 2));
 
-    String expectedOutput =
-        "(1, 'abcd')\n"
-            + "1\n"
-            + "2\n"
-            + ("14.1".equals(pgVersion)
-                ? "Unknown statement: BEGIN ISOLATION LEVEL REPEATABLE READ\n"
-                : "(2, 'pqrs')\n");
+    String expectedOutput = "(1, 'abcd')\n" + "1\n" + "2\n" + "(2, 'pqrs')\n";
     String actualOutput = executeTransactions(pgVersion, host, pgServer.getLocalPort(), statements);
     assertEquals(expectedOutput, actualOutput);
 
@@ -1314,13 +1306,7 @@ public class PythonTransactionTests extends AbstractPsycopg2Test {
     // Setting the isolation level to REPEATABLE READ works for versions lower than 9.1, because
     // psycopg2 thinks that the server does not support REPEATABLE READ, and will therefore
     // automatically convert it to SERIALIZABLE.
-    String expectedOutput =
-        "(1, 'abcd')\n"
-            + "1\n"
-            + "2\n"
-            + (pgVersion.equals("14.1")
-                ? "Unknown statement: BEGIN ISOLATION LEVEL REPEATABLE READ\n"
-                : "(2, 'pqrs')\n");
+    String expectedOutput = "(1, 'abcd')\n" + "1\n" + "2\n" + "(2, 'pqrs')\n";
     String actualOutput = executeTransactions(pgVersion, host, pgServer.getLocalPort(), statements);
     assertEquals(expectedOutput, actualOutput);
 
@@ -1477,16 +1463,12 @@ public class PythonTransactionTests extends AbstractPsycopg2Test {
 
     mockSpanner.putStatementResult(StatementResult.update(Statement.of(sql), 10));
 
-    String expectedOutput =
-        "14.1".equals(pgVersion)
-            ? "Unknown value for default_transaction_isolation: 'REPEATABLE READ'\n"
-            : "10\n";
+    String expectedOutput = "10\n";
     String actualOutput = executeTransactions(pgVersion, host, pgServer.getLocalPort(), statements);
     assertEquals(expectedOutput, actualOutput);
 
-    int expectedRequests = "14.1".equals(pgVersion) ? 0 : 1;
-    assertEquals(expectedRequests, mockSpanner.countRequestsOfType(CommitRequest.class));
-    assertEquals(expectedRequests, mockSpanner.countRequestsOfType(ExecuteSqlRequest.class));
+    assertEquals(1, mockSpanner.countRequestsOfType(CommitRequest.class));
+    assertEquals(1, mockSpanner.countRequestsOfType(ExecuteSqlRequest.class));
   }
 
   @Test
@@ -1577,7 +1559,7 @@ public class PythonTransactionTests extends AbstractPsycopg2Test {
 
     String expectedOutput =
         pgVersion.equals("14.1")
-            ? "Unknown statement: BEGIN ISOLATION LEVEL REPEATABLE READ READ ONLY NOT DEFERRABLE\n"
+            ? "Update statements are not allowed for read-only transactions\n"
             : "the 'deferrable' setting is only available from PostgreSQL 9.1\n";
     String actualOutput = executeTransactions(pgVersion, host, pgServer.getLocalPort(), statements);
 


### PR DESCRIPTION
Updates the Spanner client library to version 6.90.0. This version introduces support for isolation level repeatable read.