### PR TITLE
build: temporarily skip gorm sample test

### DIFF
--- a/.ci/e2e-expected/backslash-dt.txt
+++ b/.ci/e2e-expected/backslash-dt.txt
@@ -90,5 +90,6 @@
  testdb_e2e_psql_v?? | spanner_sys        | txn_stats_total_hour             | VIEW       |                              |                      |                           |                          |                        |                    |          |               |                   |                  |               |                 |
  testdb_e2e_psql_v?? | spanner_sys        | txn_stats_total_minute           | VIEW       |                              |                      |                           |                          |                        |                    |          |               |                   |                  |               |                 |
  testdb_e2e_psql_v?? | spanner_sys        | user_split_points                | VIEW       |                              |                      |                           |                          |                        |                    |          |               |                   |                  |               |                 |
-(89 rows)
+ testdb_e2e_psql_v?? | spanner_sys        | vector_index_metrics_history     | VIEW       |                              |                      |                           |                          |                        |                    |          |               |                   |                  |               |                 |
+(90 rows)
 

--- a/.github/workflows/samples.yaml
+++ b/.github/workflows/samples.yaml
@@ -35,9 +35,10 @@ jobs:
         with:
           go-version: '1.25.5'
       - run: go version
-      - name: Run gorm Sample tests
-        working-directory: ./samples/golang/gorm
-        run: go test
+      # Temporarily skipped due to a bug in the Emulator
+#      - name: Run gorm Sample tests
+#        working-directory: ./samples/golang/gorm
+#        run: go test
       - name: Run pgx Sample tests
         working-directory: ./samples/golang/pgx
         run: go test


### PR DESCRIPTION
The version of the Emulator that is included in version 0.53.0 of pgadapter-emulator has a bug that causes an internal error to be returned when running the gorm sample. This bug has been fixed in the Emulator, so this should be fixed in the next pgadapter-emulator release. Until then, we should disable this test to stop the builds from failing.