### PR TITLE
fix: send UUID values as untyped strings to Spanner

### DIFF
--- a/src/main/java/com/google/cloud/spanner/pgadapter/parsers/UuidParser.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/parsers/UuidParser.java
@@ -136,7 +136,8 @@ public class UuidParser extends Parser<UUID> {
   @Override
   public void bind(ImmutableMap.Builder<String, Value> parametersBuilder, String name) {
     // Send UUIDs to Spanner as untyped string values, so these can be used with both varchar and
-    // UUID columns.
+    // UUID columns. This ensures backwards compatibility, as PGAdapter would send UUID values as
+    // strings to Spanner before UUID type support was added to Spanner.
     parametersBuilder.put(
         name,
         this.item == null

--- a/src/main/java/com/google/cloud/spanner/pgadapter/parsers/UuidParser.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/parsers/UuidParser.java
@@ -22,6 +22,7 @@ import com.google.cloud.spanner.pgadapter.error.PGException;
 import com.google.cloud.spanner.pgadapter.error.SQLState;
 import com.google.cloud.spanner.pgadapter.error.Severity;
 import com.google.common.collect.ImmutableMap;
+import com.google.protobuf.NullValue;
 import java.nio.charset.StandardCharsets;
 import java.util.UUID;
 import javax.annotation.Nonnull;
@@ -30,6 +31,9 @@ import org.postgresql.util.ByteConverter;
 /** Translate from wire protocol to UUID. */
 @InternalApi
 public class UuidParser extends Parser<UUID> {
+  private static final Value NULL_VALUE =
+      Value.untyped(
+          com.google.protobuf.Value.newBuilder().setNullValue(NullValue.NULL_VALUE).build());
 
   UuidParser(Object item) {
     this.item = (UUID) item;
@@ -131,6 +135,15 @@ public class UuidParser extends Parser<UUID> {
 
   @Override
   public void bind(ImmutableMap.Builder<String, Value> parametersBuilder, String name) {
-    parametersBuilder.put(name, Value.uuid(this.item));
+    // Send UUIDs to Spanner as untyped string values, so these can be used with both varchar and
+    // UUID columns.
+    parametersBuilder.put(
+        name,
+        this.item == null
+            ? NULL_VALUE
+            : Value.untyped(
+                com.google.protobuf.Value.newBuilder()
+                    .setStringValue(this.item.toString())
+                    .build()));
   }
 }

--- a/src/test/java/com/google/cloud/spanner/pgadapter/ITJdbcTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/ITJdbcTest.java
@@ -22,6 +22,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeTrue;
 
 import com.google.cloud.ByteArray;
 import com.google.cloud.Date;
@@ -51,6 +52,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.UUID;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -1220,6 +1222,28 @@ public class ITJdbcTest implements IntegrationTest {
         assertEquals("spanner_sys", namespaces.getString(1));
 
         assertFalse(namespaces.next());
+      }
+    }
+  }
+
+  @Test
+  public void testUUID() throws SQLException {
+    // UUIDs are only supported in extended query mode.
+    // In simple mode, the PG driver will try to cast a literal to UUID.
+    assumeTrue(preferQueryMode.equals("extended"));
+
+    try (Connection connection = DriverManager.getConnection(getConnectionUrl())) {
+      connection.createStatement().execute("truncate uuid_values");
+      // It should be possible to use UUID query parameters with both UUID and varchar columns.
+      try (PreparedStatement statement =
+          connection.prepareStatement(
+              "insert into uuid_values (id, col_varchar, col_uuid) values (?, ?, ?)")) {
+        UUID uuid = UUID.randomUUID();
+        // Verify that we can insert a UUID value into both a varchar and a UUID column.
+        statement.setLong(1, 1L);
+        statement.setObject(2, uuid);
+        statement.setObject(3, uuid);
+        assertEquals(1, statement.executeUpdate());
       }
     }
   }

--- a/src/test/java/com/google/cloud/spanner/pgadapter/ITJdbcTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/ITJdbcTest.java
@@ -1233,6 +1233,11 @@ public class ITJdbcTest implements IntegrationTest {
     assumeTrue(preferQueryMode.equals("extended"));
 
     try (Connection connection = DriverManager.getConnection(getConnectionUrl())) {
+      // TODO: Change type to UUID once supported.
+      connection
+          .createStatement()
+          .execute(
+              "create table if not exists uuid_values (id bigint primary key, col_varchar varchar, col_uuid varchar)");
       connection.createStatement().execute("truncate uuid_values");
       // It should be possible to use UUID query parameters with both UUID and varchar columns.
       try (PreparedStatement statement =

--- a/src/test/java/com/google/cloud/spanner/pgadapter/JdbcMockServerTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/JdbcMockServerTest.java
@@ -4951,9 +4951,8 @@ public class JdbcMockServerTest extends AbstractMockServerTest {
     String jdbcSql = "SELECT * FROM all_types WHERE col_uuid=?";
     String pgSql = "SELECT * FROM all_types WHERE col_uuid=$1";
     UUID uuid = UUID.randomUUID();
-    mockSpanner.putStatementResult(
-        StatementResult.query(
-            Statement.newBuilder(pgSql).bind("p1").to(uuid).build(), ALL_TYPES_RESULTSET));
+    mockSpanner.putPartialStatementResult(
+        StatementResult.query(Statement.of(pgSql), ALL_TYPES_RESULTSET));
 
     try (Connection connection = DriverManager.getConnection(createUrl())) {
       try (PreparedStatement statement = connection.prepareStatement(jdbcSql)) {
@@ -4966,6 +4965,11 @@ public class JdbcMockServerTest extends AbstractMockServerTest {
     }
 
     assertEquals(1, mockSpanner.countRequestsOfType(ExecuteSqlRequest.class));
+    ExecuteSqlRequest request = mockSpanner.getRequestsOfType(ExecuteSqlRequest.class).get(0);
+    assertEquals(1, request.getParams().getFieldsCount());
+    // UUIDs should be sent to Spanner as untyped values, so Spanner can infer the correct data
+    // type. This allows clients to use UUID query parameters with both STRING and UUID columns.
+    assertEquals(0, request.getParamTypesCount());
   }
 
   @Test

--- a/src/test/java/com/google/cloud/spanner/pgadapter/PgAdapterTestEnv.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/PgAdapterTestEnv.java
@@ -140,9 +140,7 @@ public class PgAdapterTestEnv {
               + "col_array_interval varchar[], "
               + "col_array_date date[], "
               + "col_array_varchar varchar(100)[], "
-              + "col_array_jsonb jsonb[])",
-          // TODO: Change type to UUID once supported.
-          "create table uuid_values (id bigint primary key, col_varchar varchar, col_uuid varchar)");
+              + "col_array_jsonb jsonb[])");
 
   public static final ImmutableList<String> DEFAULT_DATA_MODEL_WITHOUT_COL_INTERVAL =
       DEFAULT_DATA_MODEL.stream()

--- a/src/test/java/com/google/cloud/spanner/pgadapter/PgAdapterTestEnv.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/PgAdapterTestEnv.java
@@ -140,7 +140,9 @@ public class PgAdapterTestEnv {
               + "col_array_interval varchar[], "
               + "col_array_date date[], "
               + "col_array_varchar varchar(100)[], "
-              + "col_array_jsonb jsonb[])");
+              + "col_array_jsonb jsonb[])",
+          // TODO: Change type to UUID once supported.
+          "create table uuid_values (id bigint primary key, col_varchar varchar, col_uuid varchar)");
 
   public static final ImmutableList<String> DEFAULT_DATA_MODEL_WITHOUT_COL_INTERVAL =
       DEFAULT_DATA_MODEL.stream()


### PR DESCRIPTION
Send UUID query parameter values as untyped string values to Spanner, so these can be used with both varchar and UUID columns. The latter is not yet supported on Spanner, so the tests currently only verify that they can be used with varchar.