### PR TITLE
fix: send error for invalid startup message

### DIFF
--- a/src/main/java/com/google/cloud/spanner/pgadapter/ConnectionHandler.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/ConnectionHandler.java
@@ -402,6 +402,13 @@ public class ConnectionHandler implements Runnable {
         // message. This also prevents probers that just check for an open TCP port to cause errors
         // to be logged.
         return result;
+      } catch (Exception exception) {
+        this.handleError(
+            PGException.newBuilder(exception)
+                .setSeverity(Severity.FATAL)
+                .setSQLState(SQLState.InternalError)
+                .build());
+        throw exception;
       }
       try {
         if (!ssl


### PR DESCRIPTION
If the client sends an invalid startup message, PGAdapter would just close the connection without sending an error message. An extra error handler has been added to catch these errors, write an error response, and then close the connection.

The failure in `go-sample-test` will only be resolved once this fix has been submitted and released, as the test uses the released version of PGAdapter.

Fixes #3237