### PR TITLE
ci: use airlock for moss pipeline for container images

### DIFF
--- a/build/Dockerfile_moss
+++ b/build/Dockerfile_moss
@@ -1,0 +1,53 @@
+################################################################################
+#                                     BUILD                                    #
+################################################################################
+
+# maven:3-eclipse-temurin-21
+FROM us-docker.pkg.dev/artifact-foundry-prod/docker-3p-trusted/maven@sha256:8472bdbac39626b70d2efcf87e23468ff0bea9ba48c35181b07e6932b5fda001 AS build
+
+
+# Copy over build files to docker image.
+COPY LICENSE ./
+COPY CONTRIBUTING.md ./
+COPY README.md ./
+COPY NOTIFICATIONS.md ./
+COPY logging.properties ./
+COPY src src/
+COPY pom.xml ./
+COPY license-checks.xml ./
+COPY java.header ./
+
+COPY settings_wagon_moss.xml /root/.m2/settings_wagon_moss.xml
+# Download the artifactregistry-maven-wagon
+RUN mvn -B -s /root/.m2/settings_wagon_moss.xml dependency:get -Dartifact="com.google.cloud.artifactregistry:artifactregistry-maven-wagon:2.2.4"
+
+# Copy airlock settings
+COPY settings_moss.xml /root/.m2/settings.xml
+
+COPY extensions_moss.xml .mvn/extensions.xml
+
+# Download dependencies from airlock
+RUN mvn -B -s /root/.m2/settings.xml dependency:go-offline
+
+# Build from source.
+RUN mvn -B -s /root/.m2/settings.xml package -Passembly -DskipTests
+
+################################################################################
+#                                   RELEASE                                    #
+################################################################################
+
+#eclipse-temurin:21-jre-alpine
+FROM us-docker.pkg.dev/artifact-foundry-prod/docker-3p-trusted/eclipse-temurin@sha256:f05c742dd20051b104b939370f7db4d6eb420cc7fd842aeb4e2446837da3bd03
+
+COPY --from=build target/pgadapter /home/pgadapter
+COPY --from=build LICENSE /home/pgadapter/
+COPY --from=build CONTRIBUTING.md /home/pgadapter/
+COPY --from=build README.md /home/pgadapter/
+COPY --from=build NOTIFICATIONS.md /home/pgadapter/
+COPY --from=build logging.properties /home/pgadapter/
+
+# Add startup script.
+ADD build/startup.sh /home/pgadapter/startup.sh
+RUN chmod +x /home/pgadapter/startup.sh
+
+ENTRYPOINT ["/bin/bash", "/home/pgadapter/startup.sh"]

--- a/build/distroless/Dockerfile_moss
+++ b/build/distroless/Dockerfile_moss
@@ -1,0 +1,50 @@
+################################################################################
+#                                     BUILD                                    #
+################################################################################
+
+# maven:3-eclipse-temurin-21
+FROM us-docker.pkg.dev/artifact-foundry-prod/docker-3p-trusted/maven@sha256:8472bdbac39626b70d2efcf87e23468ff0bea9ba48c35181b07e6932b5fda001 AS build
+
+# Copy over build files to docker image.
+COPY LICENSE ./
+COPY CONTRIBUTING.md ./
+COPY README.md ./
+COPY NOTIFICATIONS.md ./
+COPY logging.properties ./
+COPY src src/
+COPY pom.xml ./
+COPY license-checks.xml ./
+COPY java.header ./
+
+COPY settings_wagon_moss.xml /root/.m2/settings_wagon_moss.xml
+# Download the artifactregistry-maven-wagon
+RUN mvn -B -s /root/.m2/settings_wagon_moss.xml dependency:get -Dartifact="com.google.cloud.artifactregistry:artifactregistry-maven-wagon:2.2.4"
+
+# Copy airlock settings
+COPY settings_moss.xml /root/.m2/settings.xml
+
+COPY extensions_moss.xml .mvn/extensions.xml
+
+# Download dependencies from airlock
+RUN mvn -B -s /root/.m2/settings.xml dependency:go-offline
+
+# Build from source.
+RUN mvn -B -s /root/.m2/settings.xml package -Passembly -DskipTests
+
+################################################################################
+#                                   RELEASE                                    #
+################################################################################
+
+FROM gcr.io/distroless/java21-debian12:nonroot
+
+COPY --from=build --chown=nonroot target/pgadapter /home/pgadapter
+COPY --from=build --chown=nonroot LICENSE /home/pgadapter/
+COPY --from=build --chown=nonroot CONTRIBUTING.md /home/pgadapter/
+COPY --from=build --chown=nonroot README.md /home/pgadapter/
+COPY --from=build --chown=nonroot NOTIFICATIONS.md /home/pgadapter/
+COPY --from=build --chown=nonroot logging.properties /home/pgadapter/
+
+# Run as nonroot
+USER 65532
+WORKDIR /home/pgadapter
+ENTRYPOINT ["/usr/bin/java", "-jar", "pgadapter.jar"]

--- a/extensions_moss.xml
+++ b/extensions_moss.xml
@@ -1,0 +1,8 @@
+<extensions xmlns="http://maven.apache.org/EXTENSIONS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/EXTENSIONS/1.0.0 http://maven.apache.org/xsd/core-extensions-1.0.0.xsd">
+  <extension>
+    <groupId>com.google.cloud.artifactregistry</groupId>
+    <artifactId>artifactregistry-maven-wagon</artifactId>
+    <version>2.2.4</version>
+  </extension>
+</extensions>

--- a/settings_moss.xml
+++ b/settings_moss.xml
@@ -1,0 +1,69 @@
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 https://maven.apache.org/xsd/settings-1.0.0.xsd">
+  <mirrors>
+    <mirror>
+      <id>airlock</id>
+      <name>Airlock Maven 3P Trusted</name>
+      <url>artifactregistry://us-maven.pkg.dev/artifact-foundry-prod/maven-3p-trusted</url>
+      <mirrorOf>central</mirrorOf>
+    </mirror>
+  </mirrors>
+  <profiles>
+    <profile>
+      <id>airlock</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <repositories>
+        <repository>
+          <id>airlock</id>
+          <name>Airlock Trusted</name>
+          <url>artifactregistry://us-maven.pkg.dev/artifact-foundry-prod/maven-3p-trusted</url>
+          <layout>default</layout>
+          <releases>
+            <enabled>true</enabled>
+          </releases>
+          <snapshots>
+            <enabled>false</enabled>
+          </snapshots>
+        </repository>
+        <repository>
+          <id>central-fallback</id>
+          <name>Central Repository (mirrored)</name>
+          <url>https://repo.maven.apache.org/maven2</url>
+          <releases>
+            <updatePolicy>never</updatePolicy>
+          </releases>
+          <snapshots>
+            <enabled>false</enabled>
+          </snapshots>
+        </repository>
+      </repositories>
+      <pluginRepositories>
+        <pluginRepository>
+          <id>airlock</id>
+          <name>Airlock Trusted</name>
+          <url>artifactregistry://us-maven.pkg.dev/artifact-foundry-prod/maven-3p-trusted</url>
+          <layout>default</layout>
+          <releases>
+            <enabled>true</enabled>
+          </releases>
+          <snapshots>
+            <enabled>false</enabled>
+          </snapshots>
+        </pluginRepository>
+        <pluginRepository>
+          <id>central-fallback</id>
+          <name>Central Repository</name>
+          <url>https://repo.maven.apache.org/maven2</url>
+          <releases>
+            <updatePolicy>never</updatePolicy>
+          </releases>
+          <snapshots>
+            <enabled>false</enabled>
+          </snapshots>
+        </pluginRepository>
+      </pluginRepositories>
+    </profile>
+  </profiles>
+</settings>

--- a/settings_wagon_moss.xml
+++ b/settings_wagon_moss.xml
@@ -1,0 +1,13 @@
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 https://maven.apache.org/xsd/settings-1.0.0.xsd">
+
+  <mirrors>
+    <mirror>
+<!--      this id should be the same as the one settings_moss.xml-->
+      <id>airlock</id>
+      <name>AR Maven Central mirror</name>
+      <url>https://repo1.maven.org/maven2</url>
+      <mirrorOf>*</mirrorOf>
+    </mirror>
+  </mirrors>
+</settings>


### PR DESCRIPTION
Build docker images with base image and java dependencies from airlock for moss compliance
maven central is added as fallback for java dependencies as some of them are not available in airlock yet.