### PR TITLE
build: assign current maintainers when creating issue

### DIFF
--- a/.github/integration-test-failed-template.md
+++ b/.github/integration-test-failed-template.md
@@ -1,6 +1,6 @@
 ---
 title: PGAdapter integration tests failed
-assignees: pratickchokhani, gauravsnj, olavloite
+assignees: olavloite, rayudu3745
 labels: integration-test-failure
 ---
 PGAdapter integration tests failed for endpoint {{ env.ENDPOINT }}

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -16,6 +16,9 @@ on:
           - staging-wrenchworks.sandbox.googleapis.com
           - preprod-spanner.sandbox.googleapis.com
 name: integration
+permissions:
+  contents: read
+  issues: write
 env:
   GOOGLE_CLOUD_PROJECT: "span-cloud-testing"
   GOOGLE_CLOUD_INSTANCE: "pgadapter-testing"
@@ -158,4 +161,4 @@ jobs:
           ENDPOINT: ${{ env.GOOGLE_CLOUD_ENDPOINT }}
         with:
           filename: .github/integration-test-failed-template.md
-          assignees: pratickchokhani, olavloite
+          assignees: olavloite, rayudu3745


### PR DESCRIPTION
The integration job tried to assign issues to users who are no longer maintainers of this repository when the job failed.

Also gives the job enough permissions to actually create an issue.