### PR TITLE
docs: fix PostgreSQL JDBC driver version reference in README

### DIFF
--- a/samples/java/jdbc/README.md
+++ b/samples/java/jdbc/README.md
@@ -14,7 +14,7 @@ The sample application adds the following dependencies:
 <dependency>
   <groupId>org.postgresql</groupId>
   <artifactId>postgresql</artifactId>
-  <version>0.52.0</version>
+  <version>42.7.8</version>
 </dependency>
 <dependency>
   <groupId>com.google.cloud</groupId>


### PR DESCRIPTION
The version number for the PostgreSQL JDBC driver in the README file for the sample had been auto-updated by release-please to the PGAdapter version. This sets it back to the actual PostgreSQL JDBC version.