### PR TITLE
chore: disable tracking where sessions are checked out

### DIFF
--- a/src/main/java/com/google/cloud/spanner/PGAdapterSessionPoolOptionsHelper.java
+++ b/src/main/java/com/google/cloud/spanner/PGAdapterSessionPoolOptionsHelper.java
@@ -27,6 +27,9 @@ public class PGAdapterSessionPoolOptionsHelper {
   @InternalApi
   public static SessionPoolOptions.Builder useMultiplexedSessions(
       SessionPoolOptions.Builder builder) {
+    // Disable tracking where regular sessions are checked out, as debugging session leaks in
+    // PGAdapter should not be necessary.
+    builder.setTrackStackTraceOfSessionCheckout(false);
     return builder.setUseMultiplexedSession(true);
   }
 }


### PR DESCRIPTION
Skip tracking where sessions are checked out of the pool, as there should be no need to debug session leaks in PGAdapter. This feature creates an exception for every sesion that is checked out, which wastes a few CPU cycles for every transaction.