### PR TITLE
fix: encoded string too long could be returned

### DIFF
--- a/src/main/java/com/google/cloud/spanner/pgadapter/parsers/StringParser.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/parsers/StringParser.java
@@ -91,25 +91,13 @@ public class StringParser extends Parser<String> {
   static void writeToPG(
       SessionState sessionState, DataOutputStream dataOutputStream, String value, byte[] header) {
     int bufferSize = sessionState.getStringConversionBufferSize();
-    // Skip getting the length if we don't need it.
-    int length = bufferSize <= 0 ? 0 : value.length();
+    int length = value.length();
     try {
       if (bufferSize <= 0 || length < bufferSize) {
-        // Just use the writeUTF method of DataOutputStream if there is no header that needs to be
-        // written.
-        if (header.length == 0) {
-          // PG expects the length be 4 bytes.
-          // writeUTF writes the length as 2 bytes.
-          // So in order to get the correct length written to the stream, we first write 2 bytes
-          // containing all zeros.
-          dataOutputStream.writeShort(0);
-          dataOutputStream.writeUTF(value);
-        } else {
-          byte[] bytes = value.getBytes(StandardCharsets.UTF_8);
-          dataOutputStream.writeInt(bytes.length + header.length);
-          dataOutputStream.write(header);
-          dataOutputStream.write(bytes);
-        }
+        byte[] bytes = value.getBytes(StandardCharsets.UTF_8);
+        dataOutputStream.writeInt(bytes.length + header.length);
+        dataOutputStream.write(header);
+        dataOutputStream.write(bytes);
       } else {
         try (OutputStreamWriter writer =
             new OutputStreamWriter(dataOutputStream, StandardCharsets.UTF_8)) {

--- a/src/test/java/com/google/cloud/spanner/pgadapter/JdbcMockServerTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/JdbcMockServerTest.java
@@ -684,6 +684,86 @@ public class JdbcMockServerTest extends AbstractMockServerTest {
   }
 
   @Test
+  public void testLargeString() throws SQLException {
+    String sql = "select large_varchar from test";
+    Random rand = new Random();
+    for (int size : new int[] {100, rand.nextInt(100_000) + 1}) {
+      byte[] bytes = new byte[size];
+      rand.nextBytes(bytes);
+      String value = new String(bytes);
+      mockSpanner.putStatementResult(
+          StatementResult.query(
+              Statement.of(sql),
+              com.google.spanner.v1.ResultSet.newBuilder()
+                  .setMetadata(createMetadata(ImmutableList.of(TypeCode.STRING)))
+                  .addRows(
+                      ListValue.newBuilder()
+                          .addValues(Value.newBuilder().setStringValue(value).build())
+                          .build())
+                  .build()));
+
+      try (Connection connection = DriverManager.getConnection(createUrl())) {
+        connection.unwrap(PGConnection.class).setPrepareThreshold(-1);
+        for (int bufferSize : new int[] {0, 32}) {
+          connection
+              .createStatement()
+              .execute(String.format("set spanner.string_conversion_buffer_size=%d", bufferSize));
+          try (ResultSet resultSet = connection.createStatement().executeQuery(sql)) {
+            assertTrue(resultSet.next());
+            assertEquals(value, resultSet.getString(1));
+            assertFalse(resultSet.next());
+          }
+        }
+      }
+    }
+  }
+
+  @Test
+  public void testLargeJsonb() throws SQLException {
+    String sql = "select large_jsonb from test";
+    Random rand = new Random();
+    for (int size : new int[] {100, rand.nextInt(100_000) + 1}) {
+      byte[] bytes = new byte[size];
+      rand.nextBytes(bytes);
+      String json = String.format("{\"key\": \"%s\"}", Base64.getEncoder().encodeToString(bytes));
+      mockSpanner.putStatementResult(
+          StatementResult.query(
+              Statement.of(sql),
+              com.google.spanner.v1.ResultSet.newBuilder()
+                  .setMetadata(createMetadata(ImmutableList.of(TypeCode.JSON)))
+                  .addRows(
+                      ListValue.newBuilder()
+                          .addValues(Value.newBuilder().setStringValue(json).build())
+                          .build())
+                  .build()));
+
+      for (String binaryTransfer : new String[] {"", "&binaryTransferEnable=" + Oid.JSONB}) {
+        try (Connection connection = DriverManager.getConnection(createUrl() + binaryTransfer)) {
+          connection.unwrap(PGConnection.class).setPrepareThreshold(-1);
+          for (int bufferSize : new int[] {0, 32}) {
+            connection
+                .createStatement()
+                .execute(String.format("set spanner.string_conversion_buffer_size=%d", bufferSize));
+            try (ResultSet resultSet = connection.createStatement().executeQuery(sql)) {
+              assertTrue(resultSet.next());
+              if (binaryTransfer.isEmpty()) {
+                assertEquals(json, resultSet.getString(1));
+              } else {
+                byte[] receivedBytes = resultSet.getBytes(1);
+                assertNotNull(receivedBytes);
+                assertTrue(receivedBytes.length > 0);
+                String receivedString = new String(receivedBytes, 1, receivedBytes.length - 1);
+                assertEquals(json, receivedString);
+              }
+              assertFalse(resultSet.next());
+            }
+          }
+        }
+      }
+    }
+  }
+
+  @Test
   public void testGetCatalogs() throws SQLException {
     mockSpanner.putStatementResult(
         StatementResult.query(


### PR DESCRIPTION
Too long string or jsonb values could lead to the error "encoded string too long" to be returned.

This was introduced by the optimization in #3096, and this reverts part of that optimization.

Fixes #3235