### PR TITLE
build: override testcontainers docker host to force IPv4

### DIFF
--- a/.github/workflows/samples.yaml
+++ b/.github/workflows/samples.yaml
@@ -87,16 +87,22 @@ jobs:
         run: |
           npm install
           npm start
+        env:
+          TESTCONTAINERS_HOST_OVERRIDE: 127.0.0.1
       - name: Run Sequelize Sample tests
         working-directory: ./samples/nodejs/sequelize
         run: |
           npm install
           npm start
+        env:
+          TESTCONTAINERS_HOST_OVERRIDE: 127.0.0.1
       - name: Run Prisma Sample tests
         working-directory: ./samples/nodejs/prisma-sample-app
         run: |
           npm install
           npm start
+        env:
+          TESTCONTAINERS_HOST_OVERRIDE: 127.0.0.1
   ruby-samples:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Override the testcontainers endpoint to ensure it uses IPv4 for administrative operations (e.g. connecting to the reaper, which is responsible for removing dangling test containers).