### PR TITLE
test: wait for internal port also to be available

### DIFF
--- a/samples/dotnet/npgsql-sample/Program.cs
+++ b/samples/dotnet/npgsql-sample/Program.cs
@@ -52,6 +52,7 @@ internal static class Sample
             .WithPortBinding(5432, true)
             // Wait until the PostgreSQL port is available.
             .WithWaitStrategy(Wait.ForUnixContainer().UntilExternalTcpPortIsAvailable(5432))
+            .WithWaitStrategy(Wait.ForUnixContainer().UntilInternalTcpPortIsAvailable(5432))
             // Build the container configuration.
             .Build();
         await container.StartAsync();

--- a/samples/snippets/dotnet-snippets/sample-tests/SampleTests.cs
+++ b/samples/snippets/dotnet-snippets/sample-tests/SampleTests.cs
@@ -234,6 +234,7 @@ public class SampleTests
             .WithPortBinding(5432, true)
             // Wait until the PostgreSQL port is available.
             .WithWaitStrategy(Wait.ForUnixContainer().UntilExternalTcpPortIsAvailable(5432))
+            .WithWaitStrategy(Wait.ForUnixContainer().UntilInternalTcpPortIsAvailable(5432))
             // Build the container configuration.
             .Build();
         await container.StartAsync();


### PR DESCRIPTION
The sample should wait for both the internal port as well as the external port mapping to be available before trying to connect.