### PR TITLE
feat: a single multiplexed session is used for all operations

### DIFF
--- a/docs/command_line_arguments.md
+++ b/docs/command_line_arguments.md
@@ -92,7 +92,9 @@
     additional properties that will be used with that internal JDBC connection. All connection properties
     that are supported by the Cloud Spanner JDBC driver can also be used with this option.
     They should be in the format <key1>=<value1>;<key2>=<value2>;...
-  * Example: -r minSessions=500;maxSessions=1000;numChannels=10
+  * Example: -r numChannels=10;databaserole=my-role
+  * See https://github.com/googleapis/java-spanner-jdbc/blob/main/documentation/connection_properties.md
+    for a full list of supported properties.
 
 -v
   * This option specifies what server_version PGAdapter should claim to be. If not specified

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -57,17 +57,21 @@ SSL modes `Enabled` and `Required` require that a private key and a public certi
 the Java keystore. See [SSL Connections](ssl.md) for more information.
 
 ### How can I configure the number of sessions and/or number of gRPC channels that PGAdapter should use?
+PGAdapter uses a single [multiplexed session](https://cloud.google.com/spanner/docs/sessions#multiplexed_sessions)
+for all operations. One multiplexed session can handle any number of concurrent transactions.
+You do not need to provision a session pool.
+
 You can use the `-r` command line argument when starting PGAdapter to specify additional connection
 properties that PGAdapter should use when it is connecting to Cloud Spanner. All connection properties
 that are [supported by the JDBC driver for Cloud Spanner](https://github.com/googleapis/java-spanner-jdbc#connection-url-properties)
 are also supported by PGAdapter.
 
-Example: Use the following arguments to instruct PGAdapter to use a session pool with
-`MinSessions=200`, `MaxSessions=1600` and `NumChannels=16` (number of gRPC channels).
+Example: Use the following arguments to instruct PGAdapter to use a gRPC channel pool with
+`NumChannels=16` (number of gRPC channels).
 
 ```shell
 java -jar pgadapter.jar -p my-project -i my-instance -d my-database \
-     -r="minSessions=200;maxSessions=1600;numChannels=16"
+     -r="numChannels=16"
 ```
 
 ## Docker

--- a/docs/pgbench.md
+++ b/docs/pgbench.md
@@ -90,23 +90,23 @@ pgbench "host=/tmp port=5432 dbname=my-database" \
         --protocol=extended
 ```
 
-Note that PGAdapter by default creates an internal Cloud Spanner session pool containing at most
-400 sessions. Running `pgbench` with more than 400 clients requires more sessions.
+Note that PGAdapter by default uses a gRPC channel pool with 4 channels.
+Running `pgbench` with more than 400 clients efficiently requires more channels.
 
-Starting PGAdapter using Java with a larger session pool:
+Starting PGAdapter using Java with a larger gRPC channel pool:
 
 ```shell
 java -jar pgadapter.jar -p my-project -i my-instance -d my-database \
-     -r="minSessions=800;maxSessions=800;numChannels=16"
+     -r="numChannels=16"
 ```
 
-Starting PGAdapter using Docker with a larger session pool:
+Starting PGAdapter using Docker with a larger gRPC channel pool:
 
 ```shell
 docker run -p 5432:5432 \
   gcr.io/cloud-spanner-pg-adapter/pgadapter \
   -p my-project -i my-instance -x \
-  -r="minSessions=800;maxSessions=800;numChannels=16"
+  -r="numChannels=16"
 ```
 
 ```shell


### PR DESCRIPTION
PGAdapter now uses a single multiplexed session for all operations. This applies to all operations in auto-commit mode, in read-only transactions, and in read/write transactions.

One multiplexed session can execute an unlimited number of operations concurrently.

Configuring minSessions and maxSessions in the connection URL is therefore no longer needed for workloads that execute a large number of concurrent transactions.