### PR TITLE
chore: re-write Ruby ActiveRecord 8.1.x primary key query

### DIFF
--- a/samples/ruby/activerecord/Gemfile
+++ b/samples/ruby/activerecord/Gemfile
@@ -5,5 +5,5 @@ source 'https://rubygems.org'
 gem "testcontainers"
 gem 'pg'
 gem 'rake'
-gem 'activerecord', '8.0.4'
+gem 'activerecord', '8.1.0'
 gem 'sinatra-activerecord'

--- a/samples/ruby/activerecord/Gemfile
+++ b/samples/ruby/activerecord/Gemfile
@@ -5,5 +5,5 @@ source 'https://rubygems.org'
 gem "testcontainers"
 gem 'pg'
 gem 'rake'
-gem 'activerecord', '8.0.3'
+gem 'activerecord', '8.0.4'
 gem 'sinatra-activerecord'

--- a/samples/ruby/activerecord/Gemfile
+++ b/samples/ruby/activerecord/Gemfile
@@ -5,5 +5,5 @@ source 'https://rubygems.org'
 gem "testcontainers"
 gem 'pg'
 gem 'rake'
-gem 'activerecord', '~> 8.0'
+gem 'activerecord', '8.0.3'
 gem 'sinatra-activerecord'

--- a/samples/ruby/activerecord/Gemfile
+++ b/samples/ruby/activerecord/Gemfile
@@ -5,5 +5,5 @@ source 'https://rubygems.org'
 gem "testcontainers"
 gem 'pg'
 gem 'rake'
-gem 'activerecord', '8.1.0'
+gem 'activerecord', '~> 8.0'
 gem 'sinatra-activerecord'

--- a/src/main/java/com/google/cloud/spanner/pgadapter/statements/PgCatalog.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/statements/PgCatalog.java
@@ -893,7 +893,7 @@ public class PgCatalog {
             + "       i.is_unique='YES' as indisunique, i.is_unique='YES' and i.is_null_filtered='NO' as indnullsnotdistinct,\n"
             + "       i.index_type='PRIMARY_KEY' as indisprimary, false as indisexclusion, true as indimmediate,\n"
             + "       false as indisclustered, true as indisvalid, false as indcheckxmin, true as indisready,\n"
-            + "       true as indislive, false as indisreplident, string_agg(c.ordinal_position::varchar, ' ') as indkey,\n"
+            + "       true as indislive, false as indisreplident, array_agg(c.ordinal_position) as indkey,\n"
             + "       ''::varchar as indcollation, ''::varchar as indclass, ''::varchar as indoption,"
             + "       null::varchar as indexprs, i.filter as indpred\n"
             + "from information_schema.indexes i\n"

--- a/src/main/java/com/google/cloud/spanner/pgadapter/utils/ClientAutoDetector.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/utils/ClientAutoDetector.java
@@ -200,6 +200,22 @@ public class ClientAutoDetector {
                       + "WHERE ic.table_schema='public' and ic.table_name='$1'\n"
                       + "AND i.index_type='PRIMARY_KEY'\n"
                       + "ORDER BY ordinal_position"),
+              RegexQueryPartReplacer.replaceAndStop(
+                  Pattern.compile(
+                      "SELECT\\s+a\\.attname\\s+"
+                          + "FROM pg_index i\\s+"
+                          + "JOIN pg_attribute a\\s+"
+                          + "ON a.attrelid = i.indrelid\\s+"
+                          + "AND a.attnum = ANY\\(i.indkey\\)\\s+"
+                          + "WHERE i.indrelid = '\"?(.+?)\"?'::regclass\\s+"
+                          + "AND i.indisprimary\\s+"
+                          + "ORDER BY array_position\\(i.indkey, a.attnum\\)"),
+                  "SELECT ic.column_name as attname\n"
+                      + "FROM information_schema.index_columns ic\n"
+                      + "INNER JOIN information_schema.indexes i using (table_catalog, table_schema, table_name, index_name)\n"
+                      + "WHERE ic.table_schema='public' and ic.table_name='$1'\n"
+                      + "AND i.index_type='PRIMARY_KEY'\n"
+                      + "ORDER BY ordinal_position"),
               RegexQueryPartReplacer.replace(
                   Pattern.compile(
                       "format_type\\s*\\(\\s*a\\.atttypid\\s*,\\s*a\\.atttypmod\\s*\\)"),


### PR DESCRIPTION
The primary key query that is used by ActiveRecord changed in version 8.1.x.

The sample test still fails, as the sample uses the pre-built Docker image. This should be fixed after the next release.