### PR TITLE
feat: support for wire protocol 3.2

### DIFF
--- a/src/main/java/com/google/cloud/spanner/pgadapter/ConnectionHandler.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/ConnectionHandler.java
@@ -82,6 +82,7 @@ import java.security.SecureRandom;
 import java.text.MessageFormat;
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -128,6 +129,9 @@ public class ConnectionHandler implements Runnable {
   private Thread thread;
   private final int connectionId;
   private final int secret;
+  private final byte[] secretBytes;
+  public static final int DEFAULT_KEY_LENGTH_BYTES = 32;
+
   // Separate the following from the threat ID generator, since PG connection IDs are maximum
   //  32 bytes, and shouldn't be incremented on failed startups.
   private static final AtomicInteger incrementingConnectionId = new AtomicInteger(0);
@@ -142,6 +146,7 @@ public class ConnectionHandler implements Runnable {
   private DatabaseId databaseId;
   private WellKnownClient wellKnownClient = WellKnownClient.UNSPECIFIED;
   private boolean hasDeterminedClientUsingQuery;
+  private int protocolVersion;
 
   /**
    * List of PARSE messages that we received before auto-detecting the client. This list can be used
@@ -162,7 +167,12 @@ public class ConnectionHandler implements Runnable {
   ConnectionHandler(ProxyServer server, Socket socket, Connection spannerConnection) {
     this.server = server;
     this.socket = socket;
-    this.secret = new SecureRandom().nextInt();
+
+    SecureRandom secureRandom = new SecureRandom();
+    this.secret = secureRandom.nextInt();
+    this.secretBytes = new byte[DEFAULT_KEY_LENGTH_BYTES];
+    secureRandom.nextBytes(this.secretBytes);
+
     this.connectionId = incrementingConnectionId.incrementAndGet();
     this.spannerConnection = spannerConnection;
   }
@@ -718,6 +728,8 @@ public class ConnectionHandler implements Runnable {
    * specific connection identified by connectionId. Since cancellation is a flimsy contract at
    * best, it is not imperative that the cancellation run, but it should be attempted nonetheless.
    *
+   * <p>This method is for protocol 3.0 which uses integer secrets.
+   *
    * @param connectionId The connection whose statement must be cancelled.
    * @param secret The secret value linked to the connection that is being cancelled. If it does not
    *     match, we cannot cancel.
@@ -753,6 +765,62 @@ public class ConnectionHandler implements Runnable {
       // Since the user does not accept a response, there is no need to except here: simply return.
       return false;
     }
+    // We can mostly ignore the exception since cancel does not expect any result (positive or
+    // otherwise)
+    try {
+      connectionToCancel.getSpannerConnection().cancel();
+      connectionToCancel.getThread().interrupt();
+      return true;
+    } catch (Throwable ignore) {
+    }
+    return false;
+  }
+
+  /**
+   * To be used by a cancellation command to cancel a currently running statement, as contained in a
+   * specific connection identified by connectionId. Since cancellation is a flimsy contract at
+   * best, it is not imperative that the cancellation run, but it should be attempted nonetheless.
+   *
+   * <p>This method is for protocol 3.2 which uses byte array secrets.
+   *
+   * @param connectionId The connection whose statement must be cancelled.
+   * @param secretBytes The secret byte array linked to the connection that is being cancelled. If
+   *     it does not match, we cannot cancel.
+   * @return true if the statement was cancelled.
+   */
+  public boolean cancelActiveStatement(int connectionId, byte[] secretBytes) {
+    if (connectionId == this.connectionId) {
+      // You can't cancel your own statement.
+      return false;
+    }
+    ConnectionHandler connectionToCancel = CONNECTION_HANDLERS.get(connectionId);
+    if (connectionToCancel == null) {
+      logger.log(
+          Level.WARNING,
+          Logging.format(
+              "CancelActiveStatement",
+              () ->
+                  MessageFormat.format(
+                      "User attempted to cancel an unknown connection. Connection: {0}",
+                      connectionId)));
+      return false;
+    }
+
+    // For protocol 3.2+, compare byte arrays
+    if (!Arrays.equals(secretBytes, connectionToCancel.getSecretBytes())) {
+      logger.log(
+          Level.WARNING,
+          Logging.format(
+              "CancelActiveStatement",
+              () ->
+                  MessageFormat.format(
+                      "User attempted to cancel a connection with the incorrect secret bytes."
+                          + "Connection: {0}",
+                      connectionId)));
+      // Since the user does not accept a response, there is no need to except here: simply return.
+      return false;
+    }
+
     // We can mostly ignore the exception since cancel does not expect any result (positive or
     // otherwise)
     try {
@@ -841,6 +909,10 @@ public class ConnectionHandler implements Runnable {
     return this.secret;
   }
 
+  public byte[] getSecretBytes() {
+    return this.secretBytes;
+  }
+
   public UUID getTraceConnectionId() {
     return traceConnectionId;
   }
@@ -892,6 +964,14 @@ public class ConnectionHandler implements Runnable {
 
   public WellKnownClient getWellKnownClient() {
     return wellKnownClient;
+  }
+
+  public int getProtocolVersion() {
+    return protocolVersion;
+  }
+
+  public void setProtocolVersion(int protocolVersion) {
+    this.protocolVersion = protocolVersion;
   }
 
   public void setWellKnownClient(WellKnownClient wellKnownClient) {

--- a/src/main/java/com/google/cloud/spanner/pgadapter/ConnectionHandler.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/ConnectionHandler.java
@@ -745,7 +745,7 @@ public class ConnectionHandler implements Runnable {
       return false;
     }
 
-    if (StartupMessage.PROTOCOL_VERSION_3_0_IDENTIFIER == protocolVersion) {
+    if (StartupMessage.PROTOCOL_VERSION_3_0_IDENTIFIER == connectionToCancel.getProtocolVersion()) {
       if (secret.length != PROTOCOL_30_KEY_LENGTH_BYTES) {
         throw PGExceptionFactory.newPGException(
             "protocol version 3.0 accepts only 4 bytes for the secret ",
@@ -753,7 +753,7 @@ public class ConnectionHandler implements Runnable {
       }
     }
 
-    if (StartupMessage.PROTOCOL_VERSION_3_2_IDENTIFIER == protocolVersion) {
+    if (StartupMessage.PROTOCOL_VERSION_3_2_IDENTIFIER == connectionToCancel.getProtocolVersion()) {
       if (secret.length != DEFAULT_KEY_LENGTH_BYTES) {
         throw PGExceptionFactory.newPGException(
             "protocol version 3.2 accepts 32 bytes for the secret ", SQLState.ProtocolViolation);

--- a/src/main/java/com/google/cloud/spanner/pgadapter/ConnectionHandler.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/ConnectionHandler.java
@@ -79,6 +79,7 @@ import java.io.EOFException;
 import java.io.IOException;
 import java.net.Socket;
 import java.net.SocketException;
+import java.security.SecureRandom;
 import java.text.MessageFormat;
 import java.time.Duration;
 import java.util.ArrayList;
@@ -131,7 +132,7 @@ public class ConnectionHandler implements Runnable {
   private int protocolVersion;
   private byte[] secret;
   public static final int DEFAULT_KEY_LENGTH_BYTES = 32;
-  public static final int PROTOCOL_30_KEY_LENGTH_BYTES = 4;
+  public static final int PROTOCOL_3_0_KEY_LENGTH_BYTES = 4;
 
   // Separate the following from the threat ID generator, since PG connection IDs are maximum
   //  32 bytes, and shouldn't be incremented on failed startups.
@@ -746,7 +747,7 @@ public class ConnectionHandler implements Runnable {
     }
 
     if (StartupMessage.PROTOCOL_VERSION_3_0_IDENTIFIER == connectionToCancel.getProtocolVersion()) {
-      if (secret.length != PROTOCOL_30_KEY_LENGTH_BYTES) {
+      if (secret.length != PROTOCOL_3_0_KEY_LENGTH_BYTES) {
         throw PGExceptionFactory.newPGException(
             "protocol version 3.0 accepts only 4 bytes for the secret ",
             SQLState.ProtocolViolation);
@@ -863,10 +864,6 @@ public class ConnectionHandler implements Runnable {
     return this.secret;
   }
 
-  public void setSecret(byte[] secret) {
-    this.secret = secret;
-  }
-
   public UUID getTraceConnectionId() {
     return traceConnectionId;
   }
@@ -924,8 +921,15 @@ public class ConnectionHandler implements Runnable {
     return protocolVersion;
   }
 
-  public void setProtocolVersion(int protocolVersion) {
+  public void setProtocolVersionProperties(int protocolVersion) {
     this.protocolVersion = protocolVersion;
+    int secretLen =
+        StartupMessage.PROTOCOL_VERSION_3_0_IDENTIFIER == protocolVersion
+            ? ConnectionHandler.PROTOCOL_3_0_KEY_LENGTH_BYTES
+            : ConnectionHandler.DEFAULT_KEY_LENGTH_BYTES;
+    byte[] secretBytes = new byte[secretLen];
+    new SecureRandom().nextBytes(secretBytes);
+    this.secret = secretBytes;
   }
 
   public void setWellKnownClient(WellKnownClient wellKnownClient) {

--- a/src/main/java/com/google/cloud/spanner/pgadapter/ConnectionHandler.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/ConnectionHandler.java
@@ -721,68 +721,12 @@ public class ConnectionHandler implements Runnable {
    * specific connection identified by connectionId. Since cancellation is a flimsy contract at
    * best, it is not imperative that the cancellation run, but it should be attempted nonetheless.
    *
-   * <p>This method is for protocol 3.0 which uses integer secrets.
-   *
    * @param connectionId The connection whose statement must be cancelled.
-   * @param secret The secret value linked to the connection that is being cancelled. If it does not
-   *     match, we cannot cancel.
+   * @param secret The secret byte array linked to the connection that is being cancelled. If it
+   *     does not match, we cannot cancel.
    * @return true if the statement was cancelled.
    */
-  // public boolean cancelActiveStatement(int connectionId, int secret) {
-  //   if (connectionId == this.connectionId) {
-  //     // You can't cancel your own statement.
-  //     return false;
-  //   }
-  //   ConnectionHandler connectionToCancel = CONNECTION_HANDLERS.get(connectionId);
-  //   if (connectionToCancel == null) {
-  //     logger.log(
-  //         Level.WARNING,
-  //         Logging.format(
-  //             "CancelActiveStatement",
-  //             () ->
-  //                 MessageFormat.format(
-  //                     "User attempted to cancel an unknown connection. Connection: {0}",
-  //                     connectionId)));
-  //     return false;
-  //   }
-  //   if (secret != connectionToCancel.secret) {
-  //     logger.log(
-  //         Level.WARNING,
-  //         Logging.format(
-  //             "CancelActiveStatement",
-  //             () ->
-  //                 MessageFormat.format(
-  //                     "User attempted to cancel a connection with the incorrect secret."
-  //                         + "Connection: {0}, Secret: {1}, Expected Secret: {2}",
-  //                     connectionId, secret, connectionToCancel.secret)));
-  //     // Since the user does not accept a response, there is no need to except here: simply
-  // return.
-  //     return false;
-  //   }
-  //   // We can mostly ignore the exception since cancel does not expect any result (positive or
-  //   // otherwise)
-  //   try {
-  //     connectionToCancel.getSpannerConnection().cancel();
-  //     connectionToCancel.getThread().interrupt();
-  //     return true;
-  //   } catch (Throwable ignore) {
-  //   }
-  //   return false;
-  // }
-
-  /**
-   * To be used by a cancellation command to cancel a currently running statement, as contained in a
-   * specific connection identified by connectionId. Since cancellation is a flimsy contract at
-   * best, it is not imperative that the cancellation run, but it should be attempted nonetheless.
-   *
-   * <p>This method is for protocol 3.2 which uses byte array secrets.
-   *
-   * @param connectionId The connection whose statement must be cancelled.
-   * @param secretBytes The secret byte array linked to the connection that is being cancelled. If
-   *     it does not match, we cannot cancel.
-   * @return true if the statement was cancelled.
-   */
-  public boolean cancelActiveStatement(int connectionId, byte[] secretBytes) {
+  public boolean cancelActiveStatement(int connectionId, byte[] secret) {
     if (connectionId == this.connectionId) {
       // You can't cancel your own statement.
       return false;
@@ -801,7 +745,7 @@ public class ConnectionHandler implements Runnable {
     }
 
     if (StartupMessage.PROTOCOL_VERSION_3_0 == protocolVersion) {
-      if (secretBytes.length != 4) {
+      if (secret.length != 4) {
         throw PGExceptionFactory.newPGException(
             "protocol version 3.0 accepts only 4 bytes for the secret ",
             SQLState.ProtocolViolation);
@@ -809,26 +753,27 @@ public class ConnectionHandler implements Runnable {
     }
 
     if (StartupMessage.PROTOCOL_VERSION_3_2 == protocolVersion) {
-      if (secretBytes.length != 32) {
+      if (secret.length != 32) {
         throw PGExceptionFactory.newPGException(
             "protocol version 3.2 accepts 32 bytes for the secret ", SQLState.ProtocolViolation);
       }
     }
 
-    if (!Arrays.equals(secretBytes, connectionToCancel.getSecret())) {
+    if (!Arrays.equals(secret, connectionToCancel.getSecret())) {
       logger.log(
           Level.WARNING,
           Logging.format(
               "CancelActiveStatement",
               () ->
                   MessageFormat.format(
-                      "User attempted to cancel a connection with the incorrect secret bytes."
-                          + "Connection: {0}",
-                      connectionId)));
+                      "User attempted to cancel a connection with the incorrect secret."
+                          + "Connection: {0}, Secret: {1}, Expected Secret: {2}",
+                      connectionId,
+                      Arrays.toString(secret),
+                      Arrays.toString(connectionToCancel.getSecret()))));
       // Since the user does not accept a response, there is no need to except here: simply return.
       return false;
     }
-
     // We can mostly ignore the exception since cancel does not expect any result (positive or
     // otherwise)
     try {

--- a/src/main/java/com/google/cloud/spanner/pgadapter/ConnectionHandler.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/ConnectionHandler.java
@@ -64,6 +64,7 @@ import com.google.cloud.spanner.pgadapter.wireoutput.TerminateResponse;
 import com.google.cloud.spanner.pgadapter.wireprotocol.BootstrapMessage;
 import com.google.cloud.spanner.pgadapter.wireprotocol.ParseMessage;
 import com.google.cloud.spanner.pgadapter.wireprotocol.SSLMessage;
+import com.google.cloud.spanner.pgadapter.wireprotocol.StartupMessage;
 import com.google.cloud.spanner.pgadapter.wireprotocol.WireMessage;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
@@ -78,7 +79,6 @@ import java.io.EOFException;
 import java.io.IOException;
 import java.net.Socket;
 import java.net.SocketException;
-import java.security.SecureRandom;
 import java.text.MessageFormat;
 import java.time.Duration;
 import java.util.ArrayList;
@@ -128,8 +128,7 @@ public class ConnectionHandler implements Runnable {
   private volatile ConnectionStatus status = ConnectionStatus.UNAUTHENTICATED;
   private Thread thread;
   private final int connectionId;
-  private final int secret;
-  private final byte[] secretBytes;
+  private byte[] secret;
   public static final int DEFAULT_KEY_LENGTH_BYTES = 32;
 
   // Separate the following from the threat ID generator, since PG connection IDs are maximum
@@ -167,12 +166,6 @@ public class ConnectionHandler implements Runnable {
   ConnectionHandler(ProxyServer server, Socket socket, Connection spannerConnection) {
     this.server = server;
     this.socket = socket;
-
-    SecureRandom secureRandom = new SecureRandom();
-    this.secret = secureRandom.nextInt();
-    this.secretBytes = new byte[DEFAULT_KEY_LENGTH_BYTES];
-    secureRandom.nextBytes(this.secretBytes);
-
     this.connectionId = incrementingConnectionId.incrementAndGet();
     this.spannerConnection = spannerConnection;
   }
@@ -735,46 +728,47 @@ public class ConnectionHandler implements Runnable {
    *     match, we cannot cancel.
    * @return true if the statement was cancelled.
    */
-  public boolean cancelActiveStatement(int connectionId, int secret) {
-    if (connectionId == this.connectionId) {
-      // You can't cancel your own statement.
-      return false;
-    }
-    ConnectionHandler connectionToCancel = CONNECTION_HANDLERS.get(connectionId);
-    if (connectionToCancel == null) {
-      logger.log(
-          Level.WARNING,
-          Logging.format(
-              "CancelActiveStatement",
-              () ->
-                  MessageFormat.format(
-                      "User attempted to cancel an unknown connection. Connection: {0}",
-                      connectionId)));
-      return false;
-    }
-    if (secret != connectionToCancel.secret) {
-      logger.log(
-          Level.WARNING,
-          Logging.format(
-              "CancelActiveStatement",
-              () ->
-                  MessageFormat.format(
-                      "User attempted to cancel a connection with the incorrect secret."
-                          + "Connection: {0}, Secret: {1}, Expected Secret: {2}",
-                      connectionId, secret, connectionToCancel.secret)));
-      // Since the user does not accept a response, there is no need to except here: simply return.
-      return false;
-    }
-    // We can mostly ignore the exception since cancel does not expect any result (positive or
-    // otherwise)
-    try {
-      connectionToCancel.getSpannerConnection().cancel();
-      connectionToCancel.getThread().interrupt();
-      return true;
-    } catch (Throwable ignore) {
-    }
-    return false;
-  }
+  // public boolean cancelActiveStatement(int connectionId, int secret) {
+  //   if (connectionId == this.connectionId) {
+  //     // You can't cancel your own statement.
+  //     return false;
+  //   }
+  //   ConnectionHandler connectionToCancel = CONNECTION_HANDLERS.get(connectionId);
+  //   if (connectionToCancel == null) {
+  //     logger.log(
+  //         Level.WARNING,
+  //         Logging.format(
+  //             "CancelActiveStatement",
+  //             () ->
+  //                 MessageFormat.format(
+  //                     "User attempted to cancel an unknown connection. Connection: {0}",
+  //                     connectionId)));
+  //     return false;
+  //   }
+  //   if (secret != connectionToCancel.secret) {
+  //     logger.log(
+  //         Level.WARNING,
+  //         Logging.format(
+  //             "CancelActiveStatement",
+  //             () ->
+  //                 MessageFormat.format(
+  //                     "User attempted to cancel a connection with the incorrect secret."
+  //                         + "Connection: {0}, Secret: {1}, Expected Secret: {2}",
+  //                     connectionId, secret, connectionToCancel.secret)));
+  //     // Since the user does not accept a response, there is no need to except here: simply
+  // return.
+  //     return false;
+  //   }
+  //   // We can mostly ignore the exception since cancel does not expect any result (positive or
+  //   // otherwise)
+  //   try {
+  //     connectionToCancel.getSpannerConnection().cancel();
+  //     connectionToCancel.getThread().interrupt();
+  //     return true;
+  //   } catch (Throwable ignore) {
+  //   }
+  //   return false;
+  // }
 
   /**
    * To be used by a cancellation command to cancel a currently running statement, as contained in a
@@ -806,8 +800,22 @@ public class ConnectionHandler implements Runnable {
       return false;
     }
 
-    // For protocol 3.2+, compare byte arrays
-    if (!Arrays.equals(secretBytes, connectionToCancel.getSecretBytes())) {
+    if (StartupMessage.PROTOCOL_VERSION_3_0 == protocolVersion) {
+      if (secretBytes.length != 4) {
+        throw PGExceptionFactory.newPGException(
+            "protocol version 3.0 accepts only 4 bytes for the secret ",
+            SQLState.ProtocolViolation);
+      }
+    }
+
+    if (StartupMessage.PROTOCOL_VERSION_3_2 == protocolVersion) {
+      if (secretBytes.length != 32) {
+        throw PGExceptionFactory.newPGException(
+            "protocol version 3.2 accepts 32 bytes for the secret ", SQLState.ProtocolViolation);
+      }
+    }
+
+    if (!Arrays.equals(secretBytes, connectionToCancel.getSecret())) {
       logger.log(
           Level.WARNING,
           Logging.format(
@@ -905,12 +913,12 @@ public class ConnectionHandler implements Runnable {
     return this.connectionId;
   }
 
-  public int getSecret() {
+  public byte[] getSecret() {
     return this.secret;
   }
 
-  public byte[] getSecretBytes() {
-    return this.secretBytes;
+  public void setSecret(byte[] secret) {
+    this.secret = secret;
   }
 
   public UUID getTraceConnectionId() {

--- a/src/main/java/com/google/cloud/spanner/pgadapter/ConnectionHandler.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/ConnectionHandler.java
@@ -746,19 +746,24 @@ public class ConnectionHandler implements Runnable {
       return false;
     }
 
-    if (StartupMessage.PROTOCOL_VERSION_3_0_IDENTIFIER == connectionToCancel.getProtocolVersion()) {
-      if (secret.length != PROTOCOL_3_0_KEY_LENGTH_BYTES) {
+    switch (connectionToCancel.getProtocolVersion()) {
+      case StartupMessage.PROTOCOL_VERSION_3_0_IDENTIFIER:
+        if (secret.length != PROTOCOL_3_0_KEY_LENGTH_BYTES) {
+          throw PGExceptionFactory.newPGException(
+              "protocol version 3.0 accepts only 4 bytes for the secret ",
+              SQLState.ProtocolViolation);
+        }
+        break;
+      case StartupMessage.PROTOCOL_VERSION_3_2_IDENTIFIER:
+        if (secret.length != DEFAULT_KEY_LENGTH_BYTES) {
+          throw PGExceptionFactory.newPGException(
+              "protocol version 3.2 accepts 32 bytes for the secret ", SQLState.ProtocolViolation);
+        }
+        break;
+      default:
         throw PGExceptionFactory.newPGException(
-            "protocol version 3.0 accepts only 4 bytes for the secret ",
+            "unsupported protocol version: " + connectionToCancel.getProtocolVersion(),
             SQLState.ProtocolViolation);
-      }
-    }
-
-    if (StartupMessage.PROTOCOL_VERSION_3_2_IDENTIFIER == connectionToCancel.getProtocolVersion()) {
-      if (secret.length != DEFAULT_KEY_LENGTH_BYTES) {
-        throw PGExceptionFactory.newPGException(
-            "protocol version 3.2 accepts 32 bytes for the secret ", SQLState.ProtocolViolation);
-      }
     }
 
     if (!Arrays.equals(secret, connectionToCancel.getSecret())) {

--- a/src/main/java/com/google/cloud/spanner/pgadapter/ConnectionHandler.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/ConnectionHandler.java
@@ -128,8 +128,10 @@ public class ConnectionHandler implements Runnable {
   private volatile ConnectionStatus status = ConnectionStatus.UNAUTHENTICATED;
   private Thread thread;
   private final int connectionId;
+  private int protocolVersion;
   private byte[] secret;
   public static final int DEFAULT_KEY_LENGTH_BYTES = 32;
+  public static final int PROTOCOL_30_KEY_LENGTH_BYTES = 4;
 
   // Separate the following from the threat ID generator, since PG connection IDs are maximum
   //  32 bytes, and shouldn't be incremented on failed startups.
@@ -145,7 +147,6 @@ public class ConnectionHandler implements Runnable {
   private DatabaseId databaseId;
   private WellKnownClient wellKnownClient = WellKnownClient.UNSPECIFIED;
   private boolean hasDeterminedClientUsingQuery;
-  private int protocolVersion;
 
   /**
    * List of PARSE messages that we received before auto-detecting the client. This list can be used
@@ -722,8 +723,8 @@ public class ConnectionHandler implements Runnable {
    * best, it is not imperative that the cancellation run, but it should be attempted nonetheless.
    *
    * @param connectionId The connection whose statement must be cancelled.
-   * @param secret The secret byte array linked to the connection that is being cancelled. If it
-   *     does not match, we cannot cancel.
+   * @param secret The secret value linked to the connection that is being cancelled. If it does not
+   *     match, we cannot cancel.
    * @return true if the statement was cancelled.
    */
   public boolean cancelActiveStatement(int connectionId, byte[] secret) {
@@ -744,16 +745,16 @@ public class ConnectionHandler implements Runnable {
       return false;
     }
 
-    if (StartupMessage.PROTOCOL_VERSION_3_0 == protocolVersion) {
-      if (secret.length != 4) {
+    if (StartupMessage.PROTOCOL_VERSION_3_0_IDENTIFIER == protocolVersion) {
+      if (secret.length != PROTOCOL_30_KEY_LENGTH_BYTES) {
         throw PGExceptionFactory.newPGException(
             "protocol version 3.0 accepts only 4 bytes for the secret ",
             SQLState.ProtocolViolation);
       }
     }
 
-    if (StartupMessage.PROTOCOL_VERSION_3_2 == protocolVersion) {
-      if (secret.length != 32) {
+    if (StartupMessage.PROTOCOL_VERSION_3_2_IDENTIFIER == protocolVersion) {
+      if (secret.length != DEFAULT_KEY_LENGTH_BYTES) {
         throw PGExceptionFactory.newPGException(
             "protocol version 3.2 accepts 32 bytes for the secret ", SQLState.ProtocolViolation);
       }

--- a/src/main/java/com/google/cloud/spanner/pgadapter/wireoutput/KeyDataResponse.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/wireoutput/KeyDataResponse.java
@@ -18,6 +18,7 @@ import com.google.api.core.InternalApi;
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.text.MessageFormat;
+import java.util.Arrays;
 
 /**
  * Sends back information regarding the current connection (identifier and secret) as part of
@@ -27,18 +28,18 @@ import java.text.MessageFormat;
 public class KeyDataResponse extends WireOutput {
 
   private final int processId;
-  private final byte[] secretBytes;
+  private final byte[] secret;
 
   public KeyDataResponse(DataOutputStream output, int processId, byte[] secretKey) {
     super(output, 8 + secretKey.length);
     this.processId = processId;
-    this.secretBytes = secretKey;
+    this.secret = secretKey;
   }
 
   @Override
   public void sendPayload() throws IOException {
     this.outputStream.writeInt(this.processId);
-    this.outputStream.write(this.secretBytes);
+    this.outputStream.write(this.secret);
   }
 
   @Override
@@ -54,6 +55,6 @@ public class KeyDataResponse extends WireOutput {
   @Override
   protected String getPayloadString() {
     return new MessageFormat("Length: {0}, " + "Process ID: {1}, " + "Secret Key: {2}")
-        .format(new Object[] {this.length, this.processId, this.secretBytes});
+        .format(new Object[] {this.length, this.processId, Arrays.toString(this.secret)});
   }
 }

--- a/src/main/java/com/google/cloud/spanner/pgadapter/wireoutput/KeyDataResponse.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/wireoutput/KeyDataResponse.java
@@ -28,17 +28,30 @@ public class KeyDataResponse extends WireOutput {
 
   private final int processId;
   private final int secretKey;
+  private final byte[] secretBytes;
 
   public KeyDataResponse(DataOutputStream output, int processId, int secretKey) {
     super(output, 12);
     this.processId = processId;
     this.secretKey = secretKey;
+    this.secretBytes = null;
+  }
+
+  public KeyDataResponse(DataOutputStream output, int processId, byte[] secretKey) {
+    super(output, 8 + secretKey.length);
+    this.processId = processId;
+    this.secretBytes = secretKey;
+    this.secretKey = -1;
   }
 
   @Override
   public void sendPayload() throws IOException {
     this.outputStream.writeInt(this.processId);
-    this.outputStream.writeInt(this.secretKey);
+    if (this.secretBytes != null) {
+      this.outputStream.write(this.secretBytes);
+    } else {
+      this.outputStream.writeInt(this.secretKey);
+    }
   }
 
   @Override

--- a/src/main/java/com/google/cloud/spanner/pgadapter/wireoutput/KeyDataResponse.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/wireoutput/KeyDataResponse.java
@@ -27,31 +27,18 @@ import java.text.MessageFormat;
 public class KeyDataResponse extends WireOutput {
 
   private final int processId;
-  private final int secretKey;
   private final byte[] secretBytes;
-
-  public KeyDataResponse(DataOutputStream output, int processId, int secretKey) {
-    super(output, 12);
-    this.processId = processId;
-    this.secretKey = secretKey;
-    this.secretBytes = null;
-  }
 
   public KeyDataResponse(DataOutputStream output, int processId, byte[] secretKey) {
     super(output, 8 + secretKey.length);
     this.processId = processId;
     this.secretBytes = secretKey;
-    this.secretKey = -1;
   }
 
   @Override
   public void sendPayload() throws IOException {
     this.outputStream.writeInt(this.processId);
-    if (this.secretBytes != null) {
-      this.outputStream.write(this.secretBytes);
-    } else {
-      this.outputStream.writeInt(this.secretKey);
-    }
+    this.outputStream.write(this.secretBytes);
   }
 
   @Override
@@ -67,6 +54,6 @@ public class KeyDataResponse extends WireOutput {
   @Override
   protected String getPayloadString() {
     return new MessageFormat("Length: {0}, " + "Process ID: {1}, " + "Secret Key: {2}")
-        .format(new Object[] {this.length, this.processId, this.secretKey});
+        .format(new Object[] {this.length, this.processId, this.secretBytes});
   }
 }

--- a/src/main/java/com/google/cloud/spanner/pgadapter/wireprotocol/BootstrapMessage.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/wireprotocol/BootstrapMessage.java
@@ -36,6 +36,7 @@ import java.util.Map;
  */
 @InternalApi
 public abstract class BootstrapMessage extends WireMessage {
+
   public BootstrapMessage(ConnectionHandler connection, int length) {
     super(connection, length);
   }
@@ -56,12 +57,13 @@ public abstract class BootstrapMessage extends WireMessage {
         return new SSLMessage(connection);
       case GSSENCRequestMessage.IDENTIFIER:
         return new GSSENCRequestMessage(connection);
-      case StartupMessage.IDENTIFIER:
-        return new StartupMessage(connection, length);
+      case StartupMessage.PROTOCOL_VERSION_3_0:
+      case StartupMessage.PROTOCOL_VERSION_3_2:
+        return new StartupMessage(connection, length, protocol);
       case CancelMessage.IDENTIFIER:
-        return new CancelMessage(connection);
+        return new CancelMessage(connection, length);
       default:
-        throw new IllegalStateException("Unknown message");
+        throw new IllegalStateException("Unknown message protocol: " + protocol);
     }
   }
 
@@ -106,12 +108,18 @@ public abstract class BootstrapMessage extends WireMessage {
   public static void sendStartupMessage(
       DataOutputStream output,
       int connectionId,
+      int protocolVersion,
       int secret,
+      byte[] secretBytes,
       SessionState sessionState,
       Iterable<NoticeResponse> startupNotices)
       throws Exception {
     new AuthenticationOkResponse(output).send(false);
-    new KeyDataResponse(output, connectionId, secret).send(false);
+    if (protocolVersion == StartupMessage.PROTOCOL_VERSION_3_2) {
+      new KeyDataResponse(output, connectionId, secretBytes).send(false);
+    } else {
+      new KeyDataResponse(output, connectionId, secret).send(false);
+    }
     new ParameterStatusResponse(
             output,
             "server_version".getBytes(StandardCharsets.UTF_8),

--- a/src/main/java/com/google/cloud/spanner/pgadapter/wireprotocol/BootstrapMessage.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/wireprotocol/BootstrapMessage.java
@@ -57,8 +57,8 @@ public abstract class BootstrapMessage extends WireMessage {
         return new SSLMessage(connection);
       case GSSENCRequestMessage.IDENTIFIER:
         return new GSSENCRequestMessage(connection);
-      case StartupMessage.PROTOCOL_VERSION_3_0:
-      case StartupMessage.PROTOCOL_VERSION_3_2:
+      case StartupMessage.PROTOCOL_VERSION_3_0_IDENTIFIER:
+      case StartupMessage.PROTOCOL_VERSION_3_2_IDENTIFIER:
         return new StartupMessage(connection, length, protocol);
       case CancelMessage.IDENTIFIER:
         return new CancelMessage(connection, length);

--- a/src/main/java/com/google/cloud/spanner/pgadapter/wireprotocol/BootstrapMessage.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/wireprotocol/BootstrapMessage.java
@@ -63,7 +63,7 @@ public abstract class BootstrapMessage extends WireMessage {
       case CancelMessage.IDENTIFIER:
         return new CancelMessage(connection, length);
       default:
-        throw new IllegalStateException("Unknown message protocol: " + protocol);
+        throw new IllegalStateException("Unknown message");
     }
   }
 
@@ -108,12 +108,12 @@ public abstract class BootstrapMessage extends WireMessage {
   public static void sendStartupMessage(
       DataOutputStream output,
       int connectionId,
-      byte[] secretBytes,
+      byte[] secret,
       SessionState sessionState,
       Iterable<NoticeResponse> startupNotices)
       throws Exception {
     new AuthenticationOkResponse(output).send(false);
-    new KeyDataResponse(output, connectionId, secretBytes).send(false);
+    new KeyDataResponse(output, connectionId, secret).send(false);
     new ParameterStatusResponse(
             output,
             "server_version".getBytes(StandardCharsets.UTF_8),

--- a/src/main/java/com/google/cloud/spanner/pgadapter/wireprotocol/BootstrapMessage.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/wireprotocol/BootstrapMessage.java
@@ -108,18 +108,12 @@ public abstract class BootstrapMessage extends WireMessage {
   public static void sendStartupMessage(
       DataOutputStream output,
       int connectionId,
-      int protocolVersion,
-      int secret,
       byte[] secretBytes,
       SessionState sessionState,
       Iterable<NoticeResponse> startupNotices)
       throws Exception {
     new AuthenticationOkResponse(output).send(false);
-    if (protocolVersion == StartupMessage.PROTOCOL_VERSION_3_2) {
-      new KeyDataResponse(output, connectionId, secretBytes).send(false);
-    } else {
-      new KeyDataResponse(output, connectionId, secret).send(false);
-    }
+    new KeyDataResponse(output, connectionId, secretBytes).send(false);
     new ParameterStatusResponse(
             output,
             "server_version".getBytes(StandardCharsets.UTF_8),

--- a/src/main/java/com/google/cloud/spanner/pgadapter/wireprotocol/CancelMessage.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/wireprotocol/CancelMessage.java
@@ -31,33 +31,22 @@ import java.util.Arrays;
 @InternalApi
 public class CancelMessage extends BootstrapMessage {
 
-  private static final int PROTOCOL_3_0_MESSAGE_LENGTH = 16;
   public static final int IDENTIFIER = 80877102; // First Hextet: 1234, Second Hextet: 5678
 
   private final int connectionId;
-  private final int secret; // For protocol 3.0
-  private final byte[] secretBytes; // For protocol 3.2
+  private final byte[] secretBytes;
 
   public CancelMessage(ConnectionHandler connection, int length) throws Exception {
     super(connection, length);
+    int secretLen = length - 12;
     this.connectionId = this.inputStream.readInt();
-    if (length == PROTOCOL_3_0_MESSAGE_LENGTH) {
-      this.secret = this.inputStream.readInt();
-      this.secretBytes = null;
-    } else {
-      this.secretBytes = new byte[ConnectionHandler.DEFAULT_KEY_LENGTH_BYTES];
-      this.inputStream.readFully(secretBytes);
-      this.secret = -1;
-    }
+    this.secretBytes = new byte[secretLen];
+    this.inputStream.readFully(secretBytes);
   }
 
   @Override
   protected void sendPayload() throws Exception {
-    if (this.secretBytes != null) {
-      this.connection.cancelActiveStatement(this.connectionId, this.secretBytes);
-    } else {
-      this.connection.cancelActiveStatement(this.connectionId, this.secret);
-    }
+    this.connection.cancelActiveStatement(this.connectionId, this.secretBytes);
     this.connection.handleTerminate();
   }
 
@@ -68,13 +57,8 @@ public class CancelMessage extends BootstrapMessage {
 
   @Override
   protected String getPayloadString() {
-    if (this.secretBytes != null) {
-      return new MessageFormat("Length: {0}, Connection ID: {1}, Secret: {2}")
-          .format(new Object[] {this.length, this.connectionId, Arrays.toString(this.secretBytes)});
-    } else {
-      return new MessageFormat("Length: {0}, Connection ID: {1}, Secret: {2}")
-          .format(new Object[] {this.length, this.connectionId, this.secret});
-    }
+    return new MessageFormat("Length: {0}, Connection ID: {1}, Secret: {2}")
+        .format(new Object[] {this.length, this.connectionId, Arrays.toString(this.secretBytes)});
   }
 
   @Override
@@ -84,10 +68,6 @@ public class CancelMessage extends BootstrapMessage {
 
   public int getConnectionId() {
     return connectionId;
-  }
-
-  public int getSecret() {
-    return secret;
   }
 
   public byte[] getSecretBytes() {

--- a/src/main/java/com/google/cloud/spanner/pgadapter/wireprotocol/CancelMessage.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/wireprotocol/CancelMessage.java
@@ -17,30 +17,47 @@ package com.google.cloud.spanner.pgadapter.wireprotocol;
 import com.google.api.core.InternalApi;
 import com.google.cloud.spanner.pgadapter.ConnectionHandler;
 import java.text.MessageFormat;
+import java.util.Arrays;
 
 /**
  * This message handles the imperative cancellation, as issues in a new connection by the PG wire
  * protocol. We expect that this message contains an ID for the connection which issues the original
  * query, as well as an auth secret.
+ *
+ * <p>In protocol 3.0, the secret is a 4-byte integer.
+ *
+ * <p>In protocol 3.2, the secret is a 32-byte array.
  */
 @InternalApi
 public class CancelMessage extends BootstrapMessage {
 
-  private static final int MESSAGE_LENGTH = 16;
+  private static final int PROTOCOL_3_0_MESSAGE_LENGTH = 16;
   public static final int IDENTIFIER = 80877102; // First Hextet: 1234, Second Hextet: 5678
 
   private final int connectionId;
-  private final int secret;
+  private final int secret; // For protocol 3.0
+  private final byte[] secretBytes; // For protocol 3.2
 
-  public CancelMessage(ConnectionHandler connection) throws Exception {
-    super(connection, MESSAGE_LENGTH);
+  public CancelMessage(ConnectionHandler connection, int length) throws Exception {
+    super(connection, length);
     this.connectionId = this.inputStream.readInt();
-    this.secret = this.inputStream.readInt();
+    if (length == PROTOCOL_3_0_MESSAGE_LENGTH) {
+      this.secret = this.inputStream.readInt();
+      this.secretBytes = null;
+    } else {
+      this.secretBytes = new byte[ConnectionHandler.DEFAULT_KEY_LENGTH_BYTES];
+      this.inputStream.readFully(secretBytes);
+      this.secret = -1;
+    }
   }
 
   @Override
   protected void sendPayload() throws Exception {
-    this.connection.cancelActiveStatement(this.connectionId, this.secret);
+    if (this.secretBytes != null) {
+      this.connection.cancelActiveStatement(this.connectionId, this.secretBytes);
+    } else {
+      this.connection.cancelActiveStatement(this.connectionId, this.secret);
+    }
     this.connection.handleTerminate();
   }
 
@@ -51,8 +68,13 @@ public class CancelMessage extends BootstrapMessage {
 
   @Override
   protected String getPayloadString() {
-    return new MessageFormat("Length: {0}, " + "Connection ID: {1}, " + "Secret: {2}")
-        .format(new Object[] {this.length, this.connectionId, this.secret});
+    if (this.secretBytes != null) {
+      return new MessageFormat("Length: {0}, Connection ID: {1}, Secret: {2}")
+          .format(new Object[] {this.length, this.connectionId, Arrays.toString(this.secretBytes)});
+    } else {
+      return new MessageFormat("Length: {0}, Connection ID: {1}, Secret: {2}")
+          .format(new Object[] {this.length, this.connectionId, this.secret});
+    }
   }
 
   @Override
@@ -66,5 +88,9 @@ public class CancelMessage extends BootstrapMessage {
 
   public int getSecret() {
     return secret;
+  }
+
+  public byte[] getSecretBytes() {
+    return secretBytes;
   }
 }

--- a/src/main/java/com/google/cloud/spanner/pgadapter/wireprotocol/CancelMessage.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/wireprotocol/CancelMessage.java
@@ -23,10 +23,6 @@ import java.util.Arrays;
  * This message handles the imperative cancellation, as issues in a new connection by the PG wire
  * protocol. We expect that this message contains an ID for the connection which issues the original
  * query, as well as an auth secret.
- *
- * <p>In protocol 3.0, the secret is a 4-byte integer.
- *
- * <p>In protocol 3.2, the secret is a 32-byte array.
  */
 @InternalApi
 public class CancelMessage extends BootstrapMessage {
@@ -34,19 +30,19 @@ public class CancelMessage extends BootstrapMessage {
   public static final int IDENTIFIER = 80877102; // First Hextet: 1234, Second Hextet: 5678
 
   private final int connectionId;
-  private final byte[] secretBytes;
+  private final byte[] secret;
 
   public CancelMessage(ConnectionHandler connection, int length) throws Exception {
     super(connection, length);
     int secretLen = length - 12;
     this.connectionId = this.inputStream.readInt();
-    this.secretBytes = new byte[secretLen];
-    this.inputStream.readFully(secretBytes);
+    this.secret = new byte[secretLen];
+    this.inputStream.readFully(secret);
   }
 
   @Override
   protected void sendPayload() throws Exception {
-    this.connection.cancelActiveStatement(this.connectionId, this.secretBytes);
+    this.connection.cancelActiveStatement(this.connectionId, this.secret);
     this.connection.handleTerminate();
   }
 
@@ -58,7 +54,7 @@ public class CancelMessage extends BootstrapMessage {
   @Override
   protected String getPayloadString() {
     return new MessageFormat("Length: {0}, Connection ID: {1}, Secret: {2}")
-        .format(new Object[] {this.length, this.connectionId, Arrays.toString(this.secretBytes)});
+        .format(new Object[] {this.length, this.connectionId, Arrays.toString(this.secret)});
   }
 
   @Override
@@ -70,7 +66,7 @@ public class CancelMessage extends BootstrapMessage {
     return connectionId;
   }
 
-  public byte[] getSecretBytes() {
-    return secretBytes;
+  public byte[] getSecret() {
+    return secret;
   }
 }

--- a/src/main/java/com/google/cloud/spanner/pgadapter/wireprotocol/StartupMessage.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/wireprotocol/StartupMessage.java
@@ -38,12 +38,12 @@ public class StartupMessage extends BootstrapMessage {
   static final String DATABASE_KEY = "database";
   private static final String USER_KEY = "user";
   // Protocol version constants
-  public static final int PROTOCOL_VERSION_3_0 =
+  public static final int PROTOCOL_VERSION_3_0_IDENTIFIER =
       196608; // First Hextet: 3 (version), Second Hextet: 0
-  public static final int PROTOCOL_VERSION_3_2 =
+  public static final int PROTOCOL_VERSION_3_2_IDENTIFIER =
       196610; // First Hextet: 3 (version), Second Hextet: 2
-  public static final int IDENTIFIER = PROTOCOL_VERSION_3_0;
 
+  private final int protocolVersion;
   private final boolean authenticate;
   private final Map<String, String> parameters;
 
@@ -51,6 +51,7 @@ public class StartupMessage extends BootstrapMessage {
       throws Exception {
     super(connection, length);
     this.authenticate = connection.getServer().getOptions().shouldAuthenticate();
+    this.protocolVersion = protocolVersion;
     connection.setProtocolVersion(protocolVersion);
     setCancelSecret(connection, protocolVersion);
     String rawParameters = this.readAll();
@@ -65,7 +66,10 @@ public class StartupMessage extends BootstrapMessage {
   }
 
   private void setCancelSecret(ConnectionHandler connection, int protocolVersion) {
-    int secretLen = StartupMessage.PROTOCOL_VERSION_3_0 == protocolVersion ? 4 : 32;
+    int secretLen =
+        StartupMessage.PROTOCOL_VERSION_3_0_IDENTIFIER == protocolVersion
+            ? ConnectionHandler.PROTOCOL_30_KEY_LENGTH_BYTES
+            : ConnectionHandler.DEFAULT_KEY_LENGTH_BYTES;
     byte[] secretBytes = new byte[secretLen];
     new SecureRandom().nextBytes(secretBytes);
     connection.setSecret(secretBytes);
@@ -165,7 +169,7 @@ public class StartupMessage extends BootstrapMessage {
 
   @Override
   public String getIdentifier() {
-    return Integer.toString(IDENTIFIER);
+    return Integer.toString(protocolVersion);
   }
 
   public Map<String, String> getParameters() {

--- a/src/main/java/com/google/cloud/spanner/pgadapter/wireprotocol/StartupMessage.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/wireprotocol/StartupMessage.java
@@ -22,6 +22,7 @@ import com.google.cloud.spanner.pgadapter.utils.ClientAutoDetector;
 import com.google.cloud.spanner.pgadapter.utils.ClientAutoDetector.WellKnownClient;
 import com.google.cloud.spanner.pgadapter.wireoutput.AuthenticationCleartextPasswordResponse;
 import java.io.IOException;
+import java.security.SecureRandom;
 import java.text.MessageFormat;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -51,6 +52,7 @@ public class StartupMessage extends BootstrapMessage {
     super(connection, length);
     this.authenticate = connection.getServer().getOptions().shouldAuthenticate();
     connection.setProtocolVersion(protocolVersion);
+    setCancelSecret(connection, protocolVersion);
     String rawParameters = this.readAll();
     this.parameters = this.parseParameters(rawParameters);
     if (connection.getServer().getOptions().shouldAutoDetectClient()) {
@@ -60,6 +62,14 @@ public class StartupMessage extends BootstrapMessage {
     } else {
       connection.setWellKnownClient(WellKnownClient.UNSPECIFIED);
     }
+  }
+
+  private void setCancelSecret(ConnectionHandler connection, int protocolVersion) {
+    SecureRandom random = new SecureRandom();
+    int secretLen = StartupMessage.PROTOCOL_VERSION_3_0 == protocolVersion ? 4 : 32;
+    byte[] secretBytes = new byte[secretLen];
+    random.nextBytes(secretBytes);
+    connection.setSecret(secretBytes);
   }
 
   @Override
@@ -114,9 +124,7 @@ public class StartupMessage extends BootstrapMessage {
     sendStartupMessage(
         connection.getConnectionMetadata().getOutputStream(),
         connection.getConnectionId(),
-        connection.getProtocolVersion(),
         connection.getSecret(),
-        connection.getSecretBytes(),
         connection.getExtendedQueryProtocolHandler().getBackendConnection().getSessionState(),
         connection.getWellKnownClient().createStartupNoticeResponses(connection));
     connection.setStatus(ConnectionStatus.AUTHENTICATED);

--- a/src/main/java/com/google/cloud/spanner/pgadapter/wireprotocol/StartupMessage.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/wireprotocol/StartupMessage.java
@@ -37,14 +37,20 @@ public class StartupMessage extends BootstrapMessage {
   private static final Logger logger = Logger.getLogger(StartupMessage.class.getName());
   static final String DATABASE_KEY = "database";
   private static final String USER_KEY = "user";
-  public static final int IDENTIFIER = 196608; // First Hextet: 3 (version), Second Hextet: 0
+  // Protocol version constants
+  public static final int PROTOCOL_VERSION_3_0 = 196608;
+  public static final int PROTOCOL_VERSION_3_2 = 196610;
+  public static final int IDENTIFIER = PROTOCOL_VERSION_3_0;
 
   private final boolean authenticate;
   private final Map<String, String> parameters;
 
-  public StartupMessage(ConnectionHandler connection, int length) throws Exception {
+  /** Constructor for when the protocol version is already known. */
+  public StartupMessage(ConnectionHandler connection, int length, int protocolVersion)
+      throws Exception {
     super(connection, length);
     this.authenticate = connection.getServer().getOptions().shouldAuthenticate();
+    connection.setProtocolVersion(protocolVersion);
     String rawParameters = this.readAll();
     this.parameters = this.parseParameters(rawParameters);
     if (connection.getServer().getOptions().shouldAutoDetectClient()) {
@@ -108,7 +114,9 @@ public class StartupMessage extends BootstrapMessage {
     sendStartupMessage(
         connection.getConnectionMetadata().getOutputStream(),
         connection.getConnectionId(),
+        connection.getProtocolVersion(),
         connection.getSecret(),
+        connection.getSecretBytes(),
         connection.getExtendedQueryProtocolHandler().getBackendConnection().getSessionState(),
         connection.getWellKnownClient().createStartupNoticeResponses(connection));
     connection.setStatus(ConnectionStatus.AUTHENTICATED);

--- a/src/main/java/com/google/cloud/spanner/pgadapter/wireprotocol/StartupMessage.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/wireprotocol/StartupMessage.java
@@ -22,7 +22,6 @@ import com.google.cloud.spanner.pgadapter.utils.ClientAutoDetector;
 import com.google.cloud.spanner.pgadapter.utils.ClientAutoDetector.WellKnownClient;
 import com.google.cloud.spanner.pgadapter.wireoutput.AuthenticationCleartextPasswordResponse;
 import java.io.IOException;
-import java.security.SecureRandom;
 import java.text.MessageFormat;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -51,11 +50,10 @@ public class StartupMessage extends BootstrapMessage {
       throws Exception {
     super(connection, length);
     this.authenticate = connection.getServer().getOptions().shouldAuthenticate();
-    this.protocolVersion = protocolVersion;
-    connection.setProtocolVersion(protocolVersion);
-    setCancelSecret(connection, protocolVersion);
     String rawParameters = this.readAll();
     this.parameters = this.parseParameters(rawParameters);
+    this.protocolVersion = protocolVersion;
+    connection.setProtocolVersionProperties(protocolVersion);
     if (connection.getServer().getOptions().shouldAutoDetectClient()) {
       WellKnownClient wellKnownClient =
           ClientAutoDetector.detectClient(this.parseParameterKeys(rawParameters), this.parameters);
@@ -63,16 +61,6 @@ public class StartupMessage extends BootstrapMessage {
     } else {
       connection.setWellKnownClient(WellKnownClient.UNSPECIFIED);
     }
-  }
-
-  private void setCancelSecret(ConnectionHandler connection, int protocolVersion) {
-    int secretLen =
-        StartupMessage.PROTOCOL_VERSION_3_0_IDENTIFIER == protocolVersion
-            ? ConnectionHandler.PROTOCOL_30_KEY_LENGTH_BYTES
-            : ConnectionHandler.DEFAULT_KEY_LENGTH_BYTES;
-    byte[] secretBytes = new byte[secretLen];
-    new SecureRandom().nextBytes(secretBytes);
-    connection.setSecret(secretBytes);
   }
 
   @Override

--- a/src/main/java/com/google/cloud/spanner/pgadapter/wireprotocol/StartupMessage.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/wireprotocol/StartupMessage.java
@@ -26,7 +26,6 @@ import java.security.SecureRandom;
 import java.text.MessageFormat;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.logging.Logger;
 import javax.annotation.Nullable;
 
 /**
@@ -35,18 +34,19 @@ import javax.annotation.Nullable;
  */
 @InternalApi
 public class StartupMessage extends BootstrapMessage {
-  private static final Logger logger = Logger.getLogger(StartupMessage.class.getName());
+
   static final String DATABASE_KEY = "database";
   private static final String USER_KEY = "user";
   // Protocol version constants
-  public static final int PROTOCOL_VERSION_3_0 = 196608;
-  public static final int PROTOCOL_VERSION_3_2 = 196610;
+  public static final int PROTOCOL_VERSION_3_0 =
+      196608; // First Hextet: 3 (version), Second Hextet: 0
+  public static final int PROTOCOL_VERSION_3_2 =
+      196610; // First Hextet: 3 (version), Second Hextet: 2
   public static final int IDENTIFIER = PROTOCOL_VERSION_3_0;
 
   private final boolean authenticate;
   private final Map<String, String> parameters;
 
-  /** Constructor for when the protocol version is already known. */
   public StartupMessage(ConnectionHandler connection, int length, int protocolVersion)
       throws Exception {
     super(connection, length);
@@ -65,10 +65,9 @@ public class StartupMessage extends BootstrapMessage {
   }
 
   private void setCancelSecret(ConnectionHandler connection, int protocolVersion) {
-    SecureRandom random = new SecureRandom();
     int secretLen = StartupMessage.PROTOCOL_VERSION_3_0 == protocolVersion ? 4 : 32;
     byte[] secretBytes = new byte[secretLen];
-    random.nextBytes(secretBytes);
+    new SecureRandom().nextBytes(secretBytes);
     connection.setSecret(secretBytes);
   }
 

--- a/src/test/java/com/google/cloud/spanner/pgadapter/ConnectionHandlerTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/ConnectionHandlerTest.java
@@ -338,12 +338,11 @@ public class ConnectionHandlerTest {
           connectionHandler.cancelActiveStatement(
               connectionHandler.getConnectionId(), connectionHandler.getSecret()));
       // Cancelling a random non-existing connection should not work.
-      assertFalse(connectionHandler.cancelActiveStatement(100, 100));
+      assertFalse(connectionHandler.cancelActiveStatement(100, new byte[4]));
       // Cancelling another connecting using the wrong secret is not allowed.
       assertFalse(
           connectionHandler.cancelActiveStatement(
-              connectionHandlerToCancel.getConnectionId(),
-              connectionHandlerToCancel.getSecret() - 1));
+              connectionHandlerToCancel.getConnectionId(), new byte[4]));
 
       assertTrue(
           connectionHandler.cancelActiveStatement(

--- a/src/test/java/com/google/cloud/spanner/pgadapter/ConnectionHandlerTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/ConnectionHandlerTest.java
@@ -58,6 +58,7 @@ import com.google.cloud.spanner.pgadapter.statements.IntermediatePortalStatement
 import com.google.cloud.spanner.pgadapter.statements.IntermediatePreparedStatement;
 import com.google.cloud.spanner.pgadapter.utils.ClientAutoDetector.WellKnownClient;
 import com.google.cloud.spanner.pgadapter.wireprotocol.ParseMessage;
+import com.google.cloud.spanner.pgadapter.wireprotocol.StartupMessage;
 import com.google.cloud.spanner.pgadapter.wireprotocol.WireMessage;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -330,6 +331,8 @@ public class ConnectionHandlerTest {
     ConnectionHandler connectionHandlerToCancel =
         new ConnectionHandler(server, socket, spannerConnection);
     connectionHandlerToCancel.setThread(mock(Thread.class));
+    connectionHandlerToCancel.setProtocolVersionProperties(
+        StartupMessage.PROTOCOL_VERSION_3_0_IDENTIFIER);
     CONNECTION_HANDLERS.put(connectionHandlerToCancel.getConnectionId(), connectionHandlerToCancel);
 
     try {

--- a/src/test/java/com/google/cloud/spanner/pgadapter/InvalidMessagesTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/InvalidMessagesTest.java
@@ -66,7 +66,7 @@ public class InvalidMessagesTest extends AbstractMockServerTest {
       try (DataOutputStream outputStream = new DataOutputStream(socket.getOutputStream())) {
         // Send a startup message and then quit.
         outputStream.writeInt(8); // length == 8
-        outputStream.writeInt(StartupMessage.IDENTIFIER);
+        outputStream.writeInt(StartupMessage.PROTOCOL_VERSION_3_0_IDENTIFIER);
         outputStream.flush();
       }
     }
@@ -96,7 +96,7 @@ public class InvalidMessagesTest extends AbstractMockServerTest {
           DataOutputStream outputStream = new DataOutputStream(socket.getOutputStream())) {
         // Request startup.
         outputStream.writeInt(17);
-        outputStream.writeInt(StartupMessage.IDENTIFIER);
+        outputStream.writeInt(StartupMessage.PROTOCOL_VERSION_3_0_IDENTIFIER);
         outputStream.writeBytes("user");
         outputStream.writeByte(0);
         outputStream.writeBytes("foo");
@@ -118,7 +118,7 @@ public class InvalidMessagesTest extends AbstractMockServerTest {
           DataOutputStream outputStream = new DataOutputStream(socket.getOutputStream())) {
         // Request startup.
         outputStream.writeInt(17);
-        outputStream.writeInt(StartupMessage.IDENTIFIER);
+        outputStream.writeInt(StartupMessage.PROTOCOL_VERSION_3_0_IDENTIFIER);
         outputStream.writeBytes("user");
         outputStream.writeByte(0);
         outputStream.writeBytes("foo");
@@ -156,7 +156,7 @@ public class InvalidMessagesTest extends AbstractMockServerTest {
           DataOutputStream outputStream = new DataOutputStream(socket.getOutputStream())) {
         // Request startup.
         outputStream.writeInt(17);
-        outputStream.writeInt(StartupMessage.IDENTIFIER);
+        outputStream.writeInt(StartupMessage.PROTOCOL_VERSION_3_0_IDENTIFIER);
         outputStream.writeBytes("user");
         outputStream.writeByte(0);
         outputStream.writeBytes("foo");
@@ -258,7 +258,7 @@ public class InvalidMessagesTest extends AbstractMockServerTest {
           DataOutputStream outputStream = new DataOutputStream(socket.getOutputStream())) {
         // Request startup.
         outputStream.writeInt(17);
-        outputStream.writeInt(StartupMessage.IDENTIFIER);
+        outputStream.writeInt(StartupMessage.PROTOCOL_VERSION_3_0_IDENTIFIER);
         outputStream.writeBytes("user");
         outputStream.writeByte(0);
         outputStream.writeBytes("foo");
@@ -396,7 +396,7 @@ public class InvalidMessagesTest extends AbstractMockServerTest {
           DataOutputStream outputStream = new DataOutputStream(socket.getOutputStream())) {
         // Request startup.
         outputStream.writeInt(17);
-        outputStream.writeInt(StartupMessage.IDENTIFIER);
+        outputStream.writeInt(StartupMessage.PROTOCOL_VERSION_3_0_IDENTIFIER);
         outputStream.writeBytes("user");
         outputStream.writeByte(0);
         outputStream.writeBytes("foo");

--- a/src/test/java/com/google/cloud/spanner/pgadapter/JdbcMockServerTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/JdbcMockServerTest.java
@@ -597,7 +597,7 @@ public class JdbcMockServerTest extends AbstractMockServerTest {
 
   private String createUrl(String database) {
     return String.format(
-        "jdbc:postgresql://localhost:%d/%s?options=-c%%20server_version=%s&protocolVersion=%s",
+        "jdbc:postgresql://localhost:%d/%s?options=-c%%20server_version=%s%%20-c%%20protocol_version=%s",
         pgServer.getLocalPort(), database, pgVersion, protocolVersion);
   }
 
@@ -4106,7 +4106,7 @@ public class JdbcMockServerTest extends AbstractMockServerTest {
   @Test
   public void testShowGuessTypesOverwritten() throws SQLException {
     try (Connection connection =
-        DriverManager.getConnection(createUrl() + "&options=-c%20spanner.guess_types=0")) {
+        DriverManager.getConnection(createUrl() + "?options=-c%20spanner.guess_types=0")) {
       try (ResultSet resultSet =
           connection.createStatement().executeQuery("show spanner.guess_types")) {
         assertTrue(resultSet.next());
@@ -4589,7 +4589,7 @@ public class JdbcMockServerTest extends AbstractMockServerTest {
   @Test
   public void testSetTimeZoneToDefault() throws SQLException {
     try (Connection connection =
-        DriverManager.getConnection(createUrl() + "&options=-c%20timezone=IST")) {
+        DriverManager.getConnection(createUrl() + "?options=-c%20timezone=IST")) {
       connection.createStatement().execute("set time zone default");
       verifySettingValue(connection, "timezone", "Asia/Kolkata");
     }
@@ -4598,7 +4598,7 @@ public class JdbcMockServerTest extends AbstractMockServerTest {
   @Test
   public void testSetTimeZoneToLocal() throws SQLException {
     try (Connection connection =
-        DriverManager.getConnection(createUrl() + "&options=-c%20timezone=IST")) {
+        DriverManager.getConnection(createUrl() + "?options=-c%20timezone=IST")) {
       connection.createStatement().execute("set time zone local");
       verifySettingValue(connection, "timezone", "Asia/Kolkata");
     }
@@ -4762,7 +4762,7 @@ public class JdbcMockServerTest extends AbstractMockServerTest {
     try (Connection connection =
         DriverManager.getConnection(
             createUrl()
-                + "&options=-c%20spanner.ddl_transaction_mode=AutocommitExplicitTransaction")) {
+                + "?options=-c%20spanner.ddl_transaction_mode=AutocommitExplicitTransaction")) {
       verifySettingValue(
           connection, "spanner.ddl_transaction_mode", "AutocommitExplicitTransaction");
     }
@@ -4772,7 +4772,7 @@ public class JdbcMockServerTest extends AbstractMockServerTest {
   public void testMultipleSettingsInConnectionOptions() throws SQLException {
     try (Connection connection =
         DriverManager.getConnection(
-            createUrl() + "&options=-c%20spanner.setting1=value1%20-c%20spanner.setting2=value2")) {
+            createUrl() + "?options=-c%20spanner.setting1=value1%20-c%20spanner.setting2=value2")) {
       verifySettingValue(connection, "spanner.setting1", "value1");
       verifySettingValue(connection, "spanner.setting2", "value2");
     }
@@ -4781,7 +4781,7 @@ public class JdbcMockServerTest extends AbstractMockServerTest {
   @Test
   public void testServerVersionInConnectionOptions() throws SQLException {
     try (Connection connection =
-        DriverManager.getConnection(createUrl() + "&options=-c%20server_version=4.1")) {
+        DriverManager.getConnection(createUrl() + "?options=-c%20server_version=4.1")) {
       verifySettingValue(connection, "server_version", "4.1");
       verifySettingValue(connection, "server_version_num", "40001");
     }
@@ -4791,7 +4791,7 @@ public class JdbcMockServerTest extends AbstractMockServerTest {
   public void testCustomServerVersionInConnectionOptions() throws SQLException {
     try (Connection connection =
         DriverManager.getConnection(
-            createUrl() + "&options=-c%20server_version=5.2 custom version")) {
+            createUrl() + "?options=-c%20server_version=5.2 custom version")) {
       verifySettingValue(connection, "server_version", "5.2 custom version");
       verifySettingValue(connection, "server_version_num", "50002");
     }
@@ -4801,7 +4801,7 @@ public class JdbcMockServerTest extends AbstractMockServerTest {
   public void testSetConnectionApiOptionInConnectionOptions() throws SQLException {
     try (Connection connection =
         DriverManager.getConnection(
-            createUrl() + "&options=-c%20spanner.autocommit_dml_mode='partitioned_non_atomic'")) {
+            createUrl() + "?options=-c%20spanner.autocommit_dml_mode='partitioned_non_atomic'")) {
       verifySettingValue(connection, "spanner.autocommit_dml_mode", "PARTITIONED_NON_ATOMIC");
     }
   }
@@ -4810,7 +4810,7 @@ public class JdbcMockServerTest extends AbstractMockServerTest {
   public void testSetInvalidConnectionApiOptionInConnectionOptions() throws SQLException {
     try (Connection connection =
         DriverManager.getConnection(
-            createUrl() + "&options=-c%20spanner.read_only_staleness='foo'")) {
+            createUrl() + "?options=-c%20spanner.read_only_staleness='foo'")) {
       verifySettingValue(connection, "spanner.read_only_staleness", "STRONG");
     }
   }
@@ -4820,7 +4820,7 @@ public class JdbcMockServerTest extends AbstractMockServerTest {
     try (Connection connection =
         DriverManager.getConnection(
             createUrl()
-                + "&options=-c%20spanner.read_only_staleness='foo'"
+                + "?options=-c%20spanner.read_only_staleness='foo'"
                 + "%20-c%20spanner.autocommit_dml_mode='partitioned_non_atomic'")) {
       verifySettingValue(connection, "spanner.read_only_staleness", "STRONG");
       verifySettingValue(connection, "spanner.autocommit_dml_mode", "PARTITIONED_NON_ATOMIC");
@@ -4897,7 +4897,7 @@ public class JdbcMockServerTest extends AbstractMockServerTest {
   public void testReplacePgCatalogTablesOff() throws SQLException {
     try (Connection connection =
         DriverManager.getConnection(
-            createUrl() + "&options=-c%20spanner.replace_pg_catalog_tables=off")) {
+            createUrl() + "?options=-c%20spanner.replace_pg_catalog_tables=off")) {
       try (ResultSet resultSet =
           connection.createStatement().executeQuery("show spanner.replace_pg_catalog_tables")) {
         assertTrue(resultSet.next());

--- a/src/test/java/com/google/cloud/spanner/pgadapter/JdbcMockServerTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/JdbcMockServerTest.java
@@ -597,8 +597,8 @@ public class JdbcMockServerTest extends AbstractMockServerTest {
 
   private String createUrl(String database) {
     return String.format(
-        "jdbc:postgresql://localhost:%d/%s?options=-c%%20server_version=%s%%20-c%%20protocol_version=%s",
-        pgServer.getLocalPort(), database, pgVersion, protocolVersion);
+        "jdbc:postgresql://localhost:%d/%s?protocolVersion=%s&options=-c%%20server_version=%s",
+        pgServer.getLocalPort(), database, protocolVersion, pgVersion);
   }
 
   private String getExpectedInitialApplicationName() {

--- a/src/test/java/com/google/cloud/spanner/pgadapter/JdbcMockServerTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/JdbcMockServerTest.java
@@ -108,7 +108,7 @@ import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
+import org.junit.runners.Parameterized;
 import org.postgresql.PGConnection;
 import org.postgresql.PGStatement;
 import org.postgresql.core.Oid;
@@ -117,7 +117,7 @@ import org.postgresql.util.PGInterval;
 import org.postgresql.util.PGobject;
 import org.postgresql.util.PSQLException;
 
-@RunWith(JUnit4.class)
+@RunWith(Parameterized.class)
 public class JdbcMockServerTest extends AbstractMockServerTest {
   private static final String pgVersion = "14.1";
   private static final int RANDOM_RESULTS_ROW_COUNT = 10;
@@ -127,6 +127,17 @@ public class JdbcMockServerTest extends AbstractMockServerTest {
           "SET extra_float_digits = 2",
           "SET extra_float_digits = 3",
           "SET application_name = 'PostgreSQL JDBC Driver'");
+
+  @Parameterized.Parameters(name = "protocolVersion={0}")
+  public static Collection<Object[]> parameters() {
+    return Arrays.asList(new Object[][] {{"3.0"}, {"3.2"}});
+  }
+
+  private final String protocolVersion;
+
+  public JdbcMockServerTest(String protocolVersion) {
+    this.protocolVersion = protocolVersion;
+  }
 
   @BeforeClass
   public static void loadPgJdbcDriver() throws Exception {
@@ -586,8 +597,8 @@ public class JdbcMockServerTest extends AbstractMockServerTest {
 
   private String createUrl(String database) {
     return String.format(
-        "jdbc:postgresql://localhost:%d/%s?options=-c%%20server_version=%s",
-        pgServer.getLocalPort(), database, pgVersion);
+        "jdbc:postgresql://localhost:%d/%s?options=-c%%20server_version=%s&protocolVersion=%s",
+        pgServer.getLocalPort(), database, pgVersion, protocolVersion);
   }
 
   private String getExpectedInitialApplicationName() {
@@ -4095,7 +4106,7 @@ public class JdbcMockServerTest extends AbstractMockServerTest {
   @Test
   public void testShowGuessTypesOverwritten() throws SQLException {
     try (Connection connection =
-        DriverManager.getConnection(createUrl() + "?options=-c%20spanner.guess_types=0")) {
+        DriverManager.getConnection(createUrl() + "&options=-c%20spanner.guess_types=0")) {
       try (ResultSet resultSet =
           connection.createStatement().executeQuery("show spanner.guess_types")) {
         assertTrue(resultSet.next());
@@ -4578,7 +4589,7 @@ public class JdbcMockServerTest extends AbstractMockServerTest {
   @Test
   public void testSetTimeZoneToDefault() throws SQLException {
     try (Connection connection =
-        DriverManager.getConnection(createUrl() + "?options=-c%20timezone=IST")) {
+        DriverManager.getConnection(createUrl() + "&options=-c%20timezone=IST")) {
       connection.createStatement().execute("set time zone default");
       verifySettingValue(connection, "timezone", "Asia/Kolkata");
     }
@@ -4587,7 +4598,7 @@ public class JdbcMockServerTest extends AbstractMockServerTest {
   @Test
   public void testSetTimeZoneToLocal() throws SQLException {
     try (Connection connection =
-        DriverManager.getConnection(createUrl() + "?options=-c%20timezone=IST")) {
+        DriverManager.getConnection(createUrl() + "&options=-c%20timezone=IST")) {
       connection.createStatement().execute("set time zone local");
       verifySettingValue(connection, "timezone", "Asia/Kolkata");
     }
@@ -4751,7 +4762,7 @@ public class JdbcMockServerTest extends AbstractMockServerTest {
     try (Connection connection =
         DriverManager.getConnection(
             createUrl()
-                + "?options=-c%20spanner.ddl_transaction_mode=AutocommitExplicitTransaction")) {
+                + "&options=-c%20spanner.ddl_transaction_mode=AutocommitExplicitTransaction")) {
       verifySettingValue(
           connection, "spanner.ddl_transaction_mode", "AutocommitExplicitTransaction");
     }
@@ -4761,7 +4772,7 @@ public class JdbcMockServerTest extends AbstractMockServerTest {
   public void testMultipleSettingsInConnectionOptions() throws SQLException {
     try (Connection connection =
         DriverManager.getConnection(
-            createUrl() + "?options=-c%20spanner.setting1=value1%20-c%20spanner.setting2=value2")) {
+            createUrl() + "&options=-c%20spanner.setting1=value1%20-c%20spanner.setting2=value2")) {
       verifySettingValue(connection, "spanner.setting1", "value1");
       verifySettingValue(connection, "spanner.setting2", "value2");
     }
@@ -4770,7 +4781,7 @@ public class JdbcMockServerTest extends AbstractMockServerTest {
   @Test
   public void testServerVersionInConnectionOptions() throws SQLException {
     try (Connection connection =
-        DriverManager.getConnection(createUrl() + "?options=-c%20server_version=4.1")) {
+        DriverManager.getConnection(createUrl() + "&options=-c%20server_version=4.1")) {
       verifySettingValue(connection, "server_version", "4.1");
       verifySettingValue(connection, "server_version_num", "40001");
     }
@@ -4780,7 +4791,7 @@ public class JdbcMockServerTest extends AbstractMockServerTest {
   public void testCustomServerVersionInConnectionOptions() throws SQLException {
     try (Connection connection =
         DriverManager.getConnection(
-            createUrl() + "?options=-c%20server_version=5.2 custom version")) {
+            createUrl() + "&options=-c%20server_version=5.2 custom version")) {
       verifySettingValue(connection, "server_version", "5.2 custom version");
       verifySettingValue(connection, "server_version_num", "50002");
     }
@@ -4790,7 +4801,7 @@ public class JdbcMockServerTest extends AbstractMockServerTest {
   public void testSetConnectionApiOptionInConnectionOptions() throws SQLException {
     try (Connection connection =
         DriverManager.getConnection(
-            createUrl() + "?options=-c%20spanner.autocommit_dml_mode='partitioned_non_atomic'")) {
+            createUrl() + "&options=-c%20spanner.autocommit_dml_mode='partitioned_non_atomic'")) {
       verifySettingValue(connection, "spanner.autocommit_dml_mode", "PARTITIONED_NON_ATOMIC");
     }
   }
@@ -4799,7 +4810,7 @@ public class JdbcMockServerTest extends AbstractMockServerTest {
   public void testSetInvalidConnectionApiOptionInConnectionOptions() throws SQLException {
     try (Connection connection =
         DriverManager.getConnection(
-            createUrl() + "?options=-c%20spanner.read_only_staleness='foo'")) {
+            createUrl() + "&options=-c%20spanner.read_only_staleness='foo'")) {
       verifySettingValue(connection, "spanner.read_only_staleness", "STRONG");
     }
   }
@@ -4809,7 +4820,7 @@ public class JdbcMockServerTest extends AbstractMockServerTest {
     try (Connection connection =
         DriverManager.getConnection(
             createUrl()
-                + "?options=-c%20spanner.read_only_staleness='foo'"
+                + "&options=-c%20spanner.read_only_staleness='foo'"
                 + "%20-c%20spanner.autocommit_dml_mode='partitioned_non_atomic'")) {
       verifySettingValue(connection, "spanner.read_only_staleness", "STRONG");
       verifySettingValue(connection, "spanner.autocommit_dml_mode", "PARTITIONED_NON_ATOMIC");
@@ -4886,7 +4897,7 @@ public class JdbcMockServerTest extends AbstractMockServerTest {
   public void testReplacePgCatalogTablesOff() throws SQLException {
     try (Connection connection =
         DriverManager.getConnection(
-            createUrl() + "?options=-c%20spanner.replace_pg_catalog_tables=off")) {
+            createUrl() + "&options=-c%20spanner.replace_pg_catalog_tables=off")) {
       try (ResultSet resultSet =
           connection.createStatement().executeQuery("show spanner.replace_pg_catalog_tables")) {
         assertTrue(resultSet.next());
@@ -6025,7 +6036,6 @@ public class JdbcMockServerTest extends AbstractMockServerTest {
     String sql = "SELECT 1";
     for (boolean autocommit : new boolean[] {true, false}) {
       ExecutorService executor = Executors.newSingleThreadExecutor();
-
       try (Connection connection = DriverManager.getConnection(createUrl());
           java.sql.Statement statement = connection.createStatement()) {
         connection.setAutoCommit(autocommit);

--- a/src/test/java/com/google/cloud/spanner/pgadapter/JdbcMockServerTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/JdbcMockServerTest.java
@@ -6036,6 +6036,7 @@ public class JdbcMockServerTest extends AbstractMockServerTest {
     String sql = "SELECT 1";
     for (boolean autocommit : new boolean[] {true, false}) {
       ExecutorService executor = Executors.newSingleThreadExecutor();
+
       try (Connection connection = DriverManager.getConnection(createUrl());
           java.sql.Statement statement = connection.createStatement()) {
         connection.setAutoCommit(autocommit);

--- a/src/test/java/com/google/cloud/spanner/pgadapter/wireprotocol/BoostrapMessageTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/wireprotocol/BoostrapMessageTest.java
@@ -65,7 +65,7 @@ public class BoostrapMessageTest {
     // length
     dataOutputStream.writeInt(1024);
     // identifier
-    dataOutputStream.writeInt(StartupMessage.IDENTIFIER);
+    dataOutputStream.writeInt(StartupMessage.PROTOCOL_VERSION_3_0_IDENTIFIER);
     dataOutputStream.write(new byte[1024]);
 
     BootstrapMessage message = BootstrapMessage.create(connection);

--- a/src/test/java/com/google/cloud/spanner/pgadapter/wireprotocol/ProtocolTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/wireprotocol/ProtocolTest.java
@@ -14,6 +14,7 @@
 
 package com.google.cloud.spanner.pgadapter.wireprotocol;
 
+import static com.google.cloud.spanner.pgadapter.ConnectionHandler.DEFAULT_KEY_LENGTH_BYTES;
 import static com.google.cloud.spanner.pgadapter.statements.IntermediatePortalStatement.NO_FORMAT_CODES;
 import static com.google.cloud.spanner.pgadapter.wireprotocol.MessageReader.MAX_INVALID_MESSAGE_COUNT;
 import static org.junit.Assert.assertArrayEquals;
@@ -72,6 +73,7 @@ import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.security.SecureRandom;
 import java.time.ZoneId;
 import java.util.HashMap;
 import java.util.Map;
@@ -1709,7 +1711,141 @@ public class ProtocolTest {
   }
 
   @Test
-  public void testCancelMessage() throws Exception {
+  public void testStartUpMessageProtocolVersion32() throws Exception {
+    byte[] protocol = intToBytes(StartupMessage.PROTOCOL_VERSION_3_2);
+    byte[] payload =
+        ("database\0"
+                + "databasename\0"
+                + "application_name\0"
+                + "psql\0"
+                + "client_encoding\0"
+                + "UTF8\0"
+                + "server_version\0"
+                + "13.4\0"
+                + "user\0"
+                + "me\0")
+            .getBytes();
+    byte[] length = intToBytes(8 + payload.length);
+
+    byte[] value = Bytes.concat(length, protocol, payload);
+
+    Map<String, String> expectedParameters = new HashMap<>();
+    expectedParameters.put("database", "databasename");
+    expectedParameters.put("application_name", "psql");
+    expectedParameters.put("client_encoding", "UTF8");
+    expectedParameters.put("server_version", "13.4");
+    expectedParameters.put("user", "me");
+
+    DataInputStream inputStream = new DataInputStream(new ByteArrayInputStream(value));
+    ByteArrayOutputStream result = new ByteArrayOutputStream();
+    DataOutputStream outputStream = new DataOutputStream(result);
+
+    when(connectionHandler.getConnectionMetadata()).thenReturn(connectionMetadata);
+    when(connectionHandler.getServer()).thenReturn(server);
+    when(connectionHandler.getConnectionId()).thenReturn(1);
+    when(connectionHandler.getExtendedQueryProtocolHandler())
+        .thenReturn(extendedQueryProtocolHandler);
+    when(connectionHandler.getWellKnownClient()).thenReturn(WellKnownClient.UNSPECIFIED);
+    when(connectionHandler.getProtocolVersion()).thenReturn(StartupMessage.PROTOCOL_VERSION_3_2);
+    byte[] secretBytes = new byte[DEFAULT_KEY_LENGTH_BYTES];
+    new SecureRandom().nextBytes(secretBytes);
+    when(connectionHandler.getSecretBytes()).thenReturn(secretBytes);
+    when(extendedQueryProtocolHandler.getBackendConnection()).thenReturn(backendConnection);
+    SessionState sessionState = mock(SessionState.class);
+    PGSetting serverVersionSetting = mock(PGSetting.class);
+    when(serverVersionSetting.getSetting()).thenReturn("13.4");
+    when(sessionState.get(null, "server_version")).thenReturn(serverVersionSetting);
+    when(backendConnection.getSessionState()).thenReturn(sessionState);
+    when(server.getOptions()).thenReturn(options);
+    when(server.getMessageReader()).thenReturn(new MessageReader(options));
+    when(options.shouldAuthenticate()).thenReturn(false);
+    when(connectionMetadata.getInputStream()).thenReturn(inputStream);
+    when(connectionMetadata.getOutputStream()).thenReturn(outputStream);
+
+    WireMessage message = BootstrapMessage.create(connectionHandler);
+    assertEquals(StartupMessage.class, message.getClass());
+
+    assertEquals(expectedParameters, ((StartupMessage) message).getParameters());
+
+    message.send();
+
+    DataInputStream outputResult = inputStreamFromOutputStream(result);
+    verify(connectionHandler).connectToSpanner("databasename", null, expectedParameters);
+
+    // AuthenticationOkResponse
+    assertEquals('R', outputResult.readByte());
+    assertEquals(8, outputResult.readInt());
+    assertEquals(0, outputResult.readInt());
+
+    // KeyDataResponse
+    assertEquals('K', outputResult.readByte());
+    assertEquals(8 + 32, outputResult.readInt());
+    assertEquals(1, outputResult.readInt());
+    byte[] keyBytes = new byte[32];
+    outputResult.readFully(keyBytes);
+    assertArrayEquals(secretBytes, keyBytes);
+
+    // ParameterStatusResponse (x11)
+    assertEquals('S', outputResult.readByte());
+    assertEquals(24, outputResult.readInt());
+    assertEquals("server_version\0", readUntil(outputResult, "server_version\0".length()));
+    assertEquals("13.4\0", readUntil(outputResult, "13.4\0".length()));
+    assertEquals('S', outputResult.readByte());
+    assertEquals(31, outputResult.readInt());
+    assertEquals("application_name\0", readUntil(outputResult, "application_name\0".length()));
+    assertEquals("PGAdapter\0", readUntil(outputResult, "PGAdapter\0".length()));
+    assertEquals('S', outputResult.readByte());
+    assertEquals(23, outputResult.readInt());
+    assertEquals("is_superuser\0", readUntil(outputResult, "is_superuser\0".length()));
+    assertEquals("false\0", readUntil(outputResult, "false\0".length()));
+    assertEquals('S', outputResult.readByte());
+    assertEquals(36, outputResult.readInt());
+    assertEquals(
+        "session_authorization\0", readUntil(outputResult, "session_authorization\0".length()));
+    assertEquals("PGAdapter\0", readUntil(outputResult, "PGAdapter\0".length()));
+    assertEquals('S', outputResult.readByte());
+    assertEquals(25, outputResult.readInt());
+    assertEquals("integer_datetimes\0", readUntil(outputResult, "integer_datetimes\0".length()));
+    assertEquals("on\0", readUntil(outputResult, "on\0".length()));
+    assertEquals('S', outputResult.readByte());
+    assertEquals(25, outputResult.readInt());
+    assertEquals("server_encoding\0", readUntil(outputResult, "server_encoding\0".length()));
+    assertEquals("UTF8\0", readUntil(outputResult, "UTF8\0".length()));
+    assertEquals('S', outputResult.readByte());
+    assertEquals(25, outputResult.readInt());
+    assertEquals("client_encoding\0", readUntil(outputResult, "client_encoding\0".length()));
+    assertEquals("UTF8\0", readUntil(outputResult, "UTF8\0".length()));
+    assertEquals('S', outputResult.readByte());
+    assertEquals(22, outputResult.readInt());
+    assertEquals("DateStyle\0", readUntil(outputResult, "DateStyle\0".length()));
+    assertEquals("ISO,YMD\0", readUntil(outputResult, "ISO,YMD\0".length()));
+    assertEquals('S', outputResult.readByte());
+    assertEquals(27, outputResult.readInt());
+    assertEquals("IntervalStyle\0", readUntil(outputResult, "IntervalStyle\0".length()));
+    assertEquals("iso_8601\0", readUntil(outputResult, "iso_8601\0".length()));
+    assertEquals('S', outputResult.readByte());
+    assertEquals(35, outputResult.readInt());
+    assertEquals(
+        "standard_conforming_strings\0",
+        readUntil(outputResult, "standard_conforming_strings\0".length()));
+    assertEquals("on\0", readUntil(outputResult, "on\0".length()));
+    assertEquals('S', outputResult.readByte());
+
+    // Timezone will vary depending on the default location of the JVM that is running.
+    String timezoneIdentifier = ZoneId.systemDefault().getId();
+    int expectedLength = timezoneIdentifier.getBytes(StandardCharsets.UTF_8).length + 10 + 4;
+    assertEquals(expectedLength, outputResult.readInt());
+    assertEquals("TimeZone\0", readUntil(outputResult, "TimeZone\0".length()));
+    readUntilNullTerminator(outputResult);
+
+    // ReadyResponse
+    assertEquals('Z', outputResult.readByte());
+    assertEquals(5, outputResult.readInt());
+    assertEquals('I', outputResult.readByte());
+  }
+
+  @Test
+  public void testCancelMessageProtocolVersion30() throws Exception {
     byte[] length = intToBytes(16);
     byte[] protocol = intToBytes(80877102);
     byte[] connectionId = intToBytes(1);
@@ -1736,6 +1872,39 @@ public class ProtocolTest {
     message.send();
 
     verify(connectionHandler).cancelActiveStatement(1, 1);
+    verify(connectionHandler).handleTerminate();
+  }
+
+  @Test
+  public void testCancelMessageProtocolVersion32() throws Exception {
+    byte[] length = intToBytes(12 + 32);
+    byte[] protocol = intToBytes(80877102);
+    byte[] connectionId = intToBytes(1);
+    byte[] secret = new byte[32];
+    new SecureRandom().nextBytes(secret);
+
+    byte[] value = Bytes.concat(length, protocol, connectionId, secret);
+
+    DataInputStream inputStream = new DataInputStream(new ByteArrayInputStream(value));
+    ByteArrayOutputStream result = new ByteArrayOutputStream();
+    DataOutputStream outputStream = new DataOutputStream(result);
+
+    when(connectionHandler.getConnectionMetadata()).thenReturn(connectionMetadata);
+    when(connectionMetadata.getInputStream()).thenReturn(inputStream);
+    when(connectionMetadata.getOutputStream()).thenReturn(outputStream);
+    when(server.getMessageReader()).thenReturn(new MessageReader(options));
+    when(connectionHandler.getServer()).thenReturn(server);
+
+    WireMessage message = BootstrapMessage.create(connectionHandler);
+    assertEquals(CancelMessage.class, message.getClass());
+
+    CancelMessage cancel = (CancelMessage) message;
+    assertEquals(1, cancel.getConnectionId());
+    assertArrayEquals(secret, cancel.getSecretBytes());
+
+    message.send();
+
+    verify(connectionHandler).cancelActiveStatement(1, secret);
     verify(connectionHandler).handleTerminate();
   }
 

--- a/src/test/java/com/google/cloud/spanner/pgadapter/wireprotocol/ProtocolTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/wireprotocol/ProtocolTest.java
@@ -1874,7 +1874,7 @@ public class ProtocolTest {
     assertEquals(CancelMessage.class, message.getClass());
 
     assertEquals(1, ((CancelMessage) message).getConnectionId());
-    assertArrayEquals(secret, ((CancelMessage) message).getSecretBytes());
+    assertArrayEquals(secret, ((CancelMessage) message).getSecret());
 
     message.send();
 
@@ -1907,7 +1907,7 @@ public class ProtocolTest {
 
     CancelMessage cancel = (CancelMessage) message;
     assertEquals(1, cancel.getConnectionId());
-    assertArrayEquals(secret, cancel.getSecretBytes());
+    assertArrayEquals(secret, cancel.getSecret());
 
     message.send();
 

--- a/src/test/java/com/google/cloud/spanner/pgadapter/wireprotocol/ProtocolTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/wireprotocol/ProtocolTest.java
@@ -15,8 +15,11 @@
 package com.google.cloud.spanner.pgadapter.wireprotocol;
 
 import static com.google.cloud.spanner.pgadapter.ConnectionHandler.DEFAULT_KEY_LENGTH_BYTES;
+import static com.google.cloud.spanner.pgadapter.ConnectionHandler.PROTOCOL_30_KEY_LENGTH_BYTES;
 import static com.google.cloud.spanner.pgadapter.statements.IntermediatePortalStatement.NO_FORMAT_CODES;
 import static com.google.cloud.spanner.pgadapter.wireprotocol.MessageReader.MAX_INVALID_MESSAGE_COUNT;
+import static com.google.cloud.spanner.pgadapter.wireprotocol.StartupMessage.PROTOCOL_VERSION_3_0_IDENTIFIER;
+import static com.google.cloud.spanner.pgadapter.wireprotocol.StartupMessage.PROTOCOL_VERSION_3_2_IDENTIFIER;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -1583,8 +1586,8 @@ public class ProtocolTest {
   }
 
   @Test
-  public void testStartUpMessage() throws Exception {
-    byte[] protocol = intToBytes(196608);
+  public void testStartUpMessageProtocolVersion30() throws Exception {
+    byte[] protocol = intToBytes(PROTOCOL_VERSION_3_0_IDENTIFIER);
     byte[] payload =
         ("database\0"
                 + "databasename\0"
@@ -1618,8 +1621,8 @@ public class ProtocolTest {
     when(connectionHandler.getExtendedQueryProtocolHandler())
         .thenReturn(extendedQueryProtocolHandler);
     when(connectionHandler.getWellKnownClient()).thenReturn(WellKnownClient.UNSPECIFIED);
-    when(connectionHandler.getProtocolVersion()).thenReturn(StartupMessage.PROTOCOL_VERSION_3_0);
-    byte[] secretBytes = new byte[4];
+    when(connectionHandler.getProtocolVersion()).thenReturn(PROTOCOL_VERSION_3_0_IDENTIFIER);
+    byte[] secretBytes = new byte[PROTOCOL_30_KEY_LENGTH_BYTES];
     new SecureRandom().nextBytes(secretBytes);
     when(connectionHandler.getSecret()).thenReturn(secretBytes);
     when(extendedQueryProtocolHandler.getBackendConnection()).thenReturn(backendConnection);
@@ -1651,9 +1654,9 @@ public class ProtocolTest {
 
     // KeyDataResponse
     assertEquals('K', outputResult.readByte());
-    assertEquals(12, outputResult.readInt());
+    assertEquals(8 + PROTOCOL_30_KEY_LENGTH_BYTES, outputResult.readInt());
     assertEquals(1, outputResult.readInt());
-    byte[] keyBytes = new byte[4];
+    byte[] keyBytes = new byte[PROTOCOL_30_KEY_LENGTH_BYTES];
     outputResult.readFully(keyBytes);
     assertArrayEquals(secretBytes, keyBytes);
 
@@ -1718,7 +1721,7 @@ public class ProtocolTest {
 
   @Test
   public void testStartUpMessageProtocolVersion32() throws Exception {
-    byte[] protocol = intToBytes(StartupMessage.PROTOCOL_VERSION_3_2);
+    byte[] protocol = intToBytes(PROTOCOL_VERSION_3_2_IDENTIFIER);
     byte[] payload =
         ("database\0"
                 + "databasename\0"
@@ -1752,7 +1755,7 @@ public class ProtocolTest {
     when(connectionHandler.getExtendedQueryProtocolHandler())
         .thenReturn(extendedQueryProtocolHandler);
     when(connectionHandler.getWellKnownClient()).thenReturn(WellKnownClient.UNSPECIFIED);
-    when(connectionHandler.getProtocolVersion()).thenReturn(StartupMessage.PROTOCOL_VERSION_3_2);
+    when(connectionHandler.getProtocolVersion()).thenReturn(PROTOCOL_VERSION_3_2_IDENTIFIER);
     byte[] secretBytes = new byte[DEFAULT_KEY_LENGTH_BYTES];
     new SecureRandom().nextBytes(secretBytes);
     when(connectionHandler.getSecret()).thenReturn(secretBytes);
@@ -1785,9 +1788,9 @@ public class ProtocolTest {
 
     // KeyDataResponse
     assertEquals('K', outputResult.readByte());
-    assertEquals(8 + 32, outputResult.readInt());
+    assertEquals(8 + DEFAULT_KEY_LENGTH_BYTES, outputResult.readInt());
     assertEquals(1, outputResult.readInt());
-    byte[] keyBytes = new byte[32];
+    byte[] keyBytes = new byte[DEFAULT_KEY_LENGTH_BYTES];
     outputResult.readFully(keyBytes);
     assertArrayEquals(secretBytes, keyBytes);
 
@@ -1852,10 +1855,10 @@ public class ProtocolTest {
 
   @Test
   public void testCancelMessageProtocolVersion30() throws Exception {
-    byte[] length = intToBytes(16);
-    byte[] protocol = intToBytes(80877102);
+    byte[] length = intToBytes(12 + PROTOCOL_30_KEY_LENGTH_BYTES);
+    byte[] protocol = intToBytes(CancelMessage.IDENTIFIER);
     byte[] connectionId = intToBytes(1);
-    byte[] secret = new byte[4];
+    byte[] secret = new byte[PROTOCOL_30_KEY_LENGTH_BYTES];
     new SecureRandom().nextBytes(secret);
 
     byte[] value = Bytes.concat(length, protocol, connectionId, secret);
@@ -1884,10 +1887,10 @@ public class ProtocolTest {
 
   @Test
   public void testCancelMessageProtocolVersion32() throws Exception {
-    byte[] length = intToBytes(12 + 32);
-    byte[] protocol = intToBytes(80877102);
+    byte[] length = intToBytes(12 + DEFAULT_KEY_LENGTH_BYTES);
+    byte[] protocol = intToBytes(CancelMessage.IDENTIFIER);
     byte[] connectionId = intToBytes(1);
-    byte[] secret = new byte[32];
+    byte[] secret = new byte[DEFAULT_KEY_LENGTH_BYTES];
     new SecureRandom().nextBytes(secret);
 
     byte[] value = Bytes.concat(length, protocol, connectionId, secret);

--- a/src/test/java/com/google/cloud/spanner/pgadapter/wireprotocol/ProtocolTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/wireprotocol/ProtocolTest.java
@@ -1618,6 +1618,10 @@ public class ProtocolTest {
     when(connectionHandler.getExtendedQueryProtocolHandler())
         .thenReturn(extendedQueryProtocolHandler);
     when(connectionHandler.getWellKnownClient()).thenReturn(WellKnownClient.UNSPECIFIED);
+    when(connectionHandler.getProtocolVersion()).thenReturn(StartupMessage.PROTOCOL_VERSION_3_0);
+    byte[] secretBytes = new byte[4];
+    new SecureRandom().nextBytes(secretBytes);
+    when(connectionHandler.getSecret()).thenReturn(secretBytes);
     when(extendedQueryProtocolHandler.getBackendConnection()).thenReturn(backendConnection);
     SessionState sessionState = mock(SessionState.class);
     PGSetting serverVersionSetting = mock(PGSetting.class);
@@ -1649,7 +1653,9 @@ public class ProtocolTest {
     assertEquals('K', outputResult.readByte());
     assertEquals(12, outputResult.readInt());
     assertEquals(1, outputResult.readInt());
-    assertEquals(0, outputResult.readInt());
+    byte[] keyBytes = new byte[4];
+    outputResult.readFully(keyBytes);
+    assertArrayEquals(secretBytes, keyBytes);
 
     // ParameterStatusResponse (x11)
     assertEquals('S', outputResult.readByte());
@@ -1749,7 +1755,7 @@ public class ProtocolTest {
     when(connectionHandler.getProtocolVersion()).thenReturn(StartupMessage.PROTOCOL_VERSION_3_2);
     byte[] secretBytes = new byte[DEFAULT_KEY_LENGTH_BYTES];
     new SecureRandom().nextBytes(secretBytes);
-    when(connectionHandler.getSecretBytes()).thenReturn(secretBytes);
+    when(connectionHandler.getSecret()).thenReturn(secretBytes);
     when(extendedQueryProtocolHandler.getBackendConnection()).thenReturn(backendConnection);
     SessionState sessionState = mock(SessionState.class);
     PGSetting serverVersionSetting = mock(PGSetting.class);
@@ -1849,7 +1855,8 @@ public class ProtocolTest {
     byte[] length = intToBytes(16);
     byte[] protocol = intToBytes(80877102);
     byte[] connectionId = intToBytes(1);
-    byte[] secret = intToBytes(1);
+    byte[] secret = new byte[4];
+    new SecureRandom().nextBytes(secret);
 
     byte[] value = Bytes.concat(length, protocol, connectionId, secret);
 
@@ -1867,11 +1874,11 @@ public class ProtocolTest {
     assertEquals(CancelMessage.class, message.getClass());
 
     assertEquals(1, ((CancelMessage) message).getConnectionId());
-    assertEquals(1, ((CancelMessage) message).getSecret());
+    assertArrayEquals(secret, ((CancelMessage) message).getSecretBytes());
 
     message.send();
 
-    verify(connectionHandler).cancelActiveStatement(1, 1);
+    verify(connectionHandler).cancelActiveStatement(1, secret);
     verify(connectionHandler).handleTerminate();
   }
 

--- a/src/test/java/com/google/cloud/spanner/pgadapter/wireprotocol/ProtocolTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/wireprotocol/ProtocolTest.java
@@ -15,7 +15,7 @@
 package com.google.cloud.spanner.pgadapter.wireprotocol;
 
 import static com.google.cloud.spanner.pgadapter.ConnectionHandler.DEFAULT_KEY_LENGTH_BYTES;
-import static com.google.cloud.spanner.pgadapter.ConnectionHandler.PROTOCOL_30_KEY_LENGTH_BYTES;
+import static com.google.cloud.spanner.pgadapter.ConnectionHandler.PROTOCOL_3_0_KEY_LENGTH_BYTES;
 import static com.google.cloud.spanner.pgadapter.statements.IntermediatePortalStatement.NO_FORMAT_CODES;
 import static com.google.cloud.spanner.pgadapter.wireprotocol.MessageReader.MAX_INVALID_MESSAGE_COUNT;
 import static com.google.cloud.spanner.pgadapter.wireprotocol.StartupMessage.PROTOCOL_VERSION_3_0_IDENTIFIER;
@@ -1622,7 +1622,7 @@ public class ProtocolTest {
         .thenReturn(extendedQueryProtocolHandler);
     when(connectionHandler.getWellKnownClient()).thenReturn(WellKnownClient.UNSPECIFIED);
     when(connectionHandler.getProtocolVersion()).thenReturn(PROTOCOL_VERSION_3_0_IDENTIFIER);
-    byte[] secretBytes = new byte[PROTOCOL_30_KEY_LENGTH_BYTES];
+    byte[] secretBytes = new byte[PROTOCOL_3_0_KEY_LENGTH_BYTES];
     new SecureRandom().nextBytes(secretBytes);
     when(connectionHandler.getSecret()).thenReturn(secretBytes);
     when(extendedQueryProtocolHandler.getBackendConnection()).thenReturn(backendConnection);
@@ -1654,9 +1654,9 @@ public class ProtocolTest {
 
     // KeyDataResponse
     assertEquals('K', outputResult.readByte());
-    assertEquals(8 + PROTOCOL_30_KEY_LENGTH_BYTES, outputResult.readInt());
+    assertEquals(8 + PROTOCOL_3_0_KEY_LENGTH_BYTES, outputResult.readInt());
     assertEquals(1, outputResult.readInt());
-    byte[] keyBytes = new byte[PROTOCOL_30_KEY_LENGTH_BYTES];
+    byte[] keyBytes = new byte[PROTOCOL_3_0_KEY_LENGTH_BYTES];
     outputResult.readFully(keyBytes);
     assertArrayEquals(secretBytes, keyBytes);
 
@@ -1855,10 +1855,10 @@ public class ProtocolTest {
 
   @Test
   public void testCancelMessageProtocolVersion30() throws Exception {
-    byte[] length = intToBytes(12 + PROTOCOL_30_KEY_LENGTH_BYTES);
+    byte[] length = intToBytes(12 + PROTOCOL_3_0_KEY_LENGTH_BYTES);
     byte[] protocol = intToBytes(CancelMessage.IDENTIFIER);
     byte[] connectionId = intToBytes(1);
-    byte[] secret = new byte[PROTOCOL_30_KEY_LENGTH_BYTES];
+    byte[] secret = new byte[PROTOCOL_3_0_KEY_LENGTH_BYTES];
     new SecureRandom().nextBytes(secret);
 
     byte[] value = Bytes.concat(length, protocol, connectionId, secret);


### PR DESCRIPTION
wire protocol 3.2 added support for wider cancellation keys.
Previously cancel keys were 4 bytes now they can have a maximum of 256 bytes but currently the PGadapter sends 32 byte wide cancel keys