### PR TITLE
perf: write numbers directly to the stream

### DIFF
--- a/src/main/java/com/google/cloud/spanner/pgadapter/parsers/DoubleParser.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/parsers/DoubleParser.java
@@ -23,6 +23,8 @@ import com.google.cloud.spanner.pgadapter.ProxyServer.DataFormat;
 import com.google.cloud.spanner.pgadapter.error.PGExceptionFactory;
 import com.google.cloud.spanner.pgadapter.error.SQLState;
 import com.google.common.collect.ImmutableMap;
+import java.io.DataOutputStream;
+import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import javax.annotation.Nonnull;
 import org.postgresql.util.ByteConverter;
@@ -88,13 +90,17 @@ public class DoubleParser extends Parser<Double> {
     return result;
   }
 
-  public static byte[] convertToPG(ResultSet resultSet, int position, DataFormat format) {
+  public static byte[] convertToPG(
+      DataOutputStream outputStream, ResultSet resultSet, int position, DataFormat format)
+      throws IOException {
     switch (format) {
       case SPANNER:
       case POSTGRESQL_TEXT:
         return Double.toString(resultSet.getDouble(position)).getBytes(StandardCharsets.UTF_8);
       case POSTGRESQL_BINARY:
-        return convertToPG(resultSet.getDouble(position));
+        outputStream.writeInt(8);
+        outputStream.writeDouble(resultSet.getDouble(position));
+        return null;
       default:
         throw new IllegalArgumentException("unknown data format: " + format);
     }

--- a/src/main/java/com/google/cloud/spanner/pgadapter/parsers/FloatParser.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/parsers/FloatParser.java
@@ -22,6 +22,8 @@ import com.google.cloud.spanner.pgadapter.ProxyServer.DataFormat;
 import com.google.cloud.spanner.pgadapter.error.PGExceptionFactory;
 import com.google.cloud.spanner.pgadapter.error.SQLState;
 import com.google.common.collect.ImmutableMap;
+import java.io.DataOutputStream;
+import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import javax.annotation.Nonnull;
 import org.postgresql.util.ByteConverter;
@@ -85,13 +87,17 @@ public class FloatParser extends Parser<Float> {
     return result;
   }
 
-  public static byte[] convertToPG(ResultSet resultSet, int position, DataFormat format) {
+  public static byte[] convertToPG(
+      DataOutputStream outputStream, ResultSet resultSet, int position, DataFormat format)
+      throws IOException {
     switch (format) {
       case SPANNER:
       case POSTGRESQL_TEXT:
         return Float.toString(resultSet.getFloat(position)).getBytes(StandardCharsets.UTF_8);
       case POSTGRESQL_BINARY:
-        return convertToPG(resultSet.getFloat(position));
+        outputStream.writeInt(4);
+        outputStream.writeFloat(resultSet.getFloat(position));
+        return null;
       default:
         throw new IllegalArgumentException("unknown data format: " + format);
     }

--- a/src/main/java/com/google/cloud/spanner/pgadapter/parsers/LongParser.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/parsers/LongParser.java
@@ -125,9 +125,8 @@ public class LongParser extends Parser<Long> {
         StringParser.writeToPG(sessionState, outputStream, getLongAsString(resultSet, position));
         break;
       case POSTGRESQL_BINARY:
-        byte[] value = convertToPG(resultSet.getLong(position));
-        outputStream.writeInt(value.length);
-        outputStream.write(value);
+        outputStream.writeInt(8);
+        outputStream.writeLong(resultSet.getLong(position));
         break;
       default:
         throw new IllegalArgumentException("unknown data format: " + format);

--- a/src/main/java/com/google/cloud/spanner/pgadapter/utils/Converter.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/utils/Converter.java
@@ -169,9 +169,9 @@ public class Converter implements AutoCloseable {
       case DATE:
         return DateParser.convertToPG(sessionState, outputStream, result, position, format);
       case FLOAT32:
-        return FloatParser.convertToPG(result, position, format);
+        return FloatParser.convertToPG(outputStream, result, position, format);
       case FLOAT64:
-        return DoubleParser.convertToPG(result, position, format);
+        return DoubleParser.convertToPG(outputStream, result, position, format);
       case INT64:
       case PG_OID:
         return LongParser.convertToPG(sessionState, outputStream, result, position, format);


### PR DESCRIPTION
Write number values (long, int, float, double) directly to the underlying data stream, instead of first converting them to a byte array. This saves a bit of memory allocation for every write, which again reduces GC pressure.