### PR TITLE
chore: downgrade OpenTelemetry version for benchmark

### DIFF
--- a/benchmarks/latency-comparison/java/pom.xml
+++ b/benchmarks/latency-comparison/java/pom.xml
@@ -43,7 +43,7 @@
       <dependency>
         <groupId>io.opentelemetry</groupId>
         <artifactId>opentelemetry-bom</artifactId>
-        <version>1.52.0</version>
+        <version>1.50.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
Downgrade the version of OpenTelemetry that is used for the Java benchmark to match the version used by PGAdapter. This prevents version conflicts.