### PR TITLE
feat: support SELECT CURRENT_SCHEMA() AS SCHEMA

### DIFF
--- a/src/main/java/com/google/cloud/spanner/pgadapter/statements/BackendConnection.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/statements/BackendConnection.java
@@ -315,7 +315,7 @@ public class BackendConnection {
                 .hasReplacementStatement()) {
           LocalStatement localStatement =
               Objects.requireNonNull(localStatements.get().get(statement.getSql()));
-          result.set(localStatement.execute(BackendConnection.this));
+          result.set(localStatement.execute(BackendConnection.this, statement));
         } else if (sessionStatement != null) {
           result.set(sessionStatement.execute(sessionState, spannerConnection));
         } else if (connectionState == ConnectionState.ABORTED

--- a/src/main/java/com/google/cloud/spanner/pgadapter/statements/local/AbortTransaction.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/statements/local/AbortTransaction.java
@@ -46,7 +46,7 @@ public class AbortTransaction implements LocalStatement {
   }
 
   @Override
-  public StatementResult execute(BackendConnection backendConnection) {
+  public StatementResult execute(BackendConnection backendConnection, Statement statement) {
     // This should not be possible.
     throw new UnsupportedOperationException();
   }

--- a/src/main/java/com/google/cloud/spanner/pgadapter/statements/local/DjangoGetTableNamesStatement.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/statements/local/DjangoGetTableNamesStatement.java
@@ -16,6 +16,7 @@ package com.google.cloud.spanner.pgadapter.statements.local;
 
 import com.google.api.core.InternalApi;
 import com.google.cloud.spanner.ResultSet;
+import com.google.cloud.spanner.Statement;
 import com.google.cloud.spanner.Type;
 import com.google.cloud.spanner.Type.StructField;
 import com.google.cloud.spanner.connection.StatementResult;
@@ -58,7 +59,7 @@ public class DjangoGetTableNamesStatement implements LocalStatement {
   }
 
   @Override
-  public StatementResult execute(BackendConnection backendConnection) {
+  public StatementResult execute(BackendConnection backendConnection, Statement statement) {
     ResultSet resultSet =
         ClientSideResultSet.forRows(
             Type.struct(

--- a/src/main/java/com/google/cloud/spanner/pgadapter/statements/local/ListDatabasesStatement.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/statements/local/ListDatabasesStatement.java
@@ -21,6 +21,7 @@ import com.google.cloud.spanner.Dialect;
 import com.google.cloud.spanner.InstanceId;
 import com.google.cloud.spanner.ResultSet;
 import com.google.cloud.spanner.Spanner;
+import com.google.cloud.spanner.Statement;
 import com.google.cloud.spanner.Struct;
 import com.google.cloud.spanner.Type;
 import com.google.cloud.spanner.Type.StructField;
@@ -67,7 +68,7 @@ public class ListDatabasesStatement implements LocalStatement {
   }
 
   @Override
-  public StatementResult execute(BackendConnection backendConnection) {
+  public StatementResult execute(BackendConnection backendConnection, Statement statement) {
     Connection connection = backendConnection.getSpannerConnection();
     Spanner spanner = connection.getSpanner();
     InstanceId defaultInstanceId =

--- a/src/main/java/com/google/cloud/spanner/pgadapter/statements/local/LocalStatement.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/statements/local/LocalStatement.java
@@ -47,5 +47,5 @@ public interface LocalStatement {
   }
 
   /** Executes the local statement and returns the result. */
-  StatementResult execute(BackendConnection backendConnection);
+  StatementResult execute(BackendConnection backendConnection, Statement statement);
 }

--- a/src/main/java/com/google/cloud/spanner/pgadapter/statements/local/SelectCurrentCatalogStatement.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/statements/local/SelectCurrentCatalogStatement.java
@@ -16,6 +16,7 @@ package com.google.cloud.spanner.pgadapter.statements.local;
 
 import com.google.api.core.InternalApi;
 import com.google.cloud.spanner.ResultSet;
+import com.google.cloud.spanner.Statement;
 import com.google.cloud.spanner.Struct;
 import com.google.cloud.spanner.Type;
 import com.google.cloud.spanner.Type.StructField;
@@ -50,7 +51,7 @@ public class SelectCurrentCatalogStatement implements LocalStatement {
   }
 
   @Override
-  public StatementResult execute(BackendConnection backendConnection) {
+  public StatementResult execute(BackendConnection backendConnection, Statement statement) {
     ResultSet resultSet =
         ClientSideResultSet.forRows(
             Type.struct(StructField.of("current_catalog", Type.string())),

--- a/src/main/java/com/google/cloud/spanner/pgadapter/statements/local/SelectCurrentDatabaseStatement.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/statements/local/SelectCurrentDatabaseStatement.java
@@ -16,6 +16,7 @@ package com.google.cloud.spanner.pgadapter.statements.local;
 
 import com.google.api.core.InternalApi;
 import com.google.cloud.spanner.ResultSet;
+import com.google.cloud.spanner.Statement;
 import com.google.cloud.spanner.Struct;
 import com.google.cloud.spanner.Type;
 import com.google.cloud.spanner.Type.StructField;
@@ -51,7 +52,7 @@ public class SelectCurrentDatabaseStatement implements LocalStatement {
   }
 
   @Override
-  public StatementResult execute(BackendConnection backendConnection) {
+  public StatementResult execute(BackendConnection backendConnection, Statement statement) {
     ResultSet resultSet =
         ClientSideResultSet.forRows(
             Type.struct(StructField.of("current_database", Type.string())),

--- a/src/main/java/com/google/cloud/spanner/pgadapter/statements/local/SelectCurrentSchemaStatement.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/statements/local/SelectCurrentSchemaStatement.java
@@ -16,6 +16,7 @@ package com.google.cloud.spanner.pgadapter.statements.local;
 
 import com.google.api.core.InternalApi;
 import com.google.cloud.spanner.ResultSet;
+import com.google.cloud.spanner.Statement;
 import com.google.cloud.spanner.Struct;
 import com.google.cloud.spanner.Type;
 import com.google.cloud.spanner.Type.StructField;
@@ -46,20 +47,24 @@ public class SelectCurrentSchemaStatement implements LocalStatement {
       "SELECT * FROM current_schema()",
       "SELECT * FROM CURRENT_SCHEMA()",
       "select * from current_schema",
-      "SELECT * FROM current_schema"
+      "SELECT * FROM current_schema",
+      "SELECT CURRENT_SCHEMA() AS SCHEMA"
     };
   }
 
   @Override
-  public StatementResult execute(BackendConnection backendConnection) {
+  public StatementResult execute(BackendConnection backendConnection, Statement statement) {
+    String alias = "current_schema";
+    if (statement.getSql().equals("SELECT CURRENT_SCHEMA() AS SCHEMA")) {
+      // PostgreSQL folds all identifiers to lower-case, so even though the select statement uses
+      // upper-case, the alias will be returned in lower-case.
+      alias = "schema";
+    }
     ResultSet resultSet =
         ClientSideResultSet.forRows(
-            Type.struct(StructField.of("current_schema", Type.string())),
+            Type.struct(StructField.of(alias, Type.string())),
             ImmutableList.of(
-                Struct.newBuilder()
-                    .set("current_schema")
-                    .to(backendConnection.getCurrentSchema())
-                    .build()));
+                Struct.newBuilder().set(alias).to(backendConnection.getCurrentSchema()).build()));
     return new QueryResult(resultSet);
   }
 }

--- a/src/main/java/com/google/cloud/spanner/pgadapter/statements/local/SelectGolangMigrateAdvisoryLockStatement.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/statements/local/SelectGolangMigrateAdvisoryLockStatement.java
@@ -16,6 +16,7 @@ package com.google.cloud.spanner.pgadapter.statements.local;
 
 import com.google.api.core.InternalApi;
 import com.google.cloud.spanner.ResultSet;
+import com.google.cloud.spanner.Statement;
 import com.google.cloud.spanner.Struct;
 import com.google.cloud.spanner.Type;
 import com.google.cloud.spanner.Type.StructField;
@@ -44,7 +45,7 @@ public class SelectGolangMigrateAdvisoryLockStatement implements LocalStatement 
   }
 
   @Override
-  public StatementResult execute(BackendConnection backendConnection) {
+  public StatementResult execute(BackendConnection backendConnection, Statement statement) {
     ResultSet resultSet =
         ClientSideResultSet.forRows(
             Type.struct(StructField.of("pg_advisory_lock", Type.int64())),

--- a/src/main/java/com/google/cloud/spanner/pgadapter/statements/local/SelectGolangMigrateAdvisoryUnlockStatement.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/statements/local/SelectGolangMigrateAdvisoryUnlockStatement.java
@@ -16,6 +16,7 @@ package com.google.cloud.spanner.pgadapter.statements.local;
 
 import com.google.api.core.InternalApi;
 import com.google.cloud.spanner.ResultSet;
+import com.google.cloud.spanner.Statement;
 import com.google.cloud.spanner.Struct;
 import com.google.cloud.spanner.Type;
 import com.google.cloud.spanner.Type.StructField;
@@ -44,7 +45,7 @@ public class SelectGolangMigrateAdvisoryUnlockStatement implements LocalStatemen
   }
 
   @Override
-  public StatementResult execute(BackendConnection backendConnection) {
+  public StatementResult execute(BackendConnection backendConnection, Statement statement) {
     ResultSet resultSet =
         ClientSideResultSet.forRows(
             Type.struct(StructField.of("pg_advisory_unlock", Type.bool())),

--- a/src/main/java/com/google/cloud/spanner/pgadapter/statements/local/SelectPrismaAdvisoryLockStatement.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/statements/local/SelectPrismaAdvisoryLockStatement.java
@@ -16,6 +16,7 @@ package com.google.cloud.spanner.pgadapter.statements.local;
 
 import com.google.api.core.InternalApi;
 import com.google.cloud.spanner.ResultSet;
+import com.google.cloud.spanner.Statement;
 import com.google.cloud.spanner.Struct;
 import com.google.cloud.spanner.Type;
 import com.google.cloud.spanner.Type.StructField;
@@ -40,7 +41,7 @@ public class SelectPrismaAdvisoryLockStatement implements LocalStatement {
   }
 
   @Override
-  public StatementResult execute(BackendConnection backendConnection) {
+  public StatementResult execute(BackendConnection backendConnection, Statement statement) {
     ResultSet resultSet =
         ClientSideResultSet.forRows(
             Type.struct(StructField.of("pg_advisory_lock", Type.string())),

--- a/src/main/java/com/google/cloud/spanner/pgadapter/statements/local/SelectPrismaAdvisoryUnlockStatement.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/statements/local/SelectPrismaAdvisoryUnlockStatement.java
@@ -16,6 +16,7 @@ package com.google.cloud.spanner.pgadapter.statements.local;
 
 import com.google.api.core.InternalApi;
 import com.google.cloud.spanner.ResultSet;
+import com.google.cloud.spanner.Statement;
 import com.google.cloud.spanner.Struct;
 import com.google.cloud.spanner.Type;
 import com.google.cloud.spanner.Type.StructField;
@@ -40,7 +41,7 @@ public class SelectPrismaAdvisoryUnlockStatement implements LocalStatement {
   }
 
   @Override
-  public StatementResult execute(BackendConnection backendConnection) {
+  public StatementResult execute(BackendConnection backendConnection, Statement statement) {
     ResultSet resultSet =
         ClientSideResultSet.forRows(
             Type.struct(StructField.of("pg_advisory_unlock", Type.bool())),

--- a/src/main/java/com/google/cloud/spanner/pgadapter/statements/local/SelectVersionStatement.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/statements/local/SelectVersionStatement.java
@@ -16,6 +16,7 @@ package com.google.cloud.spanner.pgadapter.statements.local;
 
 import com.google.api.core.InternalApi;
 import com.google.cloud.spanner.ResultSet;
+import com.google.cloud.spanner.Statement;
 import com.google.cloud.spanner.Struct;
 import com.google.cloud.spanner.Type;
 import com.google.cloud.spanner.Type.StructField;
@@ -62,7 +63,7 @@ public class SelectVersionStatement implements LocalStatement {
   }
 
   @Override
-  public StatementResult execute(BackendConnection backendConnection) {
+  public StatementResult execute(BackendConnection backendConnection, Statement statement) {
     ResultSet resultSet =
         ClientSideResultSet.forRows(
             Type.struct(StructField.of("version", Type.string())),

--- a/src/main/java/com/google/cloud/spanner/pgadapter/statements/local/StartTransactionIsolationLevelRepeatableRead.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/statements/local/StartTransactionIsolationLevelRepeatableRead.java
@@ -47,7 +47,7 @@ public class StartTransactionIsolationLevelRepeatableRead implements LocalStatem
   }
 
   @Override
-  public StatementResult execute(BackendConnection backendConnection) {
+  public StatementResult execute(BackendConnection backendConnection, Statement statement) {
     // This should not be possible.
     throw new UnsupportedOperationException();
   }

--- a/src/test/golang/pgadapter_pgx5_tests/go.mod
+++ b/src/test/golang/pgadapter_pgx5_tests/go.mod
@@ -1,6 +1,8 @@
 module cloud.google.com/pgadapter_pgx5_tests
 
-go 1.19
+go 1.23.0
+
+toolchain go1.24.2
 
 require (
 	github.com/jackc/pgtype v1.14.0

--- a/src/test/java/com/google/cloud/spanner/pgadapter/statements/BackendConnectionTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/statements/BackendConnectionTest.java
@@ -23,6 +23,7 @@ import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -385,7 +386,9 @@ public class BackendConnectionTest {
     ListDatabasesStatement listDatabasesStatement = mock(ListDatabasesStatement.class);
     when(listDatabasesStatement.getSql())
         .thenReturn(new String[] {ListDatabasesStatement.LIST_DATABASES_SQL});
-    when(listDatabasesStatement.execute(any(BackendConnection.class)))
+    when(listDatabasesStatement.execute(
+            any(BackendConnection.class),
+            eq(Statement.of(ListDatabasesStatement.LIST_DATABASES_SQL))))
         .thenReturn(listDatabasesResult);
     ImmutableList<LocalStatement> localStatements = ImmutableList.of(listDatabasesStatement);
     ParsedStatement parsedListDatabasesStatement = mock(ParsedStatement.class);
@@ -412,7 +415,8 @@ public class BackendConnectionTest {
             Function.identity());
     backendConnection.flush();
 
-    verify(listDatabasesStatement).execute(backendConnection);
+    verify(listDatabasesStatement)
+        .execute(backendConnection, Statement.of(ListDatabasesStatement.LIST_DATABASES_SQL));
     assertTrue(resultFuture.isDone());
     assertEquals(listDatabasesResult, resultFuture.get());
   }
@@ -450,7 +454,7 @@ public class BackendConnectionTest {
         backendConnection.execute("SELECT", parsedStatement, statement, Function.identity());
     backendConnection.flush();
 
-    verify(listDatabasesStatement, never()).execute(backendConnection);
+    verify(listDatabasesStatement, never()).execute(backendConnection, statement);
     assertTrue(resultFuture.isDone());
     assertEquals(statementResult, resultFuture.get());
   }

--- a/src/test/java/com/google/cloud/spanner/pgadapter/statements/local/DjangoGetTableNamesTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/statements/local/DjangoGetTableNamesTest.java
@@ -19,6 +19,7 @@ import static org.junit.Assert.assertFalse;
 import static org.mockito.Mockito.mock;
 
 import com.google.cloud.spanner.ResultSet;
+import com.google.cloud.spanner.Statement;
 import com.google.cloud.spanner.Type;
 import com.google.cloud.spanner.connection.StatementResult;
 import com.google.cloud.spanner.pgadapter.statements.BackendConnection;
@@ -60,7 +61,9 @@ public class DjangoGetTableNamesTest {
 
     DjangoGetTableNamesStatement djangoGetTableNamesStatement =
         DjangoGetTableNamesStatement.INSTANCE;
-    StatementResult statementResult = djangoGetTableNamesStatement.execute(backendConnection);
+    StatementResult statementResult =
+        djangoGetTableNamesStatement.execute(
+            backendConnection, Statement.of(djangoGetTableNamesSql));
     ResultSet resultSet = statementResult.getResultSet();
     assertFalse(resultSet.next());
     assertEquals(2, resultSet.getColumnCount());

--- a/src/test/java/com/google/cloud/spanner/pgadapter/statements/local/ListDatabasesStatementTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/statements/local/ListDatabasesStatementTest.java
@@ -30,6 +30,7 @@ import com.google.cloud.spanner.Dialect;
 import com.google.cloud.spanner.InstanceId;
 import com.google.cloud.spanner.ResultSet;
 import com.google.cloud.spanner.Spanner;
+import com.google.cloud.spanner.Statement;
 import com.google.cloud.spanner.connection.Connection;
 import com.google.cloud.spanner.connection.ConnectionOptionsHelperTest;
 import com.google.cloud.spanner.connection.StatementResult;
@@ -108,7 +109,9 @@ public class ListDatabasesStatementTest {
     when(backendConnection.getSpannerConnection()).thenReturn(connection);
 
     ListDatabasesStatement statement = new ListDatabasesStatement(connectionHandler);
-    StatementResult result = statement.execute(backendConnection);
+    StatementResult result =
+        statement.execute(
+            backendConnection, Statement.of(ListDatabasesStatement.LIST_DATABASES_SQL));
 
     assertEquals(ResultType.RESULT_SET, result.getResultType());
     ResultSet resultSet = result.getResultSet();
@@ -151,7 +154,9 @@ public class ListDatabasesStatementTest {
     when(backendConnection.getSpannerConnection()).thenReturn(connection);
 
     ListDatabasesStatement statement = new ListDatabasesStatement(connectionHandler);
-    StatementResult result = statement.execute(backendConnection);
+    StatementResult result =
+        statement.execute(
+            backendConnection, Statement.of(ListDatabasesStatement.LIST_DATABASES_SQL));
 
     assertEquals(ResultType.RESULT_SET, result.getResultType());
     ResultSet resultSet = result.getResultSet();
@@ -195,7 +200,9 @@ public class ListDatabasesStatementTest {
     when(backendConnection.getSpannerConnection()).thenReturn(connection);
 
     ListDatabasesStatement statement = new ListDatabasesStatement(connectionHandler);
-    StatementResult result = statement.execute(backendConnection);
+    StatementResult result =
+        statement.execute(
+            backendConnection, Statement.of(ListDatabasesStatement.LIST_DATABASES_SQL));
 
     assertEquals(ResultType.RESULT_SET, result.getResultType());
     ResultSet resultSet = result.getResultSet();
@@ -233,7 +240,9 @@ public class ListDatabasesStatementTest {
     when(backendConnection.getSpannerConnection()).thenReturn(connection);
 
     ListDatabasesStatement statement = new ListDatabasesStatement(connectionHandler);
-    StatementResult result = statement.execute(backendConnection);
+    StatementResult result =
+        statement.execute(
+            backendConnection, Statement.of(ListDatabasesStatement.LIST_DATABASES_SQL));
 
     assertEquals(ResultType.RESULT_SET, result.getResultType());
     ResultSet resultSet = result.getResultSet();

--- a/src/test/java/com/google/cloud/spanner/pgadapter/statements/local/SelectCurrentCatalogStatementTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/statements/local/SelectCurrentCatalogStatementTest.java
@@ -21,6 +21,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.google.cloud.spanner.ResultSet;
+import com.google.cloud.spanner.Statement;
 import com.google.cloud.spanner.pgadapter.statements.BackendConnection;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -36,7 +37,9 @@ public class SelectCurrentCatalogStatementTest {
       when(backendConnection.getCurrentDatabase()).thenReturn(database);
 
       try (ResultSet resultSet =
-          SelectCurrentCatalogStatement.INSTANCE.execute(backendConnection).getResultSet()) {
+          SelectCurrentCatalogStatement.INSTANCE
+              .execute(backendConnection, Statement.of("select current_catalog"))
+              .getResultSet()) {
         assertTrue(resultSet.next());
         assertEquals(1, resultSet.getColumnCount());
         assertEquals(database, resultSet.getString("current_catalog"));

--- a/src/test/java/com/google/cloud/spanner/pgadapter/statements/local/SelectCurrentDatabaseStatementTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/statements/local/SelectCurrentDatabaseStatementTest.java
@@ -21,6 +21,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.google.cloud.spanner.ResultSet;
+import com.google.cloud.spanner.Statement;
 import com.google.cloud.spanner.pgadapter.statements.BackendConnection;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -36,7 +37,9 @@ public class SelectCurrentDatabaseStatementTest {
       when(backendConnection.getCurrentDatabase()).thenReturn(database);
 
       try (ResultSet resultSet =
-          SelectCurrentDatabaseStatement.INSTANCE.execute(backendConnection).getResultSet()) {
+          SelectCurrentDatabaseStatement.INSTANCE
+              .execute(backendConnection, Statement.of("select current_database"))
+              .getResultSet()) {
         assertTrue(resultSet.next());
         assertEquals(1, resultSet.getColumnCount());
         assertEquals(database, resultSet.getString("current_database"));

--- a/src/test/java/com/google/cloud/spanner/pgadapter/statements/local/SelectCurrentSchemaStatementTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/statements/local/SelectCurrentSchemaStatementTest.java
@@ -21,6 +21,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.google.cloud.spanner.ResultSet;
+import com.google.cloud.spanner.Statement;
 import com.google.cloud.spanner.pgadapter.statements.BackendConnection;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -36,10 +37,30 @@ public class SelectCurrentSchemaStatementTest {
       when(backendConnection.getCurrentSchema()).thenReturn(schema);
 
       try (ResultSet resultSet =
-          SelectCurrentSchemaStatement.INSTANCE.execute(backendConnection).getResultSet()) {
+          SelectCurrentSchemaStatement.INSTANCE
+              .execute(backendConnection, Statement.of("select current_schema"))
+              .getResultSet()) {
         assertTrue(resultSet.next());
         assertEquals(1, resultSet.getColumnCount());
         assertEquals(schema, resultSet.getString("current_schema"));
+        assertFalse(resultSet.next());
+      }
+    }
+  }
+
+  @Test
+  public void testExecuteSelectCurrentSchemaAsSchema() {
+    for (String schema : new String[] {"public", "information_schema", "foo"}) {
+      BackendConnection backendConnection = mock(BackendConnection.class);
+      when(backendConnection.getCurrentSchema()).thenReturn(schema);
+
+      try (ResultSet resultSet =
+          SelectCurrentSchemaStatement.INSTANCE
+              .execute(backendConnection, Statement.of("SELECT CURRENT_SCHEMA() AS SCHEMA"))
+              .getResultSet()) {
+        assertTrue(resultSet.next());
+        assertEquals(1, resultSet.getColumnCount());
+        assertEquals(schema, resultSet.getString("schema"));
         assertFalse(resultSet.next());
       }
     }

--- a/src/test/java/com/google/cloud/spanner/pgadapter/statements/local/SelectVersionStatementTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/statements/local/SelectVersionStatementTest.java
@@ -21,6 +21,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.google.cloud.spanner.ResultSet;
+import com.google.cloud.spanner.Statement;
 import com.google.cloud.spanner.pgadapter.session.PGSetting;
 import com.google.cloud.spanner.pgadapter.session.SessionState;
 import com.google.cloud.spanner.pgadapter.statements.BackendConnection;
@@ -41,7 +42,9 @@ public class SelectVersionStatementTest {
       when(pgSetting.getSetting()).thenReturn(version);
 
       try (ResultSet resultSet =
-          SelectVersionStatement.INSTANCE.execute(backendConnection).getResultSet()) {
+          SelectVersionStatement.INSTANCE
+              .execute(backendConnection, Statement.of("select server_version"))
+              .getResultSet()) {
         assertTrue(resultSet.next());
         assertEquals(1, resultSet.getColumnCount());
         assertEquals("PostgreSQL " + version, resultSet.getString("version"));


### PR DESCRIPTION
Add support for `SELECT CURRENT_SCHEMA() AS SCHEMA` that is generated by Symfony.

Fixes #3165