### PR TITLE
chore: fix a typo in pg-regress-emulator.yml

### DIFF
--- a/.github/workflows/pg-regress-emulator.yml
+++ b/.github/workflows/pg-regress-emulator.yml
@@ -84,7 +84,7 @@ jobs:
           ts=$(date +%s)
           python upload_bigquery.py results.json ${{env.BQ_TABLE}} ${{env.TARGET_ENV}} $ts
           gcloud storage cp results.json ${{env.GCS_BUCKET_PATH}}/results_$ts.json
-          gcloud storage cp results/*.out ${{env.GCS_BUCKET_PATH}}/lastest-run-results/
+          gcloud storage cp results/*.out ${{env.GCS_BUCKET_PATH}}/latest-run-results/
           gcloud storage cp regression.diffs ${{env.GCS_BUCKET_PATH}}/regression_$ts.diffs
       - name: Compare json results
         working-directory: ./postgres/src/test/regress/


### PR DESCRIPTION
A simple change to fix a typo in the config file.