### PR TITLE
fix: enable OpenTelemetry traces in Spanner

### DIFF
--- a/src/main/java/com/google/cloud/spanner/pgadapter/ConnectionHandler.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/ConnectionHandler.java
@@ -31,7 +31,6 @@ import com.google.cloud.spanner.Spanner;
 import com.google.cloud.spanner.SpannerException;
 import com.google.cloud.spanner.SpannerException.ResourceNotFoundException;
 import com.google.cloud.spanner.SpannerExceptionFactory;
-import com.google.cloud.spanner.SpannerOptions;
 import com.google.cloud.spanner.Statement;
 import com.google.cloud.spanner.connection.AbstractStatementParser;
 import com.google.cloud.spanner.connection.AbstractStatementParser.ParsedStatement;
@@ -228,8 +227,7 @@ public class ConnectionHandler implements Runnable {
                     options.getSessionPoolOptions().toBuilder())
                 .build();
     connectionOptionsBuilder.setSessionPoolOptions(sessionPoolOptions);
-    if (options.isEnableOpenTelemetryMetrics()) {
-      SpannerOptions.enableOpenTelemetryMetrics();
+    if (options.isEnableOpenTelemetry() || options.isEnableOpenTelemetryMetrics()) {
       connectionOptionsBuilder =
           connectionOptionsBuilder.setOpenTelemetry(server.getOpenTelemetry());
     }

--- a/src/main/java/com/google/cloud/spanner/pgadapter/Server.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/Server.java
@@ -19,6 +19,7 @@ import com.google.cloud.opentelemetry.metric.GoogleCloudMetricExporter;
 import com.google.cloud.opentelemetry.metric.MetricConfiguration;
 import com.google.cloud.opentelemetry.trace.TraceConfiguration;
 import com.google.cloud.opentelemetry.trace.TraceExporter;
+import com.google.cloud.spanner.SpannerOptions;
 import com.google.cloud.spanner.pgadapter.ProxyServer.ShutdownMode;
 import com.google.cloud.spanner.pgadapter.logging.DefaultLogConfiguration;
 import com.google.cloud.spanner.pgadapter.metadata.OptionsMetadata;
@@ -238,6 +239,7 @@ public class Server {
       AutoConfiguredOpenTelemetrySdkBuilder openTelemetryBuilder =
           AutoConfiguredOpenTelemetrySdk.builder();
       if (optionsMetadata.isEnableOpenTelemetry()) {
+        SpannerOptions.enableOpenTelemetryTraces();
         TraceConfiguration.Builder builder =
             TraceConfiguration.builder().setDeadline(Duration.ofSeconds(60L));
         if (projectId != null) {
@@ -269,6 +271,7 @@ public class Server {
                     .addSpanProcessor(BatchSpanProcessor.builder(traceExporter).build()));
       }
       if (optionsMetadata.isEnableOpenTelemetryMetrics()) {
+        SpannerOptions.enableOpenTelemetryMetrics();
         MetricExporter cloudMonitoringExporter =
             GoogleCloudMetricExporter.createWithConfiguration(
                 MetricConfiguration.builder()

--- a/src/test/java/com/google/cloud/spanner/MockServerHelper.java
+++ b/src/test/java/com/google/cloud/spanner/MockServerHelper.java
@@ -27,4 +27,9 @@ public class MockServerHelper {
   public static Session getSession(MockSpannerServiceImpl server, String sessionName) {
     return server.getSession(sessionName);
   }
+
+  @InternalApi
+  public static void resetActiveTracingFramework() {
+    SpannerOptions.resetActiveTracingFramework();
+  }
 }

--- a/src/test/java/com/google/cloud/spanner/pgadapter/OpenTelemetryMockServerTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/OpenTelemetryMockServerTest.java
@@ -14,6 +14,7 @@
 
 package com.google.cloud.spanner.pgadapter;
 
+import static com.google.cloud.spanner.MockServerHelper.resetActiveTracingFramework;
 import static org.junit.Assert.assertEquals;
 
 import com.google.cloud.NoCredentials;
@@ -44,6 +45,7 @@ public class OpenTelemetryMockServerTest extends AbstractMockServerTest {
             .setEnableOpenTelemetry()
             .setOpenTelemetryTraceRatio(1.0)
             .build();
+    resetActiveTracingFramework();
     OpenTelemetry openTelemetry = Server.setupOpenTelemetry(options);
     doStartMockSpannerAndPgAdapterServers(
         createMockSpannerThatReturnsOneQueryPartition(), "d", configurator -> {}, openTelemetry);


### PR DESCRIPTION
When OpenTelemetry has been enabled, it also needs to enable tracing using OpenTelemetry in Spanner for traces from the Spanner client library to be included.