### PR TITLE
build: run some of the samples on arm64

### DIFF
--- a/.github/workflows/samples.yaml
+++ b/.github/workflows/samples.yaml
@@ -28,7 +28,7 @@ jobs:
         working-directory: ./samples/java/spring-data-jpa
         run: mvn test -B -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
   go-samples:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
@@ -75,7 +75,7 @@ jobs:
           pip install -r requirements.txt
           python connectorx_sample.py
   nodejs-samples:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4


### PR DESCRIPTION
Run a subset of the samples on arm64 to ensure that we get a signal if the arm64 Docker image with the emulator is broken.

Updates #3331