### PR TITLE
perf: use ASCII printer for numbers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ target/
 /target
 .DS_STORE
 .idea/
+.vscode/
 *.iml
 *.class
 *.lst

--- a/src/main/java/com/google/cloud/spanner/pgadapter/parsers/DoubleParser.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/parsers/DoubleParser.java
@@ -22,8 +22,10 @@ import com.google.cloud.spanner.Value;
 import com.google.cloud.spanner.pgadapter.ProxyServer.DataFormat;
 import com.google.cloud.spanner.pgadapter.error.PGExceptionFactory;
 import com.google.cloud.spanner.pgadapter.error.SQLState;
+import com.google.cloud.spanner.pgadapter.utils.AsciiPrinter;
 import com.google.common.collect.ImmutableMap;
-import java.nio.charset.StandardCharsets;
+import java.io.DataOutputStream;
+import java.io.IOException;
 import javax.annotation.Nonnull;
 import org.postgresql.util.ByteConverter;
 
@@ -88,11 +90,14 @@ public class DoubleParser extends Parser<Double> {
     return result;
   }
 
-  public static byte[] convertToPG(ResultSet resultSet, int position, DataFormat format) {
+  public static byte[] convertToPG(
+      DataOutputStream outputStream, ResultSet resultSet, int position, DataFormat format)
+      throws IOException {
     switch (format) {
       case SPANNER:
       case POSTGRESQL_TEXT:
-        return Double.toString(resultSet.getDouble(position)).getBytes(StandardCharsets.UTF_8);
+        AsciiPrinter.writeAsciiToPG(outputStream, Double.toString(resultSet.getDouble(position)));
+        return null;
       case POSTGRESQL_BINARY:
         return convertToPG(resultSet.getDouble(position));
       default:

--- a/src/main/java/com/google/cloud/spanner/pgadapter/parsers/FloatParser.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/parsers/FloatParser.java
@@ -21,8 +21,10 @@ import com.google.cloud.spanner.Value;
 import com.google.cloud.spanner.pgadapter.ProxyServer.DataFormat;
 import com.google.cloud.spanner.pgadapter.error.PGExceptionFactory;
 import com.google.cloud.spanner.pgadapter.error.SQLState;
+import com.google.cloud.spanner.pgadapter.utils.AsciiPrinter;
 import com.google.common.collect.ImmutableMap;
-import java.nio.charset.StandardCharsets;
+import java.io.DataOutputStream;
+import java.io.IOException;
 import javax.annotation.Nonnull;
 import org.postgresql.util.ByteConverter;
 
@@ -85,11 +87,14 @@ public class FloatParser extends Parser<Float> {
     return result;
   }
 
-  public static byte[] convertToPG(ResultSet resultSet, int position, DataFormat format) {
+  public static byte[] convertToPG(
+      DataOutputStream outputStream, ResultSet resultSet, int position, DataFormat format)
+      throws IOException {
     switch (format) {
       case SPANNER:
       case POSTGRESQL_TEXT:
-        return Float.toString(resultSet.getFloat(position)).getBytes(StandardCharsets.UTF_8);
+        AsciiPrinter.writeAsciiToPG(outputStream, Float.toString(resultSet.getFloat(position)));
+        return null;
       case POSTGRESQL_BINARY:
         return convertToPG(resultSet.getFloat(position));
       default:

--- a/src/main/java/com/google/cloud/spanner/pgadapter/parsers/LongParser.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/parsers/LongParser.java
@@ -24,6 +24,7 @@ import com.google.cloud.spanner.pgadapter.ProxyServer.DataFormat;
 import com.google.cloud.spanner.pgadapter.error.PGExceptionFactory;
 import com.google.cloud.spanner.pgadapter.error.SQLState;
 import com.google.cloud.spanner.pgadapter.session.SessionState;
+import com.google.cloud.spanner.pgadapter.utils.AsciiPrinter;
 import com.google.common.collect.ImmutableMap;
 import java.io.DataOutputStream;
 import java.io.IOException;
@@ -122,7 +123,7 @@ public class LongParser extends Parser<Long> {
     switch (format) {
       case SPANNER:
       case POSTGRESQL_TEXT:
-        StringParser.writeToPG(sessionState, outputStream, getLongAsString(resultSet, position));
+        AsciiPrinter.writeAsciiToPG(outputStream, getLongAsString(resultSet, position));
         break;
       case POSTGRESQL_BINARY:
         byte[] value = convertToPG(resultSet.getLong(position));

--- a/src/main/java/com/google/cloud/spanner/pgadapter/parsers/NumericParser.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/parsers/NumericParser.java
@@ -20,9 +20,11 @@ import com.google.cloud.spanner.ResultSet;
 import com.google.cloud.spanner.SpannerExceptionFactory;
 import com.google.cloud.spanner.Value;
 import com.google.cloud.spanner.pgadapter.ProxyServer.DataFormat;
+import com.google.cloud.spanner.pgadapter.utils.AsciiPrinter;
 import com.google.common.collect.ImmutableMap;
+import java.io.DataOutputStream;
+import java.io.IOException;
 import java.math.BigDecimal;
-import java.nio.charset.StandardCharsets;
 import javax.annotation.Nonnull;
 import org.postgresql.util.ByteConverter;
 
@@ -96,11 +98,14 @@ public class NumericParser extends Parser<String> {
     }
   }
 
-  public static byte[] convertToPG(ResultSet resultSet, int position, DataFormat format) {
+  public static byte[] convertToPG(
+      DataOutputStream outputStream, ResultSet resultSet, int position, DataFormat format)
+      throws IOException {
     switch (format) {
       case SPANNER:
       case POSTGRESQL_TEXT:
-        return resultSet.getString(position).getBytes(StandardCharsets.UTF_8);
+        AsciiPrinter.writeAsciiToPG(outputStream, resultSet.getString(position));
+        return null;
       case POSTGRESQL_BINARY:
         return convertToPG(resultSet.getString(position));
       default:

--- a/src/main/java/com/google/cloud/spanner/pgadapter/utils/AsciiPrinter.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/utils/AsciiPrinter.java
@@ -1,0 +1,55 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.cloud.spanner.pgadapter.utils;
+
+import com.google.api.core.InternalApi;
+import java.io.DataOutputStream;
+import java.io.IOException;
+
+/**
+ * Utility class for printing pure ASCII strings directly to a stream without allocating byte[].
+ *
+ * <p><strong>WARNING:</strong> This class should ONLY be used if the caller can guarantee that the
+ * string will only contain ASCII characters (e.g., such as with numbers). It directly casts chars
+ * to bytes, which will corrupt any non-ASCII characters.
+ */
+@InternalApi
+public class AsciiPrinter {
+  private static final ThreadLocal<byte[]> BUFFER = ThreadLocal.withInitial(() -> new byte[64]);
+
+  /**
+   * Writes the given ASCII string to the output stream.
+   *
+   * @param outputStream the stream to write to
+   * @param value the string to write (must be ASCII-only)
+   * @throws IOException if an I/O error occurs
+   */
+  public static void writeAsciiToPG(DataOutputStream outputStream, String value)
+      throws IOException {
+    int length = value.length();
+    outputStream.writeInt(length);
+    if (length > 0) {
+      byte[] buffer = BUFFER.get();
+      if (length > buffer.length) {
+        buffer = new byte[length];
+        BUFFER.set(buffer);
+      }
+      for (int i = 0; i < length; i++) {
+        buffer[i] = (byte) value.charAt(i);
+      }
+      outputStream.write(buffer, 0, length);
+    }
+  }
+}

--- a/src/main/java/com/google/cloud/spanner/pgadapter/utils/Converter.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/utils/Converter.java
@@ -169,14 +169,14 @@ public class Converter implements AutoCloseable {
       case DATE:
         return DateParser.convertToPG(sessionState, outputStream, result, position, format);
       case FLOAT32:
-        return FloatParser.convertToPG(result, position, format);
+        return FloatParser.convertToPG(outputStream, result, position, format);
       case FLOAT64:
-        return DoubleParser.convertToPG(result, position, format);
+        return DoubleParser.convertToPG(outputStream, result, position, format);
       case INT64:
       case PG_OID:
         return LongParser.convertToPG(sessionState, outputStream, result, position, format);
       case PG_NUMERIC:
-        return NumericParser.convertToPG(result, position, format);
+        return NumericParser.convertToPG(outputStream, result, position, format);
       case STRING:
         return StringParser.convertToPG(sessionState, outputStream, result, position);
       case UUID:

--- a/src/test/java/com/google/cloud/spanner/pgadapter/utils/AsciiPrinterTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/utils/AsciiPrinterTest.java
@@ -1,0 +1,86 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.cloud.spanner.pgadapter.utils;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+
+import java.io.ByteArrayOutputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class AsciiPrinterTest {
+
+  @Test
+  public void testWriteEmptyString() throws IOException {
+    ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+    DataOutputStream dataOutputStream = new DataOutputStream(buffer);
+
+    AsciiPrinter.writeAsciiToPG(dataOutputStream, "");
+    dataOutputStream.flush();
+
+    byte[] result = buffer.toByteArray();
+    // Int 0 is 4 bytes of 0s
+    assertArrayEquals(new byte[] {0, 0, 0, 0}, result);
+  }
+
+  @Test
+  public void testWriteNormalString() throws IOException {
+    ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+    DataOutputStream dataOutputStream = new DataOutputStream(buffer);
+
+    String value = "123.45e-10";
+    AsciiPrinter.writeAsciiToPG(dataOutputStream, value);
+    dataOutputStream.flush();
+
+    byte[] result = buffer.toByteArray();
+    ByteBuffer byteBuffer = ByteBuffer.wrap(result);
+
+    assertEquals(value.length(), byteBuffer.getInt());
+    byte[] strBytes = new byte[value.length()];
+    byteBuffer.get(strBytes);
+    assertEquals(value, new String(strBytes, StandardCharsets.US_ASCII));
+  }
+
+  @Test
+  public void testWriteLongStringreallocatesBuffer() throws IOException {
+    ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+    DataOutputStream dataOutputStream = new DataOutputStream(buffer);
+
+    // Create a string longer than the initial 64 byte buffer
+    StringBuilder sb = new StringBuilder();
+    for (int i = 0; i < 100; i++) {
+      sb.append((i % 10)); // "01234567890123..."
+    }
+    String value = sb.toString();
+
+    AsciiPrinter.writeAsciiToPG(dataOutputStream, value);
+    dataOutputStream.flush();
+
+    byte[] result = buffer.toByteArray();
+    ByteBuffer byteBuffer = ByteBuffer.wrap(result);
+
+    assertEquals(value.length(), byteBuffer.getInt());
+    byte[] strBytes = new byte[value.length()];
+    byteBuffer.get(strBytes);
+    assertEquals(value, new String(strBytes, StandardCharsets.US_ASCII));
+  }
+}


### PR DESCRIPTION
Strings that are guaranteed to only contain ASCII characters can be written directly to the output stream without first converting to a byte array of utf8 bytes. This saves a bit of memory allocation for each number that is written.

The ASCII printer also uses a thread-local reusable buffer to further reduce memory allocations.