### PR TITLE
chore: downgrade testcontainers to 4.10.0

### DIFF
--- a/samples/python/psycopg3/requirements.txt
+++ b/samples/python/psycopg3/requirements.txt
@@ -1,5 +1,5 @@
 psycopg[binary]~=3.2.9
-testcontainers~=4.11.0
+testcontainers~=4.10.0
 requests==2.32.4
 google~=3.0.0
 google.auth~=2.40.3


### PR DESCRIPTION
testcontainers 4.11.0 has been yanked.
See https://pypi.org/project/testcontainers/#history