### PR TITLE
test: disable mTLS during tests

### DIFF
--- a/src/test/java/com/google/cloud/spanner/pgadapter/AbstractMockServerTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/AbstractMockServerTest.java
@@ -23,6 +23,7 @@ import static org.junit.Assert.assertTrue;
 import com.google.cloud.NoCredentials;
 import com.google.cloud.ServiceOptions;
 import com.google.cloud.spanner.Dialect;
+import com.google.cloud.spanner.DisableDefaultMtlsProvider;
 import com.google.cloud.spanner.ErrorCode;
 import com.google.cloud.spanner.MockSpannerServiceImpl;
 import com.google.cloud.spanner.MockSpannerServiceImpl.StatementResult;
@@ -1282,6 +1283,8 @@ public abstract class AbstractMockServerTest {
       Consumer<TestOptionsMetadataBuilder> optionsConfigurator,
       OpenTelemetry openTelemetry)
       throws Exception {
+    DisableDefaultMtlsProvider.disableDefaultMtlsProvider();
+
     mockSpanner = mockSpannerService;
     mockSpanner.setAbortProbability(0.0D); // We don't want any unpredictable aborted transactions.
     mockSpanner.putStatementResult(


### PR DESCRIPTION
Disable mTLS during tests to increase the execution speed. The check whether mTLS is available is otherwise executed for every new SpannerStub creation, and this check is relatively slow, especially on macos. This has caused the macos tests to time out regularly in the past week.