### PR TITLE
test: bump pg client version to 18

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -108,7 +108,7 @@ jobs:
           sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
           wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
           sudo apt-get update
-          sudo apt-get install --yes --no-install-recommends postgresql-client-17
+          sudo apt-get install --yes --no-install-recommends postgresql-client-18
       - name: Create PostgreSQL test database
         run: |
           psql -h /pg -U postgres -c "CREATE DATABASE pgadapter"


### PR DESCRIPTION
Bump the PG client version to 18 for the integration test runs to match with the server version that is used for the integration tests.