### PR TITLE
chore: disable SSL in gorm sample

### DIFF
--- a/samples/golang/gorm/sample.go
+++ b/samples/golang/gorm/sample.go
@@ -205,7 +205,7 @@ func runSample(project, instance, database string, emulator, isOpenSourcePG bool
 		}
 		// Use the fully-qualified database name, as PGAdapter was started without any specific project, instance or
 		// database in the command line arguments.
-		connString = fmt.Sprintf("host=127.0.0.1 port=%d database=projects/%s/instances/%s/databases/%s", port, project, instance, database)
+		connString = fmt.Sprintf("host=127.0.0.1 sslmode=disable port=%d database=projects/%s/instances/%s/databases/%s", port, project, instance, database)
 	}
 	fmt.Printf("Connecting to %s\n", connString)
 	return RunSample(connString, isOpenSourcePG)


### PR DESCRIPTION
Disable SSL when running the gorm sample, as PGAdapter does not enable SSL by default. Disabling SSL in the connection string means that gorm connects more quickly, as it does not first try SSL. It (hopefully) also fixes some flaky test failures, where the test fails due to the error `tls error: read tcp 127.0.0.1:40944->127.0.0.1:32769: read: connection reset by peer`.