### PR TITLE
chore: move control message creation to separate class

### DIFF
--- a/src/main/java/com/google/cloud/spanner/pgadapter/ProxyServer.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/ProxyServer.java
@@ -26,6 +26,7 @@ import com.google.cloud.spanner.pgadapter.metadata.OptionsMetadata;
 import com.google.cloud.spanner.pgadapter.metadata.OptionsMetadata.TextFormat;
 import com.google.cloud.spanner.pgadapter.statements.IntermediateStatement;
 import com.google.cloud.spanner.pgadapter.utils.Metrics;
+import com.google.cloud.spanner.pgadapter.wireprotocol.MessageReader;
 import com.google.cloud.spanner.pgadapter.wireprotocol.WireMessage;
 import com.google.common.collect.ImmutableList;
 import io.opentelemetry.api.OpenTelemetry;
@@ -69,6 +70,7 @@ public class ProxyServer extends AbstractApiService {
   private final Metrics metrics;
   private final Properties properties;
   private final List<ConnectionHandler> handlers = new LinkedList<>();
+  private final MessageReader messageReader;
 
   /**
    * Latch that is closed when the TCP server has started. We need this to know the exact port that
@@ -162,6 +164,7 @@ public class ProxyServer extends AbstractApiService {
   public ProxyServer(
       OptionsMetadata optionsMetadata, OpenTelemetry openTelemetry, Properties properties) {
     this.options = optionsMetadata;
+    this.messageReader = new MessageReader(optionsMetadata);
     this.openTelemetry = openTelemetry;
     this.metrics =
         optionsMetadata.isEnableOpenTelemetryMetrics()
@@ -174,6 +177,10 @@ public class ProxyServer extends AbstractApiService {
         ThreadFactoryUtil.createVirtualOrPlatformDaemonThreadFactory(
             "ConnectionHandler", optionsMetadata.isUseVirtualThreads());
     addConnectionProperties();
+  }
+
+  public MessageReader getMessageReader() {
+    return this.messageReader;
   }
 
   private void addConnectionProperties() {

--- a/src/main/java/com/google/cloud/spanner/pgadapter/wireprotocol/BindMessage.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/wireprotocol/BindMessage.java
@@ -47,9 +47,9 @@ public class BindMessage extends AbstractQueryProtocolMessage {
     super(connection);
     this.portalName = this.readString();
     this.statementName = this.readString();
-    this.formatCodes = getFormatCodes(this.inputStream);
+    this.formatCodes = MessageReader.getFormatCodes(this.inputStream);
     this.parameters = getParameters(this.inputStream);
-    this.resultFormatCodes = getFormatCodes(this.inputStream);
+    this.resultFormatCodes = MessageReader.getFormatCodes(this.inputStream);
     IntermediatePreparedStatement statement = connection.getStatement(statementName);
     this.statement =
         statement.createPortal(

--- a/src/main/java/com/google/cloud/spanner/pgadapter/wireprotocol/ControlMessage.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/wireprotocol/ControlMessage.java
@@ -15,7 +15,6 @@
 package com.google.cloud.spanner.pgadapter.wireprotocol;
 
 import static com.google.cloud.spanner.pgadapter.statements.BackendConnection.DB_STATEMENT;
-import static com.google.cloud.spanner.pgadapter.statements.IntermediatePortalStatement.NO_FORMAT_CODES;
 
 import com.google.api.core.InternalApi;
 import com.google.api.gax.grpc.GrpcCallContext;
@@ -32,12 +31,8 @@ import com.google.cloud.spanner.connection.Connection;
 import com.google.cloud.spanner.connection.StatementResult;
 import com.google.cloud.spanner.connection.StatementResult.ResultType;
 import com.google.cloud.spanner.pgadapter.ConnectionHandler;
-import com.google.cloud.spanner.pgadapter.ConnectionHandler.ConnectionStatus;
 import com.google.cloud.spanner.pgadapter.ConnectionHandler.QueryMode;
-import com.google.cloud.spanner.pgadapter.error.PGException;
 import com.google.cloud.spanner.pgadapter.error.PGExceptionFactory;
-import com.google.cloud.spanner.pgadapter.error.SQLState;
-import com.google.cloud.spanner.pgadapter.error.Severity;
 import com.google.cloud.spanner.pgadapter.metadata.SendResultSetState;
 import com.google.cloud.spanner.pgadapter.statements.BackendConnection.PartitionQueryResult;
 import com.google.cloud.spanner.pgadapter.statements.CopyToStatement;
@@ -61,7 +56,6 @@ import io.grpc.MethodDescriptor;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.context.Scope;
-import java.io.DataInputStream;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
@@ -107,117 +101,6 @@ public abstract class ControlMessage extends WireMessage {
 
   public boolean isExtendedProtocol() {
     return manuallyCreatedToken == null;
-  }
-
-  /**
-   * Factory method to create the message from the specific command type char.
-   *
-   * @param connection The connection handler object setup with the ability to send/receive.
-   * @return The constructed wire message given the input message.
-   * @throws Exception If construction or reading fails.
-   */
-  public static ControlMessage create(ConnectionHandler connection) throws Exception {
-    boolean validMessage = true;
-    char nextMsg = (char) connection.getConnectionMetadata().getInputStream().readUnsignedByte();
-    try {
-      if (connection.getStatus() == ConnectionStatus.COPY_IN) {
-        switch (nextMsg) {
-          case CopyDoneMessage.IDENTIFIER:
-            return new CopyDoneMessage(connection);
-          case CopyDataMessage.IDENTIFIER:
-            return new CopyDataMessage(connection);
-          case CopyFailMessage.IDENTIFIER:
-            return new CopyFailMessage(connection);
-          case SyncMessage.IDENTIFIER:
-          case FlushMessage.IDENTIFIER:
-            // Skip sync/flush in COPY_IN. This is consistent with real PostgreSQL which also does
-            // this to accommodate clients that do not check what type of statement they sent in an
-            // ExecuteMessage, and instead always blindly send a flush/sync after each execute.
-            return SkipMessage.createForValidStream(connection);
-          default:
-            // Skip other unexpected messages and throw an exception to fail the copy operation.
-            validMessage = false;
-            SkipMessage.createForInvalidStream(connection);
-            throw new IllegalStateException(
-                String.format(
-                    "Expected CopyData ('d'), CopyDone ('c') or CopyFail ('f') messages, got: '%c'",
-                    nextMsg));
-        }
-      } else {
-        switch (nextMsg) {
-          case QueryMessage.IDENTIFIER:
-            return new QueryMessage(connection);
-          case ParseMessage.IDENTIFIER:
-            return new ParseMessage(connection);
-          case BindMessage.IDENTIFIER:
-            return new BindMessage(connection);
-          case DescribeMessage.IDENTIFIER:
-            return new DescribeMessage(connection);
-          case ExecuteMessage.IDENTIFIER:
-            return new ExecuteMessage(connection);
-          case CloseMessage.IDENTIFIER:
-            return new CloseMessage(connection);
-          case TerminateMessage.IDENTIFIER:
-            return new TerminateMessage(connection);
-          case FunctionCallMessage.IDENTIFIER:
-            return new FunctionCallMessage(connection);
-          case FlushMessage.IDENTIFIER:
-            return new FlushMessage(connection);
-          case SyncMessage.IDENTIFIER:
-            return new SyncMessage(connection);
-          case CopyDoneMessage.IDENTIFIER:
-          case CopyDataMessage.IDENTIFIER:
-          case CopyFailMessage.IDENTIFIER:
-            // Silently skip COPY messages in non-COPY mode. This is consistent with the PG wire
-            // protocol. If we continue to receive COPY messages while in non-COPY mode, we'll
-            // terminate the connection to prevent the server from being flooded with invalid
-            // messages.
-            validMessage = false;
-            // Note: The stream itself is still valid as we received a message that we recognized.
-            return SkipMessage.createForValidStream(connection);
-          default:
-            throw new IllegalStateException(String.format("Unknown message: %c", nextMsg));
-        }
-      }
-    } finally {
-      if (validMessage) {
-        connection.clearInvalidMessageCount();
-      } else {
-        connection.increaseInvalidMessageCount();
-        if (connection.getInvalidMessageCount() > MAX_INVALID_MESSAGE_COUNT) {
-          new ErrorResponse(
-                  connection,
-                  PGException.newBuilder(
-                          String.format(
-                              "Received %d invalid/unexpected messages. Last received message: '%c'",
-                              connection.getInvalidMessageCount(), nextMsg))
-                      .setSQLState(SQLState.ProtocolViolation)
-                      .setSeverity(Severity.FATAL)
-                      .build())
-              .send();
-          connection.setStatus(ConnectionStatus.TERMINATED);
-        }
-      }
-    }
-  }
-
-  /**
-   * Extract format codes from message (useful for both input and output format codes).
-   *
-   * @param input The data stream containing the user request.
-   * @return A list of format codes.
-   * @throws Exception If reading fails in any way.
-   */
-  protected static short[] getFormatCodes(DataInputStream input) throws Exception {
-    short numberOfFormatCodes = input.readShort();
-    if (numberOfFormatCodes == 0) {
-      return NO_FORMAT_CODES;
-    }
-    short[] formatCodes = new short[numberOfFormatCodes];
-    for (int i = 0; i < numberOfFormatCodes; i++) {
-      formatCodes[i] = input.readShort();
-    }
-    return formatCodes;
   }
 
   public enum PreparedType {

--- a/src/main/java/com/google/cloud/spanner/pgadapter/wireprotocol/FunctionCallMessage.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/wireprotocol/FunctionCallMessage.java
@@ -37,7 +37,7 @@ public class FunctionCallMessage extends ControlMessage {
   public FunctionCallMessage(ConnectionHandler connection) throws Exception {
     super(connection);
     this.functionID = this.inputStream.readInt();
-    this.argumentFormatCodes = getFormatCodes(this.inputStream);
+    this.argumentFormatCodes = MessageReader.getFormatCodes(this.inputStream);
     this.arguments = getParameters(this.inputStream);
     this.resultFormatCode = this.inputStream.readShort();
   }

--- a/src/main/java/com/google/cloud/spanner/pgadapter/wireprotocol/MessageReader.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/wireprotocol/MessageReader.java
@@ -1,0 +1,158 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.cloud.spanner.pgadapter.wireprotocol;
+
+import static com.google.cloud.spanner.pgadapter.statements.IntermediatePortalStatement.NO_FORMAT_CODES;
+
+import com.google.api.core.InternalApi;
+import com.google.cloud.spanner.pgadapter.ConnectionHandler;
+import com.google.cloud.spanner.pgadapter.ConnectionHandler.ConnectionStatus;
+import com.google.cloud.spanner.pgadapter.error.PGException;
+import com.google.cloud.spanner.pgadapter.error.SQLState;
+import com.google.cloud.spanner.pgadapter.error.Severity;
+import com.google.cloud.spanner.pgadapter.metadata.OptionsMetadata;
+import com.google.cloud.spanner.pgadapter.wireoutput.ErrorResponse;
+import java.io.DataInputStream;
+import java.io.IOException;
+
+/** This class reads the next control message for a connection. */
+@InternalApi
+public class MessageReader {
+  /** Maximum number of invalid messages in a row allowed before we terminate the connection. */
+  static final int MAX_INVALID_MESSAGE_COUNT = 50;
+
+  private final OptionsMetadata options;
+
+  public MessageReader(OptionsMetadata options) {
+    this.options = options;
+  }
+
+  /**
+   * Factory method to create the next control message for the given connection.
+   *
+   * @param connection The connection handler object setup with the ability to send/receive.
+   * @return The constructed wire message given the input message.
+   * @throws Exception If construction or reading fails.
+   */
+  public ControlMessage create(ConnectionHandler connection) throws Exception {
+    boolean validMessage = true;
+    char nextMsg = readNextMsgIdentifier(connection);
+    try {
+      if (connection.getStatus() == ConnectionStatus.COPY_IN) {
+        switch (nextMsg) {
+          case CopyDoneMessage.IDENTIFIER:
+            return new CopyDoneMessage(connection);
+          case CopyDataMessage.IDENTIFIER:
+            return new CopyDataMessage(connection);
+          case CopyFailMessage.IDENTIFIER:
+            return new CopyFailMessage(connection);
+          case SyncMessage.IDENTIFIER:
+          case FlushMessage.IDENTIFIER:
+            // Skip sync/flush in COPY_IN. This is consistent with real PostgreSQL which also does
+            // this to accommodate clients that do not check what type of statement they sent in an
+            // ExecuteMessage, and instead always blindly send a flush/sync after each execute.
+            return SkipMessage.createForValidStream(connection);
+          default:
+            // Skip other unexpected messages and throw an exception to fail the copy operation.
+            validMessage = false;
+            SkipMessage.createForInvalidStream(connection);
+            throw new IllegalStateException(
+                String.format(
+                    "Expected CopyData ('d'), CopyDone ('c') or CopyFail ('f') messages, got: '%c'",
+                    nextMsg));
+        }
+      } else {
+        switch (nextMsg) {
+          case QueryMessage.IDENTIFIER:
+            return new QueryMessage(connection);
+          case ParseMessage.IDENTIFIER:
+            return new ParseMessage(connection);
+          case BindMessage.IDENTIFIER:
+            return new BindMessage(connection);
+          case DescribeMessage.IDENTIFIER:
+            return new DescribeMessage(connection);
+          case ExecuteMessage.IDENTIFIER:
+            return new ExecuteMessage(connection);
+          case CloseMessage.IDENTIFIER:
+            return new CloseMessage(connection);
+          case TerminateMessage.IDENTIFIER:
+            return new TerminateMessage(connection);
+          case FunctionCallMessage.IDENTIFIER:
+            return new FunctionCallMessage(connection);
+          case FlushMessage.IDENTIFIER:
+            return new FlushMessage(connection);
+          case SyncMessage.IDENTIFIER:
+            return new SyncMessage(connection);
+          case CopyDoneMessage.IDENTIFIER:
+          case CopyDataMessage.IDENTIFIER:
+          case CopyFailMessage.IDENTIFIER:
+            // Silently skip COPY messages in non-COPY mode. This is consistent with the PG wire
+            // protocol. If we continue to receive COPY messages while in non-COPY mode, we'll
+            // terminate the connection to prevent the server from being flooded with invalid
+            // messages.
+            validMessage = false;
+            // Note: The stream itself is still valid as we received a message that we recognized.
+            return SkipMessage.createForValidStream(connection);
+          default:
+            throw new IllegalStateException(String.format("Unknown message: %c", nextMsg));
+        }
+      }
+    } finally {
+      if (validMessage) {
+        connection.clearInvalidMessageCount();
+      } else {
+        connection.increaseInvalidMessageCount();
+        if (connection.getInvalidMessageCount() > MAX_INVALID_MESSAGE_COUNT) {
+          new ErrorResponse(
+                  connection,
+                  PGException.newBuilder(
+                          String.format(
+                              "Received %d invalid/unexpected messages. Last received message: '%c'",
+                              connection.getInvalidMessageCount(), nextMsg))
+                      .setSQLState(SQLState.ProtocolViolation)
+                      .setSeverity(Severity.FATAL)
+                      .build())
+              .send();
+          connection.setStatus(ConnectionStatus.TERMINATED);
+        }
+      }
+    }
+  }
+
+  /** Reads the next control message identifier. */
+  private char readNextMsgIdentifier(ConnectionHandler connection) throws IOException {
+    DataInputStream inputStream = connection.getConnectionMetadata().getInputStream();
+    return (char) inputStream.readUnsignedByte();
+  }
+
+  /**
+   * Read the format codes from the current message (useful for both input and output format codes).
+   *
+   * @param input The data stream for the connection.
+   * @return A list of format codes.
+   * @throws Exception If reading fails in any way.
+   */
+  static short[] getFormatCodes(DataInputStream input) throws Exception {
+    short numberOfFormatCodes = input.readShort();
+    if (numberOfFormatCodes == 0) {
+      return NO_FORMAT_CODES;
+    }
+    short[] formatCodes = new short[numberOfFormatCodes];
+    for (int i = 0; i < numberOfFormatCodes; i++) {
+      formatCodes[i] = input.readShort();
+    }
+    return formatCodes;
+  }
+}

--- a/src/main/java/com/google/cloud/spanner/pgadapter/wireprotocol/WireMessage.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/wireprotocol/WireMessage.java
@@ -32,14 +32,16 @@ public abstract class WireMessage {
 
   private static final Logger logger = Logger.getLogger(WireMessage.class.getName());
 
-  protected int length;
-  protected DataInputStream inputStream;
-  protected DataOutputStream outputStream;
-  protected ConnectionHandler connection;
+  protected final int length;
+  protected final MessageReader messageReader;
+  protected final DataInputStream inputStream;
+  protected final DataOutputStream outputStream;
+  protected final ConnectionHandler connection;
 
   public WireMessage(ConnectionHandler connection, int length) {
     Preconditions.checkArgument(length >= 4);
     this.connection = connection;
+    this.messageReader = connection.getServer().getMessageReader();
     this.inputStream = connection.getConnectionMetadata().getInputStream();
     this.outputStream = connection.getConnectionMetadata().getOutputStream();
     this.length = length;
@@ -207,6 +209,6 @@ public abstract class WireMessage {
    * setting for {@link ConnectionHandler}.
    */
   public void nextHandler() throws Exception {
-    this.connection.setMessageState(ControlMessage.create(this.connection));
+    this.connection.setMessageState(this.messageReader.create(this.connection));
   }
 }

--- a/src/test/java/com/google/cloud/spanner/pgadapter/statements/StatementTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/statements/StatementTest.java
@@ -57,7 +57,7 @@ import com.google.cloud.spanner.pgadapter.session.SessionState;
 import com.google.cloud.spanner.pgadapter.utils.ClientAutoDetector.WellKnownClient;
 import com.google.cloud.spanner.pgadapter.utils.Metrics;
 import com.google.cloud.spanner.pgadapter.utils.MutationWriter;
-import com.google.cloud.spanner.pgadapter.wireprotocol.ControlMessage;
+import com.google.cloud.spanner.pgadapter.wireprotocol.MessageReader;
 import com.google.cloud.spanner.pgadapter.wireprotocol.QueryMessage;
 import com.google.cloud.spanner.pgadapter.wireprotocol.WireMessage;
 import com.google.common.collect.ImmutableList;
@@ -477,15 +477,16 @@ public class StatementTest {
     byte[] value = Bytes.concat(messageMetadata, payload.getBytes());
     DataInputStream inputStream = new DataInputStream(new ByteArrayInputStream(value));
 
-    when(connectionHandler.getConnectionMetadata()).thenReturn(connectionMetadata);
+    when(server.getMessageReader()).thenReturn(new MessageReader(mock(OptionsMetadata.class)));
     when(connectionHandler.getServer()).thenReturn(server);
+    when(connectionHandler.getConnectionMetadata()).thenReturn(connectionMetadata);
     when(connectionHandler.getExtendedQueryProtocolHandler())
         .thenReturn(extendedQueryProtocolHandler);
     when(server.getOptions()).thenReturn(options);
     when(connectionMetadata.getInputStream()).thenReturn(inputStream);
     when(connectionMetadata.getOutputStream()).thenReturn(outputStream);
 
-    WireMessage message = ControlMessage.create(connectionHandler);
+    WireMessage message = server.getMessageReader().create(connectionHandler);
     assertEquals(QueryMessage.class, message.getClass());
     SimpleQueryStatement simpleQueryStatement = ((QueryMessage) message).getSimpleQueryStatement();
 

--- a/src/test/java/com/google/cloud/spanner/pgadapter/wireprotocol/ControlMessageTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/wireprotocol/ControlMessageTest.java
@@ -20,7 +20,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.google.cloud.spanner.connection.AbstractStatementParser.StatementType;
-import com.google.cloud.spanner.connection.Connection;
 import com.google.cloud.spanner.connection.StatementResult;
 import com.google.cloud.spanner.connection.StatementResult.ResultType;
 import com.google.cloud.spanner.pgadapter.ConnectionHandler;
@@ -65,7 +64,6 @@ public final class ControlMessageTest {
   @Mock private ExtendedQueryProtocolHandler extendedQueryProtocolHandler;
   @Mock private IntermediateStatement intermediateStatement;
   @Mock private ConnectionMetadata connectionMetadata;
-  @Mock private Connection connection;
 
   @Test
   public void testInsertResult() throws Exception {
@@ -102,7 +100,7 @@ public final class ControlMessageTest {
     when(connectionHandler.getExtendedQueryProtocolHandler())
         .thenReturn(extendedQueryProtocolHandler);
 
-    ControlMessage controlMessage = ControlMessage.create(connectionHandler);
+    ControlMessage controlMessage = server.getMessageReader().create(connectionHandler);
     controlMessage.sendSpannerResult(intermediateStatement, QueryMode.SIMPLE, 0L);
 
     DataInputStream outputReader =
@@ -126,6 +124,7 @@ public final class ControlMessageTest {
         new DataInputStream(
             new ByteArrayInputStream(new byte[] {(byte) QUERY_IDENTIFIER, 0, 0, 0, 5, 0}));
 
+    when(connectionHandler.getServer()).thenReturn(mock(ProxyServer.class));
     when(connectionMetadata.getInputStream()).thenReturn(inputStream);
     when(connectionMetadata.getOutputStream()).thenReturn(outputStream);
     when(connectionHandler.getExtendedQueryProtocolHandler())
@@ -157,6 +156,7 @@ public final class ControlMessageTest {
   public void testSendNoRowsAsResultSetFails() {
     OpenTelemetry otel = OpenTelemetry.noop();
     Tracer tracer = otel.getTracer("test");
+    when(connectionHandler.getServer()).thenReturn(mock(ProxyServer.class));
     when(connectionHandler.getConnectionMetadata()).thenReturn(connectionMetadata);
     when(connectionHandler.getExtendedQueryProtocolHandler())
         .thenReturn(extendedQueryProtocolHandler);

--- a/src/test/java/com/google/cloud/spanner/pgadapter/wireprotocol/ProtocolTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/wireprotocol/ProtocolTest.java
@@ -15,7 +15,7 @@
 package com.google.cloud.spanner.pgadapter.wireprotocol;
 
 import static com.google.cloud.spanner.pgadapter.statements.IntermediatePortalStatement.NO_FORMAT_CODES;
-import static com.google.cloud.spanner.pgadapter.wireprotocol.ControlMessage.MAX_INVALID_MESSAGE_COUNT;
+import static com.google.cloud.spanner.pgadapter.wireprotocol.MessageReader.MAX_INVALID_MESSAGE_COUNT;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -145,6 +145,7 @@ public class ProtocolTest {
 
     when(connectionHandler.getServer()).thenReturn(server);
     when(server.getOptions()).thenReturn(options);
+    when(server.getMessageReader()).thenReturn(new MessageReader(options));
     when(options.requiresMatcher()).thenReturn(false);
     when(connectionHandler.getSpannerConnection()).thenReturn(connection);
     when(connectionHandler.getConnectionMetadata()).thenReturn(connectionMetadata);
@@ -156,7 +157,7 @@ public class ProtocolTest {
     when(connectionMetadata.getInputStream()).thenReturn(inputStream);
     when(connectionMetadata.getOutputStream()).thenReturn(outputStream);
 
-    WireMessage message = ControlMessage.create(connectionHandler);
+    WireMessage message = server.getMessageReader().create(connectionHandler);
     assertEquals(QueryMessage.class, message.getClass());
     assertEquals(expectedSQL, ((QueryMessage) message).getStatement().getSql());
 
@@ -179,11 +180,12 @@ public class ProtocolTest {
         .thenReturn(extendedQueryProtocolHandler);
     when(connectionHandler.getServer()).thenReturn(server);
     when(server.getOptions()).thenReturn(options);
+    when(server.getMessageReader()).thenReturn(new MessageReader(options));
     when(connectionHandler.getConnectionMetadata()).thenReturn(connectionMetadata);
     when(connectionMetadata.getInputStream()).thenReturn(inputStream);
     when(connectionMetadata.getOutputStream()).thenReturn(outputStream);
 
-    WireMessage message = ControlMessage.create(connectionHandler);
+    WireMessage message = server.getMessageReader().create(connectionHandler);
     assertEquals(QueryMessage.class, message.getClass());
     assertNotNull(((QueryMessage) message).getSimpleQueryStatement());
     assertEquals(expectedSQL, ((QueryMessage) message).getStatement().getSql());
@@ -197,13 +199,15 @@ public class ProtocolTest {
 
     DataInputStream inputStream = new DataInputStream(new ByteArrayInputStream(value));
 
+    when(server.getMessageReader()).thenReturn(new MessageReader(options));
+    when(connectionHandler.getServer()).thenReturn(server);
     when(connectionHandler.getExtendedQueryProtocolHandler())
         .thenReturn(extendedQueryProtocolHandler);
     when(connectionHandler.getConnectionMetadata()).thenReturn(connectionMetadata);
     when(connectionMetadata.getInputStream()).thenReturn(inputStream);
     when(connectionMetadata.getOutputStream()).thenReturn(outputStream);
 
-    assertThrows(IOException.class, () -> ControlMessage.create(connectionHandler));
+    assertThrows(IOException.class, () -> server.getMessageReader().create(connectionHandler));
   }
 
   @Test
@@ -242,6 +246,7 @@ public class ProtocolTest {
 
     when(connectionHandler.getServer()).thenReturn(server);
     when(server.getOptions()).thenReturn(options);
+    when(server.getMessageReader()).thenReturn(new MessageReader(options));
     when(connectionHandler.getSpannerConnection()).thenReturn(connection);
     when(connectionHandler.getConnectionMetadata()).thenReturn(connectionMetadata);
     when(connectionMetadata.getInputStream()).thenReturn(inputStream);
@@ -249,7 +254,7 @@ public class ProtocolTest {
     when(connectionHandler.getExtendedQueryProtocolHandler())
         .thenReturn(extendedQueryProtocolHandler);
 
-    WireMessage message = ControlMessage.create(connectionHandler);
+    WireMessage message = server.getMessageReader().create(connectionHandler);
     assertEquals(ParseMessage.class, message.getClass());
     assertEquals(expectedMessageName, ((ParseMessage) message).getName());
     assertEquals(expectedSQL, ((ParseMessage) message).getStatement().getSql());
@@ -306,6 +311,7 @@ public class ProtocolTest {
 
     when(connectionHandler.getServer()).thenReturn(server);
     when(server.getOptions()).thenReturn(options);
+    when(server.getMessageReader()).thenReturn(new MessageReader(options));
     when(connectionHandler.getSpannerConnection()).thenReturn(connection);
     when(connectionHandler.getConnectionMetadata()).thenReturn(connectionMetadata);
     when(connectionMetadata.getInputStream()).thenReturn(inputStream);
@@ -313,7 +319,7 @@ public class ProtocolTest {
     when(connectionHandler.getExtendedQueryProtocolHandler())
         .thenReturn(extendedQueryProtocolHandler);
 
-    WireMessage message = ControlMessage.create(connectionHandler);
+    WireMessage message = server.getMessageReader().create(connectionHandler);
     assertEquals(ParseMessage.class, message.getClass());
     assertEquals(expectedMessageName, ((ParseMessage) message).getName());
     assertEquals(expectedSQL, ((ParseMessage) message).getStatement().getSql());
@@ -371,6 +377,7 @@ public class ProtocolTest {
 
     when(connectionHandler.getServer()).thenReturn(server);
     when(server.getOptions()).thenReturn(options);
+    when(server.getMessageReader()).thenReturn(new MessageReader(options));
     when(connectionHandler.getSpannerConnection()).thenReturn(connection);
     when(connectionHandler.getConnectionMetadata()).thenReturn(connectionMetadata);
     when(connectionMetadata.getInputStream()).thenReturn(inputStream);
@@ -378,7 +385,7 @@ public class ProtocolTest {
     when(connectionHandler.getExtendedQueryProtocolHandler())
         .thenReturn(extendedQueryProtocolHandler);
 
-    WireMessage message = ControlMessage.create(connectionHandler);
+    WireMessage message = server.getMessageReader().create(connectionHandler);
     assertEquals(ParseMessage.class, message.getClass());
     assertEquals(expectedMessageName, ((ParseMessage) message).getName());
     assertEquals(expectedSQL, ((ParseMessage) message).getStatement().getSql());
@@ -421,6 +428,7 @@ public class ProtocolTest {
 
     when(connectionHandler.getServer()).thenReturn(server);
     when(server.getOptions()).thenReturn(options);
+    when(server.getMessageReader()).thenReturn(new MessageReader(options));
     when(connectionHandler.getSpannerConnection()).thenReturn(connection);
     when(connectionHandler.getConnectionMetadata()).thenReturn(connectionMetadata);
     when(connectionMetadata.getInputStream()).thenReturn(inputStream);
@@ -428,7 +436,7 @@ public class ProtocolTest {
     when(connectionHandler.getExtendedQueryProtocolHandler())
         .thenReturn(extendedQueryProtocolHandler);
 
-    WireMessage message = ControlMessage.create(connectionHandler);
+    WireMessage message = server.getMessageReader().create(connectionHandler);
     assertEquals(ParseMessage.class, message.getClass());
     assertEquals(expectedMessageName, ((ParseMessage) message).getName());
     assertEquals(expectedSQL, ((ParseMessage) message).getStatement().getSql());
@@ -479,6 +487,7 @@ public class ProtocolTest {
 
     when(connectionHandler.getServer()).thenReturn(server);
     when(server.getOptions()).thenReturn(options);
+    when(server.getMessageReader()).thenReturn(new MessageReader(options));
     when(connectionHandler.getSpannerConnection()).thenReturn(connection);
     when(connectionHandler.getConnectionMetadata()).thenReturn(connectionMetadata);
     when(connectionMetadata.getInputStream()).thenReturn(inputStream);
@@ -486,7 +495,7 @@ public class ProtocolTest {
     when(connectionHandler.getExtendedQueryProtocolHandler())
         .thenReturn(extendedQueryProtocolHandler);
 
-    WireMessage message = ControlMessage.create(connectionHandler);
+    WireMessage message = server.getMessageReader().create(connectionHandler);
 
     when(connectionHandler.hasStatement(anyString())).thenReturn(true);
     assertThrows(IllegalStateException.class, message::send);
@@ -525,6 +534,7 @@ public class ProtocolTest {
 
     when(connectionHandler.getServer()).thenReturn(server);
     when(server.getOptions()).thenReturn(options);
+    when(server.getMessageReader()).thenReturn(new MessageReader(options));
     when(connectionHandler.getSpannerConnection()).thenReturn(connection);
     when(connectionHandler.getConnectionMetadata()).thenReturn(connectionMetadata);
     when(connectionMetadata.getInputStream()).thenReturn(inputStream);
@@ -532,7 +542,7 @@ public class ProtocolTest {
     when(connectionHandler.getExtendedQueryProtocolHandler())
         .thenReturn(extendedQueryProtocolHandler);
 
-    WireMessage message = ControlMessage.create(connectionHandler);
+    WireMessage message = server.getMessageReader().create(connectionHandler);
 
     when(connectionHandler.hasStatement(anyString())).thenReturn(true);
     assertThrows(IllegalStateException.class, message::send);
@@ -572,6 +582,7 @@ public class ProtocolTest {
 
     when(connectionHandler.getServer()).thenReturn(server);
     when(server.getOptions()).thenReturn(options);
+    when(server.getMessageReader()).thenReturn(new MessageReader(options));
     when(connectionHandler.getSpannerConnection()).thenReturn(connection);
     when(connectionHandler.getConnectionMetadata()).thenReturn(connectionMetadata);
     when(connectionMetadata.getInputStream()).thenReturn(inputStream);
@@ -579,7 +590,7 @@ public class ProtocolTest {
     when(connectionHandler.getExtendedQueryProtocolHandler())
         .thenReturn(extendedQueryProtocolHandler);
 
-    WireMessage message = ControlMessage.create(connectionHandler);
+    WireMessage message = server.getMessageReader().create(connectionHandler);
 
     message.send();
   }
@@ -621,6 +632,7 @@ public class ProtocolTest {
             parameter,
             resultCodesCount);
 
+    when(server.getMessageReader()).thenReturn(new MessageReader(options));
     when(connectionHandler.getStatement(anyString())).thenReturn(intermediatePreparedStatement);
     when(intermediatePreparedStatement.createPortal(anyString(), any(), any(), any()))
         .thenReturn(intermediatePortalStatement);
@@ -642,8 +654,9 @@ public class ProtocolTest {
     when(connectionMetadata.getOutputStream()).thenReturn(outputStream);
     when(connectionHandler.getExtendedQueryProtocolHandler())
         .thenReturn(extendedQueryProtocolHandler);
+    when(connectionHandler.getServer()).thenReturn(server);
 
-    WireMessage message = ControlMessage.create(connectionHandler);
+    WireMessage message = server.getMessageReader().create(connectionHandler);
     assertEquals(BindMessage.class, message.getClass());
     assertEquals(expectedPortalName, ((BindMessage) message).getPortalName());
     assertEquals(expectedStatementName, ((BindMessage) message).getStatementName());
@@ -720,6 +733,7 @@ public class ProtocolTest {
 
     DataInputStream inputStream = new DataInputStream(new ByteArrayInputStream(value));
 
+    when(server.getMessageReader()).thenReturn(new MessageReader(options));
     when(connectionHandler.getExtendedQueryProtocolHandler())
         .thenReturn(extendedQueryProtocolHandler);
     when(connectionHandler.getConnectionMetadata()).thenReturn(connectionMetadata);
@@ -728,8 +742,9 @@ public class ProtocolTest {
     when(connectionHandler.getStatement(anyString())).thenReturn(intermediatePreparedStatement);
     when(intermediatePreparedStatement.createPortal(anyString(), any(), any(), any()))
         .thenReturn(intermediatePortalStatement);
+    when(connectionHandler.getServer()).thenReturn(server);
 
-    WireMessage message = ControlMessage.create(connectionHandler);
+    WireMessage message = server.getMessageReader().create(connectionHandler);
     assertEquals(BindMessage.class, message.getClass());
     assertEquals(expectedPortalName, ((BindMessage) message).getPortalName());
     assertEquals(expectedStatementName, ((BindMessage) message).getStatementName());
@@ -795,6 +810,7 @@ public class ProtocolTest {
 
     DataInputStream inputStream = new DataInputStream(new ByteArrayInputStream(value));
 
+    when(server.getMessageReader()).thenReturn(new MessageReader(options));
     when(connectionHandler.getExtendedQueryProtocolHandler())
         .thenReturn(extendedQueryProtocolHandler);
     when(connectionHandler.getConnectionMetadata()).thenReturn(connectionMetadata);
@@ -803,8 +819,9 @@ public class ProtocolTest {
     when(connectionHandler.getStatement(anyString())).thenReturn(intermediatePreparedStatement);
     when(intermediatePreparedStatement.createPortal(anyString(), any(), any(), any()))
         .thenReturn(intermediatePortalStatement);
+    when(connectionHandler.getServer()).thenReturn(server);
 
-    WireMessage message = ControlMessage.create(connectionHandler);
+    WireMessage message = server.getMessageReader().create(connectionHandler);
     assertEquals(BindMessage.class, message.getClass());
     assertEquals(expectedPortalName, ((BindMessage) message).getPortalName());
     assertEquals(expectedStatementName, ((BindMessage) message).getStatementName());
@@ -828,6 +845,7 @@ public class ProtocolTest {
     ByteArrayOutputStream result = new ByteArrayOutputStream();
     DataOutputStream outputStream = new DataOutputStream(result);
 
+    when(server.getMessageReader()).thenReturn(new MessageReader(options));
     when(connectionHandler.getPortal(anyString())).thenReturn(intermediatePortalStatement);
     when(intermediatePortalStatement.getSql()).thenReturn("select * from foo");
     when(connectionHandler.getConnectionMetadata()).thenReturn(connectionMetadata);
@@ -835,8 +853,9 @@ public class ProtocolTest {
     when(connectionMetadata.getOutputStream()).thenReturn(outputStream);
     when(connectionHandler.getExtendedQueryProtocolHandler())
         .thenReturn(extendedQueryProtocolHandler);
+    when(connectionHandler.getServer()).thenReturn(server);
 
-    WireMessage message = ControlMessage.create(connectionHandler);
+    WireMessage message = server.getMessageReader().create(connectionHandler);
     assertEquals(DescribeMessage.class, message.getClass());
     assertEquals(expectedStatementName, ((DescribeMessage) message).getName());
     assertEquals("select * from foo", ((DescribeMessage) message).getSql());
@@ -867,14 +886,16 @@ public class ProtocolTest {
     ByteArrayOutputStream result = new ByteArrayOutputStream();
     DataOutputStream outputStream = new DataOutputStream(result);
 
+    when(server.getMessageReader()).thenReturn(new MessageReader(options));
     when(connectionHandler.getStatement(anyString())).thenReturn(intermediatePreparedStatement);
     when(connectionHandler.getConnectionMetadata()).thenReturn(connectionMetadata);
     when(connectionMetadata.getInputStream()).thenReturn(inputStream);
     when(connectionMetadata.getOutputStream()).thenReturn(outputStream);
     when(connectionHandler.getExtendedQueryProtocolHandler())
         .thenReturn(extendedQueryProtocolHandler);
+    when(connectionHandler.getServer()).thenReturn(server);
 
-    WireMessage message = ControlMessage.create(connectionHandler);
+    WireMessage message = server.getMessageReader().create(connectionHandler);
     assertEquals(DescribeMessage.class, message.getClass());
     assertEquals(expectedStatementName, ((DescribeMessage) message).getName());
 
@@ -903,6 +924,7 @@ public class ProtocolTest {
     ByteArrayOutputStream result = new ByteArrayOutputStream();
     DataOutputStream outputStream = new DataOutputStream(result);
 
+    when(server.getMessageReader()).thenReturn(new MessageReader(options));
     when(connectionHandler.getStatement(anyString())).thenReturn(intermediatePreparedStatement);
     when(connectionHandler.getConnectionMetadata()).thenReturn(connectionMetadata);
     when(connectionMetadata.getInputStream()).thenReturn(inputStream);
@@ -912,8 +934,9 @@ public class ProtocolTest {
     when(intermediatePreparedStatement.hasException()).thenReturn(true);
     when(intermediatePreparedStatement.getException())
         .thenReturn(PGExceptionFactory.newPGException("test error", SQLState.InternalError));
+    when(connectionHandler.getServer()).thenReturn(server);
 
-    WireMessage message = ControlMessage.create(connectionHandler);
+    WireMessage message = server.getMessageReader().create(connectionHandler);
     assertEquals(DescribeMessage.class, message.getClass());
     DescribeMessage describeMessage = (DescribeMessage) message;
 
@@ -938,6 +961,8 @@ public class ProtocolTest {
     ByteArrayOutputStream result = new ByteArrayOutputStream();
     DataOutputStream outputStream = new DataOutputStream(result);
 
+    when(server.getMessageReader()).thenReturn(new MessageReader(options));
+    when(connectionHandler.getServer()).thenReturn(server);
     when(connectionHandler.getPortal(anyString())).thenReturn(intermediatePortalStatement);
     when(connectionHandler.getConnectionMetadata()).thenReturn(connectionMetadata);
     when(connectionMetadata.getInputStream()).thenReturn(inputStream);
@@ -946,7 +971,7 @@ public class ProtocolTest {
         .thenReturn(extendedQueryProtocolHandler);
     when(extendedQueryProtocolHandler.getBackendConnection()).thenReturn(backendConnection);
 
-    WireMessage message = ControlMessage.create(connectionHandler);
+    WireMessage message = server.getMessageReader().create(connectionHandler);
     assertEquals(ExecuteMessage.class, message.getClass());
     assertEquals(expectedStatementName, ((ExecuteMessage) message).getName());
     assertEquals(totalRows, ((ExecuteMessage) message).getMaxRows());
@@ -985,6 +1010,7 @@ public class ProtocolTest {
 
     PGException testException =
         PGExceptionFactory.newPGException("test error", SQLState.SyntaxError);
+    when(server.getMessageReader()).thenReturn(new MessageReader(options));
     when(intermediatePortalStatement.hasException()).thenReturn(true);
     when(intermediatePortalStatement.getException()).thenReturn(testException);
     when(connectionHandler.getWellKnownClient()).thenReturn(WellKnownClient.UNSPECIFIED);
@@ -995,8 +1021,9 @@ public class ProtocolTest {
     when(connectionHandler.getExtendedQueryProtocolHandler())
         .thenReturn(extendedQueryProtocolHandler);
     when(extendedQueryProtocolHandler.getBackendConnection()).thenReturn(backendConnection);
+    when(connectionHandler.getServer()).thenReturn(server);
 
-    WireMessage message = ControlMessage.create(connectionHandler);
+    WireMessage message = server.getMessageReader().create(connectionHandler);
     assertEquals(ExecuteMessage.class, message.getClass());
     assertEquals(expectedStatementName, ((ExecuteMessage) message).getName());
     assertEquals(totalRows, ((ExecuteMessage) message).getMaxRows());
@@ -1028,12 +1055,14 @@ public class ProtocolTest {
     ByteArrayOutputStream result = new ByteArrayOutputStream();
     DataOutputStream outputStream = new DataOutputStream(result);
 
+    when(server.getMessageReader()).thenReturn(new MessageReader(options));
     when(connectionHandler.getPortal(anyString())).thenReturn(intermediatePortalStatement);
     when(connectionHandler.getConnectionMetadata()).thenReturn(connectionMetadata);
     when(connectionMetadata.getInputStream()).thenReturn(inputStream);
     when(connectionMetadata.getOutputStream()).thenReturn(outputStream);
+    when(connectionHandler.getServer()).thenReturn(server);
 
-    WireMessage message = ControlMessage.create(connectionHandler);
+    WireMessage message = server.getMessageReader().create(connectionHandler);
     assertEquals(CloseMessage.class, message.getClass());
     assertEquals(expectedStatementName, ((CloseMessage) message).getName());
     assertEquals(expectedType, ((CloseMessage) message).getType());
@@ -1066,12 +1095,14 @@ public class ProtocolTest {
     ByteArrayOutputStream result = new ByteArrayOutputStream();
     DataOutputStream outputStream = new DataOutputStream(result);
 
+    when(server.getMessageReader()).thenReturn(new MessageReader(options));
+    when(connectionHandler.getServer()).thenReturn(server);
     when(connectionHandler.getStatement(anyString())).thenReturn(intermediatePortalStatement);
     when(connectionHandler.getConnectionMetadata()).thenReturn(connectionMetadata);
     when(connectionMetadata.getInputStream()).thenReturn(inputStream);
     when(connectionMetadata.getOutputStream()).thenReturn(outputStream);
 
-    WireMessage message = ControlMessage.create(connectionHandler);
+    WireMessage message = server.getMessageReader().create(connectionHandler);
     assertEquals(CloseMessage.class, message.getClass());
     assertEquals(expectedStatementName, ((CloseMessage) message).getName());
     assertEquals(expectedType, ((CloseMessage) message).getType());
@@ -1099,6 +1130,8 @@ public class ProtocolTest {
     ByteArrayOutputStream result = new ByteArrayOutputStream();
     DataOutputStream outputStream = new DataOutputStream(result);
 
+    when(server.getMessageReader()).thenReturn(new MessageReader(options));
+    when(connectionHandler.getServer()).thenReturn(server);
     when(connectionHandler.getTraceConnectionId()).thenReturn(UUID.randomUUID());
     ExtendedQueryProtocolHandler extendedQueryProtocolHandler =
         new ExtendedQueryProtocolHandler(connectionHandler, backendConnection);
@@ -1111,7 +1144,7 @@ public class ProtocolTest {
         .thenReturn(extendedQueryProtocolHandler);
     when(backendConnection.getConnectionState()).thenReturn(ConnectionState.IDLE);
 
-    WireMessage message = ControlMessage.create(connectionHandler);
+    WireMessage message = server.getMessageReader().create(connectionHandler);
     assertEquals(message.getClass(), SyncMessage.class);
 
     message.send();
@@ -1135,6 +1168,7 @@ public class ProtocolTest {
     ByteArrayOutputStream result = new ByteArrayOutputStream();
     DataOutputStream outputStream = new DataOutputStream(result);
 
+    when(server.getMessageReader()).thenReturn(new MessageReader(options));
     when(connectionHandler.getTraceConnectionId()).thenReturn(UUID.randomUUID());
     ExtendedQueryProtocolHandler extendedQueryProtocolHandler =
         new ExtendedQueryProtocolHandler(connectionHandler, backendConnection);
@@ -1142,12 +1176,13 @@ public class ProtocolTest {
     when(connectionHandler.getConnectionMetadata()).thenReturn(connectionMetadata);
     when(connectionMetadata.getInputStream()).thenReturn(inputStream);
     when(connectionMetadata.getOutputStream()).thenReturn(outputStream);
+    when(connectionHandler.getServer()).thenReturn(server);
 
     when(connectionHandler.getExtendedQueryProtocolHandler())
         .thenReturn(extendedQueryProtocolHandler);
     when(backendConnection.getConnectionState()).thenReturn(ConnectionState.TRANSACTION);
 
-    WireMessage message = ControlMessage.create(connectionHandler);
+    WireMessage message = server.getMessageReader().create(connectionHandler);
     assertEquals(SyncMessage.class, message.getClass());
 
     message.send();
@@ -1170,13 +1205,15 @@ public class ProtocolTest {
     DataInputStream inputStream = new DataInputStream(new ByteArrayInputStream(value));
     DataOutputStream outputStream = mock(DataOutputStream.class);
 
+    when(server.getMessageReader()).thenReturn(new MessageReader(options));
     when(connectionHandler.getConnectionMetadata()).thenReturn(connectionMetadata);
     when(connectionMetadata.getInputStream()).thenReturn(inputStream);
     when(connectionMetadata.getOutputStream()).thenReturn(outputStream);
     when(connectionHandler.getExtendedQueryProtocolHandler())
         .thenReturn(extendedQueryProtocolHandler);
+    when(connectionHandler.getServer()).thenReturn(server);
 
-    WireMessage message = ControlMessage.create(connectionHandler);
+    WireMessage message = server.getMessageReader().create(connectionHandler);
     assertEquals(message.getClass(), FlushMessage.class);
 
     message.send();
@@ -1196,13 +1233,15 @@ public class ProtocolTest {
     DataInputStream inputStream = new DataInputStream(new ByteArrayInputStream(value));
     DataOutputStream outputStream = mock(DataOutputStream.class);
 
+    when(server.getMessageReader()).thenReturn(new MessageReader(options));
+    when(connectionHandler.getServer()).thenReturn(server);
     when(connectionHandler.getExtendedQueryProtocolHandler())
         .thenReturn(extendedQueryProtocolHandler);
     when(connectionHandler.getConnectionMetadata()).thenReturn(connectionMetadata);
     when(connectionMetadata.getInputStream()).thenReturn(inputStream);
     when(connectionMetadata.getOutputStream()).thenReturn(outputStream);
 
-    WireMessage message = ControlMessage.create(connectionHandler);
+    WireMessage message = server.getMessageReader().create(connectionHandler);
     assertEquals(FlushMessage.class, message.getClass());
 
     message.send();
@@ -1239,6 +1278,7 @@ public class ProtocolTest {
     when(backendConnection.getMetrics()).thenReturn(new Metrics(OpenTelemetry.noop()));
     OptionsMetadata options = mock(OptionsMetadata.class);
     when(server.getOptions()).thenReturn(options);
+    when(server.getMessageReader()).thenReturn(new MessageReader(options));
     when(connectionMetadata.getInputStream()).thenReturn(inputStream);
     when(connectionMetadata.getOutputStream()).thenReturn(outputStream);
 
@@ -1247,7 +1287,7 @@ public class ProtocolTest {
     when(connectionHandler.getExtendedQueryProtocolHandler())
         .thenReturn(extendedQueryProtocolHandler);
 
-    WireMessage message = ControlMessage.create(connectionHandler);
+    WireMessage message = server.getMessageReader().create(connectionHandler);
     assertEquals(QueryMessage.class, message.getClass());
     assertEquals(expectedSQL, ((QueryMessage) message).getStatement().getSql());
 
@@ -1286,8 +1326,10 @@ public class ProtocolTest {
     when(connectionHandler.getConnectionMetadata()).thenReturn(connectionMetadata);
     when(connectionMetadata.getInputStream()).thenReturn(inputStream);
     when(connectionMetadata.getOutputStream()).thenReturn(outputStream);
+    when(server.getMessageReader()).thenReturn(new MessageReader(options));
+    when(connectionHandler.getServer()).thenReturn(server);
 
-    WireMessage message = ControlMessage.create(connectionHandler);
+    WireMessage message = server.getMessageReader().create(connectionHandler);
     assertEquals(TerminateMessage.class, message.getClass());
   }
 
@@ -1299,8 +1341,10 @@ public class ProtocolTest {
 
     when(connectionHandler.getConnectionMetadata()).thenReturn(connectionMetadata);
     when(connectionMetadata.getInputStream()).thenReturn(inputStream);
+    when(server.getMessageReader()).thenReturn(new MessageReader(options));
 
-    assertThrows(IllegalStateException.class, () -> ControlMessage.create(connectionHandler));
+    assertThrows(
+        IllegalStateException.class, () -> server.getMessageReader().create(connectionHandler));
   }
 
   @Test
@@ -1318,11 +1362,13 @@ public class ProtocolTest {
     when(connectionHandler.getStatus()).thenReturn(ConnectionStatus.COPY_IN);
     when(connectionMetadata.getInputStream()).thenReturn(inputStream);
     when(connectionMetadata.getOutputStream()).thenReturn(outputStream);
+    when(server.getMessageReader()).thenReturn(new MessageReader(options));
+    when(connectionHandler.getServer()).thenReturn(server);
 
     MutationWriter mw = mock(MutationWriter.class);
     when(copyStatement.getMutationWriter()).thenReturn(mw);
 
-    WireMessage message = ControlMessage.create(connectionHandler);
+    WireMessage message = server.getMessageReader().create(connectionHandler);
     assertEquals(CopyDataMessage.class, message.getClass());
     assertArrayEquals(payload, ((CopyDataMessage) message).getPayload());
 
@@ -1346,8 +1392,10 @@ public class ProtocolTest {
     when(connectionHandler.getStatus()).thenReturn(ConnectionStatus.COPY_IN);
     when(connectionMetadata.getInputStream()).thenReturn(inputStream);
     when(connectionMetadata.getOutputStream()).thenReturn(outputStream);
+    when(server.getMessageReader()).thenReturn(new MessageReader(options));
+    when(connectionHandler.getServer()).thenReturn(server);
 
-    WireMessage message = ControlMessage.create(connectionHandler);
+    WireMessage message = server.getMessageReader().create(connectionHandler);
     // This should be a no-op.
     message.sendPayload();
   }
@@ -1357,6 +1405,7 @@ public class ProtocolTest {
     when(connectionHandler.getSpannerConnection()).thenReturn(connection);
     when(connectionHandler.getConnectionMetadata()).thenReturn(connectionMetadata);
     when(connectionHandler.getStatus()).thenReturn(ConnectionStatus.COPY_IN);
+    when(server.getMessageReader()).thenReturn(new MessageReader(options));
 
     byte[] messageMetadata = {'d'};
     byte[] payload1 = "1\t'one'\n2\t".getBytes();
@@ -1382,10 +1431,11 @@ public class ProtocolTest {
     when(connectionHandler.getActiveCopyStatement()).thenReturn(copyStatement);
     when(connectionHandler.getConnectionMetadata()).thenReturn(connectionMetadata);
     when(connectionMetadata.getOutputStream()).thenReturn(outputStream);
+    when(connectionHandler.getServer()).thenReturn(server);
 
     {
       when(connectionMetadata.getInputStream()).thenReturn(inputStream1);
-      WireMessage message = ControlMessage.create(connectionHandler);
+      WireMessage message = server.getMessageReader().create(connectionHandler);
       assertEquals(CopyDataMessage.class, message.getClass());
       assertArrayEquals(payload1, ((CopyDataMessage) message).getPayload());
       CopyDataMessage copyDataMessage = (CopyDataMessage) message;
@@ -1393,7 +1443,7 @@ public class ProtocolTest {
     }
     {
       when(connectionMetadata.getInputStream()).thenReturn(inputStream2);
-      WireMessage message = ControlMessage.create(connectionHandler);
+      WireMessage message = server.getMessageReader().create(connectionHandler);
       assertEquals(CopyDataMessage.class, message.getClass());
       assertArrayEquals(payload2, ((CopyDataMessage) message).getPayload());
       CopyDataMessage copyDataMessage = (CopyDataMessage) message;
@@ -1401,7 +1451,7 @@ public class ProtocolTest {
     }
     {
       when(connectionMetadata.getInputStream()).thenReturn(inputStream3);
-      WireMessage message = ControlMessage.create(connectionHandler);
+      WireMessage message = server.getMessageReader().create(connectionHandler);
       assertEquals(CopyDataMessage.class, message.getClass());
       assertArrayEquals(payload3, ((CopyDataMessage) message).getPayload());
       CopyDataMessage copyDataMessage = (CopyDataMessage) message;
@@ -1427,8 +1477,10 @@ public class ProtocolTest {
     when(connectionHandler.getStatus()).thenReturn(ConnectionStatus.COPY_IN);
     when(connectionMetadata.getInputStream()).thenReturn(inputStream);
     when(connectionMetadata.getOutputStream()).thenReturn(outputStream);
+    when(server.getMessageReader()).thenReturn(new MessageReader(options));
+    when(connectionHandler.getServer()).thenReturn(server);
 
-    WireMessage message = ControlMessage.create(connectionHandler);
+    WireMessage message = server.getMessageReader().create(connectionHandler);
 
     assertEquals(CopyDoneMessage.class, message.getClass());
     CopyDoneMessage messageSpy = (CopyDoneMessage) spy(message);
@@ -1459,8 +1511,10 @@ public class ProtocolTest {
     when(connectionHandler.getStatus()).thenReturn(ConnectionStatus.COPY_IN);
     when(connectionMetadata.getInputStream()).thenReturn(inputStream);
     when(connectionMetadata.getOutputStream()).thenReturn(outputStream);
+    when(server.getMessageReader()).thenReturn(new MessageReader(options));
+    when(connectionHandler.getServer()).thenReturn(server);
 
-    WireMessage message = ControlMessage.create(connectionHandler);
+    WireMessage message = server.getMessageReader().create(connectionHandler);
 
     assertEquals(CopyFailMessage.class, message.getClass());
     assertEquals(expectedErrorMessage, ((CopyFailMessage) message).getErrorMessage());
@@ -1514,8 +1568,10 @@ public class ProtocolTest {
     when(connectionHandler.getConnectionMetadata()).thenReturn(connectionMetadata);
     when(connectionMetadata.getInputStream()).thenReturn(inputStream);
     when(connectionMetadata.getOutputStream()).thenReturn(outputStream);
+    when(server.getMessageReader()).thenReturn(new MessageReader(options));
+    when(connectionHandler.getServer()).thenReturn(server);
 
-    WireMessage message = ControlMessage.create(connectionHandler);
+    WireMessage message = server.getMessageReader().create(connectionHandler);
 
     assertEquals(FunctionCallMessage.class, message.getClass());
     assertThrows(IllegalStateException.class, message::send);
@@ -1564,6 +1620,7 @@ public class ProtocolTest {
     when(sessionState.get(null, "server_version")).thenReturn(serverVersionSetting);
     when(backendConnection.getSessionState()).thenReturn(sessionState);
     when(server.getOptions()).thenReturn(options);
+    when(server.getMessageReader()).thenReturn(new MessageReader(options));
     when(options.shouldAuthenticate()).thenReturn(false);
     when(connectionMetadata.getInputStream()).thenReturn(inputStream);
     when(connectionMetadata.getOutputStream()).thenReturn(outputStream);
@@ -1664,6 +1721,8 @@ public class ProtocolTest {
     when(connectionHandler.getConnectionMetadata()).thenReturn(connectionMetadata);
     when(connectionMetadata.getInputStream()).thenReturn(inputStream);
     when(connectionMetadata.getOutputStream()).thenReturn(outputStream);
+    when(server.getMessageReader()).thenReturn(new MessageReader(options));
+    when(connectionHandler.getServer()).thenReturn(server);
 
     WireMessage message = BootstrapMessage.create(connectionHandler);
     assertEquals(CancelMessage.class, message.getClass());
@@ -1694,6 +1753,7 @@ public class ProtocolTest {
     when(options.getSslMode()).thenReturn(SslMode.Enable);
     when(connectionMetadata.getInputStream()).thenReturn(inputStream);
     when(connectionMetadata.getOutputStream()).thenReturn(outputStream);
+    when(server.getMessageReader()).thenReturn(new MessageReader(options));
 
     WireMessage message = BootstrapMessage.create(connectionHandler);
     assertEquals(SSLMessage.class, message.getClass());
@@ -1724,6 +1784,7 @@ public class ProtocolTest {
     when(options.getSslMode()).thenReturn(SslMode.Disable);
     when(connectionMetadata.getInputStream()).thenReturn(inputStream);
     when(connectionMetadata.getOutputStream()).thenReturn(outputStream);
+    when(server.getMessageReader()).thenReturn(new MessageReader(options));
 
     WireMessage message = BootstrapMessage.create(connectionHandler);
     assertEquals(SSLMessage.class, message.getClass());
@@ -1747,6 +1808,8 @@ public class ProtocolTest {
     when(intermediatePortalStatement.containsResultSet()).thenReturn(true);
     when(intermediatePortalStatement.describeAsync(backendConnection))
         .thenReturn(SettableFuture.create());
+    when(server.getMessageReader()).thenReturn(new MessageReader(options));
+    when(connectionHandler.getServer()).thenReturn(server);
 
     DescribeMessage describeMessage =
         new DescribeMessage(connectionHandler, ManuallyCreatedToken.MANUALLY_CREATED_TOKEN);
@@ -1768,6 +1831,8 @@ public class ProtocolTest {
     when(connectionMetadata.getInputStream()).thenReturn(inputStream);
     when(connectionMetadata.getOutputStream()).thenReturn(outputStream);
     when(connectionHandler.getConnectionMetadata()).thenReturn(connectionMetadata);
+    when(server.getMessageReader()).thenReturn(new MessageReader(options));
+    when(connectionHandler.getServer()).thenReturn(server);
 
     SkipMessage message = SkipMessage.createForValidStream(connectionHandler);
     message.send();
@@ -1791,8 +1856,10 @@ public class ProtocolTest {
     when(connectionMetadata.getOutputStream()).thenReturn(outputStream);
     when(connectionHandler.getConnectionMetadata()).thenReturn(connectionMetadata);
     when(connectionHandler.getStatus()).thenReturn(ConnectionStatus.COPY_IN);
+    when(server.getMessageReader()).thenReturn(new MessageReader(options));
+    when(connectionHandler.getServer()).thenReturn(server);
 
-    ControlMessage message = ControlMessage.create(connectionHandler);
+    ControlMessage message = server.getMessageReader().create(connectionHandler);
 
     assertEquals(SkipMessage.class, message.getClass());
     // Verify that nothing was written to the output.
@@ -1811,8 +1878,10 @@ public class ProtocolTest {
     when(connectionMetadata.getOutputStream()).thenReturn(outputStream);
     when(connectionHandler.getConnectionMetadata()).thenReturn(connectionMetadata);
     when(connectionHandler.getStatus()).thenReturn(ConnectionStatus.COPY_IN);
+    when(server.getMessageReader()).thenReturn(new MessageReader(options));
+    when(connectionHandler.getServer()).thenReturn(server);
 
-    ControlMessage message = ControlMessage.create(connectionHandler);
+    ControlMessage message = server.getMessageReader().create(connectionHandler);
 
     assertEquals(SkipMessage.class, message.getClass());
     // Verify that nothing was written to the output.
@@ -1833,8 +1902,10 @@ public class ProtocolTest {
     when(connectionMetadata.getOutputStream()).thenReturn(outputStream);
     when(connectionHandler.getConnectionMetadata()).thenReturn(connectionMetadata);
     when(connectionHandler.getStatus()).thenReturn(ConnectionStatus.AUTHENTICATED);
+    when(server.getMessageReader()).thenReturn(new MessageReader(options));
+    when(connectionHandler.getServer()).thenReturn(server);
 
-    ControlMessage message = ControlMessage.create(connectionHandler);
+    ControlMessage message = server.getMessageReader().create(connectionHandler);
 
     assertEquals(SkipMessage.class, message.getClass());
     // Verify that nothing was written to the output.
@@ -1853,8 +1924,10 @@ public class ProtocolTest {
     when(connectionMetadata.getOutputStream()).thenReturn(outputStream);
     when(connectionHandler.getConnectionMetadata()).thenReturn(connectionMetadata);
     when(connectionHandler.getStatus()).thenReturn(ConnectionStatus.AUTHENTICATED);
+    when(connectionHandler.getServer()).thenReturn(server);
+    when(server.getMessageReader()).thenReturn(new MessageReader(options));
 
-    ControlMessage message = ControlMessage.create(connectionHandler);
+    ControlMessage message = server.getMessageReader().create(connectionHandler);
 
     assertEquals(SkipMessage.class, message.getClass());
     // Verify that nothing was written to the output.
@@ -1873,8 +1946,10 @@ public class ProtocolTest {
     when(connectionMetadata.getOutputStream()).thenReturn(outputStream);
     when(connectionHandler.getConnectionMetadata()).thenReturn(connectionMetadata);
     when(connectionHandler.getStatus()).thenReturn(ConnectionStatus.AUTHENTICATED);
+    when(server.getMessageReader()).thenReturn(new MessageReader(options));
+    when(connectionHandler.getServer()).thenReturn(server);
 
-    ControlMessage message = ControlMessage.create(connectionHandler);
+    ControlMessage message = server.getMessageReader().create(connectionHandler);
 
     assertEquals(SkipMessage.class, message.getClass());
     // Verify that nothing was written to the output.
@@ -1908,16 +1983,18 @@ public class ProtocolTest {
     when(connectionHandler.getStatus()).thenReturn(ConnectionStatus.AUTHENTICATED);
     doCallRealMethod().when(connectionHandler).increaseInvalidMessageCount();
     when(connectionHandler.getInvalidMessageCount()).thenCallRealMethod();
+    when(server.getMessageReader()).thenReturn(new MessageReader(options));
+    when(connectionHandler.getServer()).thenReturn(server);
 
     for (int i = 0; i < MAX_INVALID_MESSAGE_COUNT; i++) {
-      ControlMessage message = ControlMessage.create(connectionHandler);
+      ControlMessage message = server.getMessageReader().create(connectionHandler);
       assertEquals(SkipMessage.class, message.getClass());
       // Verify that nothing was written to the output.
       assertEquals(0, result.size());
       verify(connectionHandler, never()).setStatus(ConnectionStatus.TERMINATED);
     }
 
-    ControlMessage.create(connectionHandler);
+    server.getMessageReader().create(connectionHandler);
     verify(connectionHandler).setStatus(ConnectionStatus.TERMINATED);
     byte[] resultBytes = result.toByteArray();
     assertEquals('E', resultBytes[0]);


### PR DESCRIPTION
Move the logic for creating a control message to a separate MessageReader class. This makes it easier to optimize this specific part of the code for specific use cases, e.g. introducing a busy-wait for messages in low-QPS scenarios.

This change only moves the code into a separate class, but does not make any changes.