### PR TITLE
test: pin the exact Prisma version for tests

### DIFF
--- a/src/test/java/com/google/cloud/spanner/pgadapter/nodejs/PrismaMockServerTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/nodejs/PrismaMockServerTest.java
@@ -1904,7 +1904,7 @@ public class PrismaMockServerTest extends AbstractMockServerTest {
             + "  from information_schema.schemata\n"
             + ")\n"
             + "\n"
-            + "                SELECT replace(tbl.relname, 'prisma_migrations', '_prisma_migrations') AS table_name\n"
+            + "                SELECT replace(tbl.relname, 'prisma_migrations', '_prisma_migrations') AS table_name, namespace.nspname AS table_namespace\n"
             + "                FROM pg_class AS tbl\n"
             + "                INNER JOIN pg_namespace AS namespace ON namespace.oid = tbl.relnamespace\n"
             + "                WHERE tbl.relkind = 'r' AND namespace.nspname = ANY ( $1 )\n"
@@ -1916,6 +1916,11 @@ public class PrismaMockServerTest extends AbstractMockServerTest {
                     .addFields(
                         Field.newBuilder()
                             .setName("table_name")
+                            .setType(Type.newBuilder().setCode(TypeCode.STRING).build())
+                            .build())
+                    .addFields(
+                        Field.newBuilder()
+                            .setName("table_namespace")
                             .setType(Type.newBuilder().setCode(TypeCode.STRING).build())
                             .build())
                     .build())

--- a/src/test/nodejs/prisma-tests/package.json
+++ b/src/test/nodejs/prisma-tests/package.json
@@ -15,7 +15,7 @@
     "typescript": "^5.8.2"
   },
   "dependencies": {
-    "@prisma/client": "^6.5.0",
+    "@prisma/client": "6.13.0",
     "yargs": "^17.5.1"
   }
 }


### PR DESCRIPTION
Pin the exact Prisma version that is used for tests, to prevent new releases from breaking the build randomly. Version 6.13.0 introduced a new system query that currently breaks the existing tests.