### PR TITLE
test: wait after starting PGAdapter before running sample

### DIFF
--- a/samples/golang/gorm/sample.go
+++ b/samples/golang/gorm/sample.go
@@ -198,6 +198,7 @@ func runSample(project, instance, database string, emulator, isOpenSourcePG bool
 			fmt.Printf("Could not start PGAdapter: %v\n", err)
 			return err
 		}
+    time.Sleep(time.Second)
 		defer pgadapter.Stop(context.Background())
 		port, err := pgadapter.GetHostPort()
 		if err != nil {

--- a/samples/golang/migrate/sample.go
+++ b/samples/golang/migrate/sample.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"time"
 
 	pgadapter "github.com/GoogleCloudPlatform/pgadapter/wrappers/golang"
 	"github.com/golang-migrate/migrate/v4"
@@ -46,6 +47,7 @@ func runSample() (string, error) {
 		fmt.Printf("failed to start PGAdapter: %v\n", err)
 		return "", err
 	}
+	time.Sleep(time.Second)
 	// Stop PGAdapter when this function returns.
 	// This is not required, as the PGAdapter sub-process shuts down automatically when your
 	// application shuts down. The PGAdapter sub-process is not guaranteed to shut down if


### PR DESCRIPTION
Wait a bit before running the sample to ensure that the connection to PGAdapter succeeds.