### PR TITLE
chore: update experimental host config

### DIFF
--- a/src/main/java/com/google/cloud/spanner/pgadapter/metadata/OptionsMetadata.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/metadata/OptionsMetadata.java
@@ -43,7 +43,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import java.util.regex.Pattern;
 import javax.annotation.Nullable;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;
@@ -65,12 +64,11 @@ public class OptionsMetadata {
   private static final String SPANNER_EMULATOR_HOST_ENV_VAR = "SPANNER_EMULATOR_HOST";
 
   static Duration DEFAULT_STARTUP_TIMEOUT = Duration.ofSeconds(30L);
-  private static final String CLOUD_SPANNER_HOST_FORMAT = ".*\\.googleapis\\.com.*";
-  private static final Pattern CLOUD_SPANNER_HOST_PATTERN =
-      Pattern.compile(CLOUD_SPANNER_HOST_FORMAT);
 
   private static final String EXTERNAL_HOST_PROJECT = "default";
   private static final String EXTERNAL_HOST_INSTANCE = "default";
+
+  private static final String IS_EXPERIMENTAL_HOST_PROPERTY_NAME = "isExperimentalHost";
 
   /**
    * Builder class for creating an instance of {@link OptionsMetadata}.
@@ -118,6 +116,7 @@ public class OptionsMetadata {
     private Duration startupTimeout = DEFAULT_STARTUP_TIMEOUT;
     private String clientCertificate;
     private String clientKey;
+    private boolean isExperimentalHost = false;
 
     Builder() {}
 
@@ -425,7 +424,7 @@ public class OptionsMetadata {
 
     /**
      * Configures mTLS authentication using the provided client certificate and key files. mTLS is
-     * only supported for external spanner hosts.
+     * only supported for experimental spanner hosts.
      *
      * @param clientCertificate Path to the client certificate file.
      * @param clientKey Path to the client private key file.
@@ -434,6 +433,18 @@ public class OptionsMetadata {
     Builder useClientCert(String clientCertificate, String clientKey) {
       this.clientCertificate = clientCertificate;
       this.clientKey = clientKey;
+      return this;
+    }
+
+    /*
+     * Configures connection to an experimental host endpoint
+     *
+     * @params experimentalHost url of the experimental host endpoint
+     */
+    @ExperimentalApi("https://github.com/googleapis/java-spanner/pull/3574")
+    Builder setExperimentalHost(String experimentalHost) {
+      setEndpoint(experimentalHost);
+      this.isExperimentalHost = true;
       return this;
     }
 
@@ -504,7 +515,8 @@ public class OptionsMetadata {
           || autoConfigEmulator
           || useVirtualGrpcTransportThreads
           || enableEndToEndTracing
-          || (clientKey != null && clientCertificate != null)) {
+          || (clientKey != null && clientCertificate != null)
+          || isExperimentalHost) {
         StringBuilder jdbcOptionBuilder = new StringBuilder();
         if (usePlainText) {
           jdbcOptionBuilder.append("usePlainText=true;");
@@ -529,6 +541,9 @@ public class OptionsMetadata {
         if (clientKey != null && clientCertificate != null) {
           jdbcOptionBuilder.append("clientCertificate=").append(clientCertificate).append(";");
           jdbcOptionBuilder.append("clientKey=").append(clientKey).append(";");
+        }
+        if (isExperimentalHost) {
+          jdbcOptionBuilder.append("isExperimentalHost=true;");
         }
         addOption(args, OPTION_JDBC_PROPERTIES, jdbcOptionBuilder.toString());
       }
@@ -733,8 +748,7 @@ public class OptionsMetadata {
     if (!propertyMap.containsKey("defaultSequenceKind")) {
       propertyMap.put("defaultSequenceKind", "bit_reversed_positive");
     }
-    boolean usesExternalHost =
-        isExternalHost(Preconditions.checkNotNull(environment), commandLine, propertyMap);
+    boolean usesExperimentalHost = isExperimentalHost(commandLine, propertyMap);
 
     this.environment = environment;
     this.osName = osName;
@@ -752,7 +766,7 @@ public class OptionsMetadata {
               + "OR use -c to set the credentials in PGAdapter and use these credentials for all connections.");
     }
     if (this.commandLine.hasOption(OPTION_DATABASE_NAME)
-        && !usesExternalHost
+        && !usesExperimentalHost
         && !(this.commandLine.hasOption(OPTION_PROJECT_ID)
             && this.commandLine.hasOption(OPTION_INSTANCE_ID))) {
       throw SpannerExceptionFactory.newSpannerException(
@@ -761,7 +775,7 @@ public class OptionsMetadata {
               + "Use the options -p <project-id> -i <instance-id> -d <database-id> to specify the "
               + "database that all connections to this instance of PGAdapter should use.");
     }
-    if ((usesExternalHost
+    if ((usesExperimentalHost
             || (this.commandLine.hasOption(OPTION_PROJECT_ID)
                 && this.commandLine.hasOption(OPTION_INSTANCE_ID)))
         && this.commandLine.hasOption(OPTION_DATABASE_NAME)) {
@@ -1023,7 +1037,7 @@ public class OptionsMetadata {
    */
   public String buildCredentialsFile() {
     // Skip if a com.google.auth.Credentials instance has been set.
-    if (isExternalHost() || credentials != null) {
+    if (isExperimentalHost() || credentials != null) {
       return null;
     }
     if (!commandLine.hasOption(OPTION_CREDENTIALS_FILE)) {
@@ -1113,17 +1127,23 @@ public class OptionsMetadata {
         || isAutoConfigEmulator(propertyMap);
   }
 
-  private boolean isExternalHost() {
-    return isExternalHost(this.environment, this.commandLine, this.propertyMap);
+  private boolean isExperimentalHost() {
+    if (this.propertyMap == null) {
+      return isExperimentalHost(
+          this.commandLine,
+          parseProperties(this.commandLine.getOptionValue(OPTION_JDBC_PROPERTIES, "")));
+    }
+    return isExperimentalHost(this.commandLine, this.propertyMap);
   }
 
-  private static boolean isExternalHost(
-      Map<String, String> environment, CommandLine commandLine, Map<String, String> propertyMap) {
-    return !usesEmulator(environment, propertyMap)
-        && commandLine.hasOption(OPTION_SPANNER_ENDPOINT)
-        && !CLOUD_SPANNER_HOST_PATTERN
-            .matcher(commandLine.getOptionValue(OPTION_SPANNER_ENDPOINT))
-            .matches();
+  private static boolean isExperimentalHost(
+      CommandLine commandLine, Map<String, String> propertyMap) {
+    if (propertyMap == null) {
+      return false;
+    }
+    return commandLine.hasOption(OPTION_SPANNER_ENDPOINT)
+        && commandLine.hasOption(OPTION_JDBC_PROPERTIES)
+        && propertyMap.containsKey(IS_EXPERIMENTAL_HOST_PROPERTY_NAME);
   }
 
   /** Returns the fully qualified database name based on the given database id or name. */
@@ -1135,7 +1155,7 @@ public class OptionsMetadata {
       String projectId;
       if (commandLine.hasOption(OPTION_PROJECT_ID)) {
         projectId = commandLine.getOptionValue(OPTION_PROJECT_ID);
-      } else if (isExternalHost()) {
+      } else if (isExperimentalHost()) {
         projectId = EXTERNAL_HOST_PROJECT;
       } else {
         projectId = getDefaultProjectId();
@@ -1150,7 +1170,7 @@ public class OptionsMetadata {
       String instanceId;
       if (commandLine.hasOption(OPTION_INSTANCE_ID)) {
         instanceId = commandLine.getOptionValue(OPTION_INSTANCE_ID);
-      } else if (isExternalHost()) {
+      } else if (isExperimentalHost()) {
         instanceId = EXTERNAL_HOST_INSTANCE;
       } else {
         throw SpannerExceptionFactory.newSpannerException(
@@ -1576,10 +1596,10 @@ public class OptionsMetadata {
   public DatabaseId getDefaultDatabaseId() {
     return this.hasDefaultConnectionUrl()
         ? DatabaseId.of(
-            !commandLine.hasOption(OPTION_PROJECT_ID) && isExternalHost()
+            !commandLine.hasOption(OPTION_PROJECT_ID) && isExperimentalHost()
                 ? EXTERNAL_HOST_PROJECT
                 : commandLine.getOptionValue(OPTION_PROJECT_ID),
-            !commandLine.hasOption(OPTION_INSTANCE_ID) && isExternalHost()
+            !commandLine.hasOption(OPTION_INSTANCE_ID) && isExperimentalHost()
                 ? EXTERNAL_HOST_INSTANCE
                 : commandLine.getOptionValue(OPTION_INSTANCE_ID),
             commandLine.getOptionValue(OPTION_DATABASE_NAME))
@@ -1588,7 +1608,7 @@ public class OptionsMetadata {
 
   /** Returns true if these options contain a default instance id. */
   public boolean hasDefaultInstanceId() {
-    return isExternalHost()
+    return isExperimentalHost()
         || (commandLine.hasOption(OPTION_PROJECT_ID) && commandLine.hasOption(OPTION_INSTANCE_ID));
   }
 
@@ -1596,10 +1616,10 @@ public class OptionsMetadata {
   public InstanceId getDefaultInstanceId() {
     if (hasDefaultInstanceId()) {
       return InstanceId.of(
-          !commandLine.hasOption(OPTION_PROJECT_ID) && isExternalHost()
+          !commandLine.hasOption(OPTION_PROJECT_ID) && isExperimentalHost()
               ? EXTERNAL_HOST_PROJECT
               : commandLine.getOptionValue(OPTION_PROJECT_ID),
-          !commandLine.hasOption(OPTION_INSTANCE_ID) && isExternalHost()
+          !commandLine.hasOption(OPTION_INSTANCE_ID) && isExperimentalHost()
               ? EXTERNAL_HOST_INSTANCE
               : commandLine.getOptionValue(OPTION_INSTANCE_ID));
     }

--- a/src/test/java/com/google/cloud/spanner/pgadapter/ITAuthTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/ITAuthTest.java
@@ -55,6 +55,7 @@ public class ITAuthTest implements IntegrationTest {
 
   @BeforeClass
   public static void setup() throws ClassNotFoundException {
+    IntegrationTest.skipOnExperimentalHost("Cloud auth is not applicable for experimental host");
     // Make sure the PG JDBC driver is loaded.
     Class.forName("org.postgresql.Driver");
 

--- a/src/test/java/com/google/cloud/spanner/pgadapter/ITOpenTelemetryTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/ITOpenTelemetryTest.java
@@ -19,7 +19,6 @@ import static com.google.cloud.spanner.pgadapter.statements.BackendConnection.DB
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assume.assumeFalse;
 
 import com.google.api.gax.rpc.PermissionDeniedException;
 import com.google.api.gax.rpc.ResourceExhaustedException;

--- a/src/test/java/com/google/cloud/spanner/pgadapter/ITOpenTelemetryTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/ITOpenTelemetryTest.java
@@ -19,6 +19,7 @@ import static com.google.cloud.spanner.pgadapter.statements.BackendConnection.DB
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeFalse;
 
 import com.google.api.gax.rpc.PermissionDeniedException;
 import com.google.api.gax.rpc.ResourceExhaustedException;
@@ -56,6 +57,7 @@ public class ITOpenTelemetryTest implements IntegrationTest {
   @BeforeClass
   public static void setup() throws IOException {
     IntegrationTest.skipOnEmulator("This test requires credentials");
+    IntegrationTest.skipOnExperimentalHost("Cloud auth is not applicable for experimental host");
 
     OptionsMetadata.Builder openTelemetryOptionsBuilder =
         OptionsMetadata.newBuilder()

--- a/src/test/java/com/google/cloud/spanner/pgadapter/IntegrationTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/IntegrationTest.java
@@ -22,7 +22,15 @@ public interface IntegrationTest {
     assumeFalse(reason, isRunningOnEmulator());
   }
 
+  static void skipOnExperimentalHost(String reason) {
+    assumeFalse(reason, isRunningOnExperimentalHost());
+  }
+
   static boolean isRunningOnEmulator() {
     return System.getenv("SPANNER_EMULATOR_HOST") != null;
+  }
+
+  static boolean isRunningOnExperimentalHost() {
+    return System.getProperty("SPANNER_EXPERIMENTAL_HOST") != null;
   }
 }

--- a/src/test/java/com/google/cloud/spanner/pgadapter/PgAdapterTestEnv.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/PgAdapterTestEnv.java
@@ -43,6 +43,7 @@ import com.google.common.collect.Iterables;
 import com.google.common.primitives.Bytes;
 import com.google.spanner.admin.database.v1.CreateDatabaseMetadata;
 import com.google.spanner.admin.database.v1.UpdateDatabaseDdlMetadata;
+import io.grpc.ManagedChannelBuilder;
 import io.opentelemetry.api.OpenTelemetry;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
@@ -112,6 +113,9 @@ public class PgAdapterTestEnv {
 
   // Default Spanner url. Null indicates that the default URL should be used.
   static final String DEFAULT_SPANNER_URL = null;
+
+  public static final String SPANNER_EXPERIMENTAL_HOST =
+      System.getProperty("SPANNER_EXPERIMENTAL_HOST", null);
 
   public static final ImmutableList<String> DEFAULT_DATA_MODEL =
       ImmutableList.of(
@@ -235,7 +239,7 @@ public class PgAdapterTestEnv {
 
   private void startPGAdapterServer(
       String databaseId, Iterable<String> additionalPGAdapterOptions, OpenTelemetry openTelemetry) {
-    if (PG_ADAPTER_ADDRESS == null) {
+    if (PG_ADAPTER_ADDRESS == null && SPANNER_EXPERIMENTAL_HOST == null) {
       additionalPGAdapterOptions = maybeAddAutoConfigEmulator(additionalPGAdapterOptions);
       String credentials = getCredentials();
       ImmutableList.Builder<String> argsListBuilder =
@@ -257,6 +261,21 @@ public class PgAdapterTestEnv {
       argsListBuilder.addAll(additionalPGAdapterOptions);
       String[] args = argsListBuilder.build().toArray(new String[0]);
       server = new ProxyServer(new OptionsMetadata(args), openTelemetry);
+      server.startServer();
+    } else if (SPANNER_EXPERIMENTAL_HOST != null) {
+      ImmutableList.Builder<String> argsListBuilder =
+          ImmutableList.<String>builder()
+              .add(
+                  "-e",
+                  SPANNER_EXPERIMENTAL_HOST,
+                  "-r",
+                  "isExperimentalHost=true;usePlainText=true");
+      if (databaseId != null) {
+        argsListBuilder.add("-d", databaseId);
+      }
+      argsListBuilder.add("-s", String.valueOf(0));
+      String[] args = argsListBuilder.build().toArray(new String[0]);
+      server = new ProxyServer(new OptionsMetadata(args));
       server.startServer();
     }
   }
@@ -350,6 +369,9 @@ public class PgAdapterTestEnv {
     if (hostUrl == null) {
       hostUrl = System.getProperty(TEST_SPANNER_URL_PROPERTY, DEFAULT_SPANNER_URL);
     }
+    if (SPANNER_EXPERIMENTAL_HOST != null) {
+      hostUrl = SPANNER_EXPERIMENTAL_HOST;
+    }
     return hostUrl;
   }
 
@@ -361,12 +383,18 @@ public class PgAdapterTestEnv {
     if (projectId == null) {
       projectId = System.getProperty(TEST_PROJECT_PROPERTY, DEFAULT_PROJECT_ID);
     }
+    if (SPANNER_EXPERIMENTAL_HOST != null) {
+      projectId = "default";
+    }
     return projectId;
   }
 
   public String getInstanceId() {
     if (instanceId == null) {
       instanceId = System.getProperty(TEST_INSTANCE_PROPERTY, DEFAULT_INSTANCE_ID);
+    }
+    if (SPANNER_EXPERIMENTAL_HOST != null) {
+      instanceId = "default";
     }
     return instanceId;
   }
@@ -517,7 +545,7 @@ public class PgAdapterTestEnv {
     Map<String, String> env = System.getenv();
     gcpCredentials = env.get(GCP_CREDENTIALS);
     GoogleCredentials credentials = null;
-    if (!Strings.isNullOrEmpty(gcpCredentials)) {
+    if (!Strings.isNullOrEmpty(gcpCredentials) && SPANNER_EXPERIMENTAL_HOST == null) {
       try {
         credentials = GoogleCredentials.fromStream(new FileInputStream(gcpCredentials));
       } catch (IOException e) {
@@ -550,6 +578,18 @@ public class PgAdapterTestEnv {
       }
     } else if (spannerHost != null) {
       builder.setHost(spannerHost);
+    }
+
+    if (SPANNER_EXPERIMENTAL_HOST != null) {
+      if (!SPANNER_EXPERIMENTAL_HOST.startsWith("http")) {
+        builder.setExperimentalHost("http://" + SPANNER_EXPERIMENTAL_HOST);
+      } else {
+        builder.setExperimentalHost(SPANNER_EXPERIMENTAL_HOST);
+      }
+      builder
+          .setChannelConfigurator(ManagedChannelBuilder::usePlaintext)
+          .setCredentials(NoCredentials.getInstance());
+      credentials = null;
     }
 
     if (System.getProperty(CHANNEL_PROVIDER_PROPERTY) == null && credentials != null) {

--- a/src/test/java/com/google/cloud/spanner/pgadapter/metadata/OptionsMetadataTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/metadata/OptionsMetadataTest.java
@@ -642,7 +642,10 @@ public class OptionsMetadataTest {
   public void testExternalHostConfigurations() {
     assertEquals(
         DatabaseId.of("default", "default", "test_db"),
-        (new OptionsMetadata(new String[] {"-d", "test_db", "-e", "localhost:8000"}))
+        (new OptionsMetadata(
+                new String[] {
+                  "-d", "test_db", "-e", "localhost:8000", "-r", "isExperimentalHost=true"
+                }))
             .getDefaultDatabaseId());
     SpannerException spannerException =
         assertThrows(
@@ -656,7 +659,7 @@ public class OptionsMetadataTest {
     assertEquals(
         DatabaseId.of("default", "default", "test_db"),
         OptionsMetadata.newBuilder()
-            .setEndpoint("localhost:8000")
+            .setExperimentalHost("localhost:8000")
             .setDatabase("test_db")
             .build()
             .getDefaultDatabaseId());
@@ -679,5 +682,13 @@ public class OptionsMetadataTest {
                     .setDatabase("test_db")
                     .build());
     assertEquals(ErrorCode.INVALID_ARGUMENT, spannerException.getErrorCode());
+    assertEquals(
+        DatabaseId.of("default", "default", "test_db"),
+        OptionsMetadata.newBuilder()
+            .setEnvironment(ImmutableMap.of("SPANNER_EMULATOR_HOST", "localhost:9010"))
+            .setExperimentalHost("localhost:8000")
+            .setDatabase("test_db")
+            .build()
+            .getDefaultDatabaseId());
   }
 }


### PR DESCRIPTION
Previously the change was made in https://github.com/GoogleCloudPlatform/pgadapter/pull/2856 to distinguish between experimental host endpoint and cloud spanner endpoint using url pattern matching. Now we have a isExperimentalHost parameter which is much more deterministic in determining whether its a experimental host endpoint.

The PR also contains changes to make the Integration tests compatible with experimental host