### PR TITLE
fix: ignore TCP-aliveness check connections

### DIFF
--- a/src/main/java/com/google/cloud/spanner/pgadapter/ConnectionHandler.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/ConnectionHandler.java
@@ -397,6 +397,13 @@ public class ConnectionHandler implements Runnable {
 
       try {
         this.message = this.server.recordMessage(BootstrapMessage.create(this));
+      } catch (EOFException ignore) {
+        // Just ignore the connection and close it if the client never sends us a valid startup
+        // message. This also prevents probers that just check for an open TCP port to cause errors
+        // to be logged.
+        return result;
+      }
+      try {
         if (!ssl
             && getServer().getOptions().getSslMode().isSslEnabled()
             && this.message instanceof SSLMessage) {

--- a/src/test/java/com/google/cloud/spanner/pgadapter/ProxyServerTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/ProxyServerTest.java
@@ -19,6 +19,7 @@ import static org.junit.Assert.assertTrue;
 
 import com.google.cloud.spanner.pgadapter.metadata.OptionsMetadata;
 import com.google.cloud.spanner.pgadapter.metadata.TestOptionsMetadataBuilder;
+import java.net.Socket;
 import java.time.Duration;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -26,6 +27,22 @@ import org.junit.runners.JUnit4;
 
 @RunWith(JUnit4.class)
 public class ProxyServerTest {
+
+  @Test
+  public void testProbeConnection() throws Exception {
+    // This test verifies that doing a simple TCP aliveness probe to check whether PGAdapter is
+    // running can be done without any errors.
+    ProxyServer server = new ProxyServer(OptionsMetadata.newBuilder().setPort(0).build());
+    server.startServer();
+    server.awaitRunning();
+
+    //noinspection EmptyTryBlock
+    try (Socket ignore = new Socket("localhost", server.getLocalPort())) {
+      // Do nothing, just verify that we can connect without any errors.
+    }
+    server.stopServer();
+    server.awaitTerminated();
+  }
 
   @Test
   public void testFailedStartProxyServer() {

--- a/src/test/java/com/google/cloud/spanner/pgadapter/wireprotocol/BoostrapMessageTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/wireprotocol/BoostrapMessageTest.java
@@ -70,7 +70,7 @@ public class BoostrapMessageTest {
 
     BootstrapMessage message = BootstrapMessage.create(connection);
     assertEquals(StartupMessage.class, message.getClass());
-    assertEquals(message.length, 1024);
+    assertEquals(1024, message.length);
   }
 
   @Test
@@ -83,7 +83,7 @@ public class BoostrapMessageTest {
 
     BootstrapMessage message = BootstrapMessage.create(connection);
     assertEquals(SSLMessage.class, message.getClass());
-    assertEquals(message.length, 8);
+    assertEquals(8, message.length);
   }
 
   @Test
@@ -96,7 +96,7 @@ public class BoostrapMessageTest {
 
     BootstrapMessage message = BootstrapMessage.create(connection);
     assertEquals(CancelMessage.class, message.getClass());
-    assertEquals(message.length, 16);
+    assertEquals(16, message.length);
   }
 
   @Test


### PR DESCRIPTION
Aliveness checks that only open a TCP connection to PGAdapter could cause an EOF error to be printed by PGAdapter, as these connections close while PGAdapter is waiting for a PostgreSQL startup message. This makes PGAdapter just ignore EOF failures at that point of the connection phase, as it is very likely that such a connection came from a TCP aliveness prober that checks whether PGAdapter is running or not.