### PR TITLE
fix: support COPY for FLOAT8/FLOAT4 NaN/Infinity

### DIFF
--- a/src/main/java/com/google/cloud/spanner/pgadapter/parsers/DoubleParser.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/parsers/DoubleParser.java
@@ -20,8 +20,10 @@ import com.google.cloud.spanner.ResultSet;
 import com.google.cloud.spanner.SpannerExceptionFactory;
 import com.google.cloud.spanner.Value;
 import com.google.cloud.spanner.pgadapter.ProxyServer.DataFormat;
+import com.google.cloud.spanner.pgadapter.error.PGException;
 import com.google.cloud.spanner.pgadapter.error.PGExceptionFactory;
 import com.google.cloud.spanner.pgadapter.error.SQLState;
+import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMap;
 import java.io.DataOutputStream;
 import java.io.IOException;
@@ -45,13 +47,8 @@ public class DoubleParser extends Parser<Double> {
     if (item != null) {
       switch (formatCode) {
         case TEXT:
-          String stringValue = new String(item);
-          try {
-            this.item = Double.valueOf(stringValue);
-          } catch (Exception exception) {
-            throw PGExceptionFactory.newPGException(
-                "Invalid float8 value: " + stringValue, SQLState.SyntaxError);
-          }
+          String stringValue = new String(item, StandardCharsets.UTF_8);
+          this.item = parseDouble(stringValue);
           break;
         case BINARY:
           this.item = toDouble(item);
@@ -108,6 +105,55 @@ public class DoubleParser extends Parser<Double> {
 
   @Override
   public void bind(ImmutableMap.Builder<String, Value> parametersBuilder, String name) {
-    parametersBuilder.put(name, Value.float64(this.item));
+    parametersBuilder.put(name, toValue(this.item));
+  }
+
+  /**
+   * Converts a string to a double. This method correctly recognizes valid PostgreSQL formats for
+   * the special Inf, -Inf, and NaN.
+   */
+  public static double parseDouble(@Nonnull String s) throws PGException {
+    if (Strings.isNullOrEmpty(s)) {
+      throw PGExceptionFactory.newPGException("Invalid float8 value: " + s, SQLState.SyntaxError);
+    }
+    // Quick check for Inf, -Inf, and NaN.
+    s = s.trim();
+    if (s.isEmpty()) {
+      throw PGExceptionFactory.newPGException("Invalid float8 value: " + s, SQLState.SyntaxError);
+    }
+    if (s.equalsIgnoreCase("inf")
+        || s.equalsIgnoreCase("infinity")
+        || s.equalsIgnoreCase("+inf")
+        || s.equalsIgnoreCase("+infinity")) {
+      return Double.POSITIVE_INFINITY;
+    }
+    if (s.equalsIgnoreCase("-inf") || s.equalsIgnoreCase("-infinity")) {
+      return Double.NEGATIVE_INFINITY;
+    }
+    if (s.equalsIgnoreCase("NaN")) {
+      return Double.NaN;
+    }
+    try {
+      return Double.parseDouble(s);
+    } catch (NumberFormatException exception) {
+      throw PGExceptionFactory.newPGException("Invalid float8 value: " + s, SQLState.SyntaxError);
+    }
+  }
+
+  /**
+   * Converts a double to a Spanner {@link Value}. This method correctly encodes the special values
+   * Inf, -Inf, and NaN into a string value.
+   */
+  public static Value toValue(Double value) {
+    if (value != null) {
+      if (value == Double.POSITIVE_INFINITY) {
+        return Value.string("Infinity");
+      } else if (value == Double.NEGATIVE_INFINITY) {
+        return Value.string("-Infinity");
+      } else if (Double.isNaN(value)) {
+        return Value.string("NaN");
+      }
+    }
+    return Value.float64(value);
   }
 }

--- a/src/main/java/com/google/cloud/spanner/pgadapter/parsers/FloatParser.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/parsers/FloatParser.java
@@ -19,8 +19,10 @@ import com.google.cloud.spanner.ResultSet;
 import com.google.cloud.spanner.SpannerExceptionFactory;
 import com.google.cloud.spanner.Value;
 import com.google.cloud.spanner.pgadapter.ProxyServer.DataFormat;
+import com.google.cloud.spanner.pgadapter.error.PGException;
 import com.google.cloud.spanner.pgadapter.error.PGExceptionFactory;
 import com.google.cloud.spanner.pgadapter.error.SQLState;
+import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMap;
 import java.io.DataOutputStream;
 import java.io.IOException;
@@ -44,12 +46,7 @@ public class FloatParser extends Parser<Float> {
       switch (formatCode) {
         case TEXT:
           String stringValue = new String(item);
-          try {
-            this.item = Float.valueOf(stringValue);
-          } catch (Exception exception) {
-            throw PGExceptionFactory.newPGException(
-                "Invalid float4 value: " + stringValue, SQLState.SyntaxError);
-          }
+          this.item = parseFloat(stringValue);
           break;
         case BINARY:
           this.item = ByteConverter.float4(item, 0);
@@ -105,6 +102,55 @@ public class FloatParser extends Parser<Float> {
 
   @Override
   public void bind(ImmutableMap.Builder<String, Value> parametersBuilder, String name) {
-    parametersBuilder.put(name, Value.float32(this.item));
+    parametersBuilder.put(name, toValue(this.item));
+  }
+
+  /**
+   * Converts a string to a float. This method correctly recognizes valid PostgreSQL formats for the
+   * special Inf, -Inf, and NaN.
+   */
+  public static float parseFloat(@Nonnull String s) throws PGException {
+    if (Strings.isNullOrEmpty(s)) {
+      throw PGExceptionFactory.newPGException("Invalid float4 value: " + s, SQLState.SyntaxError);
+    }
+    // Quick check for Inf, -Inf, and NaN.
+    s = s.trim();
+    if (s.isEmpty()) {
+      throw PGExceptionFactory.newPGException("Invalid float4 value: " + s, SQLState.SyntaxError);
+    }
+    if (s.equalsIgnoreCase("inf")
+        || s.equalsIgnoreCase("infinity")
+        || s.equalsIgnoreCase("+inf")
+        || s.equalsIgnoreCase("+infinity")) {
+      return Float.POSITIVE_INFINITY;
+    }
+    if (s.equalsIgnoreCase("-inf") || s.equalsIgnoreCase("-infinity")) {
+      return Float.NEGATIVE_INFINITY;
+    }
+    if (s.equalsIgnoreCase("NaN")) {
+      return Float.NaN;
+    }
+    try {
+      return Float.parseFloat(s);
+    } catch (NumberFormatException exception) {
+      throw PGExceptionFactory.newPGException("Invalid float4 value: " + s, SQLState.SyntaxError);
+    }
+  }
+
+  /**
+   * Converts a float to a Spanner {@link Value}. This method correctly encodes the special values
+   * Inf, -Inf, and NaN into a string value.
+   */
+  public static Value toValue(Float value) {
+    if (value != null) {
+      if (value == Float.POSITIVE_INFINITY) {
+        return Value.string("Infinity");
+      } else if (value == Float.NEGATIVE_INFINITY) {
+        return Value.string("-Infinity");
+      } else if (Float.isNaN(value)) {
+        return Value.string("NaN");
+      }
+    }
+    return Value.float32(value);
   }
 }

--- a/src/main/java/com/google/cloud/spanner/pgadapter/utils/CsvCopyParser.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/utils/CsvCopyParser.java
@@ -132,6 +132,22 @@ class CsvCopyParser implements CopyInParser {
       return getSpannerValue(sessionState, type, recordValue);
     }
 
+    private static Value getNonFiniteValue(String recordValue) {
+      if ("NaN".equalsIgnoreCase(recordValue)) {
+        return Value.string("NaN");
+      }
+      if ("Infinity".equalsIgnoreCase(recordValue)
+          || "+Infinity".equalsIgnoreCase(recordValue)
+          || "inf".equalsIgnoreCase(recordValue)
+          || "+inf".equalsIgnoreCase(recordValue)) {
+        return Value.string("Infinity");
+      }
+      if ("-Infinity".equalsIgnoreCase(recordValue) || "-inf".equalsIgnoreCase(recordValue)) {
+        return Value.string("-Infinity");
+      }
+      return null;
+    }
+
     static Value getSpannerValue(SessionState sessionState, Type type, String recordValue)
         throws SpannerException {
       try {
@@ -145,9 +161,23 @@ class CsvCopyParser implements CopyInParser {
           case INT64:
             return Value.int64(recordValue == null ? null : Long.parseLong(recordValue));
           case FLOAT32:
-            return Value.float32(recordValue == null ? null : Float.parseFloat(recordValue));
+            if (recordValue == null) {
+              return Value.float32(null);
+            }
+            Value nonFiniteValue32 = getNonFiniteValue(recordValue);
+            if (nonFiniteValue32 != null) {
+              return nonFiniteValue32;
+            }
+            return Value.float32(Float.parseFloat(recordValue));
           case FLOAT64:
-            return Value.float64(recordValue == null ? null : Double.parseDouble(recordValue));
+            if (recordValue == null) {
+              return Value.float64(null);
+            }
+            Value nonFiniteValue64 = getNonFiniteValue(recordValue);
+            if (nonFiniteValue64 != null) {
+              return nonFiniteValue64;
+            }
+            return Value.float64(Double.parseDouble(recordValue));
           case PG_NUMERIC:
             return Value.pgNumeric(recordValue);
           case BYTES:

--- a/src/main/java/com/google/cloud/spanner/pgadapter/utils/CsvCopyParser.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/utils/CsvCopyParser.java
@@ -24,6 +24,8 @@ import com.google.cloud.spanner.Type;
 import com.google.cloud.spanner.Value;
 import com.google.cloud.spanner.pgadapter.parsers.ArrayParser;
 import com.google.cloud.spanner.pgadapter.parsers.BooleanParser;
+import com.google.cloud.spanner.pgadapter.parsers.DoubleParser;
+import com.google.cloud.spanner.pgadapter.parsers.FloatParser;
 import com.google.cloud.spanner.pgadapter.parsers.TimestampParser;
 import com.google.cloud.spanner.pgadapter.session.SessionState;
 import com.google.common.collect.Iterators;
@@ -132,22 +134,6 @@ class CsvCopyParser implements CopyInParser {
       return getSpannerValue(sessionState, type, recordValue);
     }
 
-    private static Value getNonFiniteValue(String recordValue) {
-      if ("NaN".equalsIgnoreCase(recordValue)) {
-        return Value.string("NaN");
-      }
-      if ("Infinity".equalsIgnoreCase(recordValue)
-          || "+Infinity".equalsIgnoreCase(recordValue)
-          || "inf".equalsIgnoreCase(recordValue)
-          || "+inf".equalsIgnoreCase(recordValue)) {
-        return Value.string("Infinity");
-      }
-      if ("-Infinity".equalsIgnoreCase(recordValue) || "-inf".equalsIgnoreCase(recordValue)) {
-        return Value.string("-Infinity");
-      }
-      return null;
-    }
-
     static Value getSpannerValue(SessionState sessionState, Type type, String recordValue)
         throws SpannerException {
       try {
@@ -161,23 +147,13 @@ class CsvCopyParser implements CopyInParser {
           case INT64:
             return Value.int64(recordValue == null ? null : Long.parseLong(recordValue));
           case FLOAT32:
-            if (recordValue == null) {
-              return Value.float32(null);
-            }
-            Value nonFiniteValue32 = getNonFiniteValue(recordValue);
-            if (nonFiniteValue32 != null) {
-              return nonFiniteValue32;
-            }
-            return Value.float32(Float.parseFloat(recordValue));
+            return recordValue == null
+                ? Value.float32(null)
+                : FloatParser.toValue(FloatParser.parseFloat(recordValue));
           case FLOAT64:
-            if (recordValue == null) {
-              return Value.float64(null);
-            }
-            Value nonFiniteValue64 = getNonFiniteValue(recordValue);
-            if (nonFiniteValue64 != null) {
-              return nonFiniteValue64;
-            }
-            return Value.float64(Double.parseDouble(recordValue));
+            return recordValue == null
+                ? Value.float64(null)
+                : DoubleParser.toValue(DoubleParser.parseDouble(recordValue));
           case PG_NUMERIC:
             return Value.pgNumeric(recordValue);
           case BYTES:

--- a/src/test/java/com/google/cloud/spanner/pgadapter/CopyInMockServerTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/CopyInMockServerTest.java
@@ -39,6 +39,7 @@ import com.google.protobuf.ListValue;
 import com.google.protobuf.NullValue;
 import com.google.protobuf.Value;
 import com.google.protobuf.Value.KindCase;
+import com.google.protobuf.util.JsonFormat;
 import com.google.spanner.v1.CommitRequest;
 import com.google.spanner.v1.ExecuteSqlRequest;
 import com.google.spanner.v1.Mutation;
@@ -578,6 +579,150 @@ public class CopyInMockServerTest extends AbstractMockServerTest {
     for (int col = 1; col < mutation.getInsert().getColumnsCount(); col++) {
       assertEquals(nullValue, mutation.getInsert().getValues(0).getValues(col));
     }
+  }
+
+  @Test
+  public void testCopyInFloat8NonFinite() throws SQLException, IOException {
+    setupCopyInformationSchemaResults();
+
+    try (Connection connection = DriverManager.getConnection(createUrl())) {
+      PGConnection pgConnection = connection.unwrap(PGConnection.class);
+      CopyManager copyManager = pgConnection.getCopyAPI();
+      long copyCount =
+          copyManager.copyIn(
+              "copy all_types from stdin;",
+              new StringReader(
+                  "1\ttrue\t\\x01\t1.0\tNaN\t1\t1.0\t2026-03-30T23:40:58Z\t2026-03-30\ttest\t{}\n"
+                      + "2\ttrue\t\\x01\t1.0\tInfinity\t1\t1.0\t2026-03-30T23:40:58Z\t2026-03-30\ttest\t{}\n"
+                      + "3\ttrue\t\\x01\t1.0\t-Infinity\t1\t1.0\t2026-03-30T23:40:58Z\t2026-03-30\ttest\t{}\n"
+                      + "4\ttrue\t\\x01\t1.0\tnan\t1\t1.0\t2026-03-30T23:40:58Z\t2026-03-30\ttest\t{}\n"
+                      + "5\ttrue\t\\x01\t1.0\tinfinity\t1\t1.0\t2026-03-30T23:40:58Z\t2026-03-30\ttest\t{}\n"
+                      + "6\ttrue\t\\x01\t1.0\t+Infinity\t1\t1.0\t2026-03-30T23:40:58Z\t2026-03-30\ttest\t{}\n"
+                      + "7\ttrue\t\\x01\t1.0\tinf\t1\t1.0\t2026-03-30T23:40:58Z\t2026-03-30\ttest\t{}\n"
+                      + "8\ttrue\t\\x01\t1.0\t+inf\t1\t1.0\t2026-03-30T23:40:58Z\t2026-03-30\ttest\t{}\n"
+                      + "9\ttrue\t\\x01\t1.0\t-inf\t1\t1.0\t2026-03-30T23:40:58Z\t2026-03-30\ttest\t{}\n"));
+      assertEquals(9L, copyCount);
+    }
+
+    List<CommitRequest> commitRequests = mockSpanner.getRequestsOfType(CommitRequest.class);
+    assertEquals(1, commitRequests.size());
+    CommitRequest commitRequest = commitRequests.get(0);
+    assertEquals(1, commitRequest.getMutationsCount());
+
+    Mutation mutation = commitRequest.getMutations(0);
+    assertEquals(OperationCase.INSERT, mutation.getOperationCase());
+    assertEquals(9, mutation.getInsert().getValuesCount());
+
+    // Row 1: NaN
+    ListValue row1 = mutation.getInsert().getValues(0);
+    assertEquals("NaN", row1.getValues(4).getStringValue());
+
+    // Row 2: Infinity
+    ListValue row2 = mutation.getInsert().getValues(1);
+    assertEquals("Infinity", row2.getValues(4).getStringValue());
+
+    // Row 3: -Infinity
+    ListValue row3 = mutation.getInsert().getValues(2);
+    assertEquals("-Infinity", row3.getValues(4).getStringValue());
+
+    // Row 4: nan
+    ListValue row4 = mutation.getInsert().getValues(3);
+    assertEquals("NaN", row4.getValues(4).getStringValue());
+
+    // Row 5: infinity
+    ListValue row5 = mutation.getInsert().getValues(4);
+    assertEquals("Infinity", row5.getValues(4).getStringValue());
+
+    // Row 6: +Infinity
+    ListValue row6 = mutation.getInsert().getValues(5);
+    assertEquals("Infinity", row6.getValues(4).getStringValue());
+
+    // Row 7: inf
+    ListValue row7 = mutation.getInsert().getValues(6);
+    assertEquals("Infinity", row7.getValues(4).getStringValue());
+
+    // Row 8: +inf
+    ListValue row8 = mutation.getInsert().getValues(7);
+    assertEquals("Infinity", row8.getValues(4).getStringValue());
+
+    // Row 9: -inf
+    ListValue row9 = mutation.getInsert().getValues(8);
+    assertEquals("-Infinity", row9.getValues(4).getStringValue());
+
+    // Verify that JsonFormat now succeeds on the whole request
+    String json = JsonFormat.printer().print(commitRequest);
+    assertTrue(json.contains("\"NaN\""));
+    assertTrue(json.contains("\"Infinity\""));
+    assertTrue(json.contains("\"-Infinity\""));
+  }
+
+  @Test
+  public void testCopyInFloat4NonFinite() throws SQLException, IOException {
+    setupCopyInformationSchemaResults();
+
+    try (Connection connection = DriverManager.getConnection(createUrl())) {
+      PGConnection pgConnection = connection.unwrap(PGConnection.class);
+      CopyManager copyManager = pgConnection.getCopyAPI();
+      long copyCount =
+          copyManager.copyIn(
+              "copy all_types from stdin;",
+              new StringReader(
+                  "1\ttrue\t\\x01\tNaN\t1.0\t1\t1.0\t2026-03-30T23:40:58Z\t2026-03-30\ttest\t{}\n"
+                      + "2\ttrue\t\\x01\tInfinity\t1.0\t1\t1.0\t2026-03-30T23:40:58Z\t2026-03-30\ttest\t{}\n"
+                      + "3\ttrue\t\\x01\t-Infinity\t1.0\t1\t1.0\t2026-03-30T23:40:58Z\t2026-03-30\ttest\t{}\n"
+                      + "4\ttrue\t\\x01\tnan\t1.0\t1\t1.0\t2026-03-30T23:40:58Z\t2026-03-30\ttest\t{}\n"
+                      + "5\ttrue\t\\x01\tinfinity\t1.0\t1\t1.0\t2026-03-30T23:40:58Z\t2026-03-30\ttest\t{}\n"
+                      + "6\ttrue\t\\x01\t+Infinity\t1.0\t1\t1.0\t2026-03-30T23:40:58Z\t2026-03-30\ttest\t{}\n"
+                      + "7\ttrue\t\\x01\tinf\t1.0\t1\t1.0\t2026-03-30T23:40:58Z\t2026-03-30\ttest\t{}\n"
+                      + "8\ttrue\t\\x01\t+inf\t1.0\t1\t1.0\t2026-03-30T23:40:58Z\t2026-03-30\ttest\t{}\n"
+                      + "9\ttrue\t\\x01\t-inf\t1.0\t1\t1.0\t2026-03-30T23:40:58Z\t2026-03-30\ttest\t{}\n"));
+      assertEquals(9L, copyCount);
+    }
+
+    List<CommitRequest> commitRequests = mockSpanner.getRequestsOfType(CommitRequest.class);
+    assertEquals(1, commitRequests.size());
+    CommitRequest commitRequest = commitRequests.get(0);
+    assertEquals(1, commitRequest.getMutationsCount());
+
+    Mutation mutation = commitRequest.getMutations(0);
+    assertEquals(OperationCase.INSERT, mutation.getOperationCase());
+    assertEquals(9, mutation.getInsert().getValuesCount());
+
+    // Row 1: NaN
+    ListValue row1 = mutation.getInsert().getValues(0);
+    assertEquals("NaN", row1.getValues(3).getStringValue());
+
+    // Row 2: Infinity
+    ListValue row2 = mutation.getInsert().getValues(1);
+    assertEquals("Infinity", row2.getValues(3).getStringValue());
+
+    // Row 3: -Infinity
+    ListValue row3 = mutation.getInsert().getValues(2);
+    assertEquals("-Infinity", row3.getValues(3).getStringValue());
+
+    // Row 4: nan
+    ListValue row4 = mutation.getInsert().getValues(3);
+    assertEquals("NaN", row4.getValues(3).getStringValue());
+
+    // Row 5: infinity
+    ListValue row5 = mutation.getInsert().getValues(4);
+    assertEquals("Infinity", row5.getValues(3).getStringValue());
+
+    // Row 6: +Infinity
+    ListValue row6 = mutation.getInsert().getValues(5);
+    assertEquals("Infinity", row6.getValues(3).getStringValue());
+
+    // Row 7: inf
+    ListValue row7 = mutation.getInsert().getValues(6);
+    assertEquals("Infinity", row7.getValues(3).getStringValue());
+
+    // Row 8: +inf
+    ListValue row8 = mutation.getInsert().getValues(7);
+    assertEquals("Infinity", row8.getValues(3).getStringValue());
+
+    // Row 9: -inf
+    ListValue row9 = mutation.getInsert().getValues(8);
+    assertEquals("-Infinity", row9.getValues(3).getStringValue());
   }
 
   @Test

--- a/src/test/java/com/google/cloud/spanner/pgadapter/parsers/DoubleParserTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/parsers/DoubleParserTest.java
@@ -20,8 +20,10 @@ import static org.junit.Assert.assertThrows;
 
 import com.google.cloud.spanner.ErrorCode;
 import com.google.cloud.spanner.SpannerException;
+import com.google.cloud.spanner.Value;
 import com.google.cloud.spanner.pgadapter.error.PGException;
 import com.google.cloud.spanner.pgadapter.parsers.Parser.FormatCode;
+import com.google.common.collect.ImmutableMap;
 import java.nio.charset.StandardCharsets;
 import java.util.Random;
 import org.junit.Test;
@@ -31,6 +33,46 @@ import org.postgresql.util.ByteConverter;
 
 @RunWith(JUnit4.class)
 public class DoubleParserTest {
+
+  @Test
+  public void testParseDouble() {
+    assertEquals(Double.POSITIVE_INFINITY, DoubleParser.parseDouble("inf"), 0.0);
+    assertEquals(Double.POSITIVE_INFINITY, DoubleParser.parseDouble("+inf"), 0.0);
+    assertEquals(Double.POSITIVE_INFINITY, DoubleParser.parseDouble("infinity"), 0.0);
+    assertEquals(Double.POSITIVE_INFINITY, DoubleParser.parseDouble("+infinity"), 0.0);
+    assertEquals(Double.POSITIVE_INFINITY, DoubleParser.parseDouble("INF"), 0.0);
+    assertEquals(Double.POSITIVE_INFINITY, DoubleParser.parseDouble("Infinity"), 0.0);
+    assertEquals(Double.POSITIVE_INFINITY, DoubleParser.parseDouble("+INF"), 0.0);
+
+    assertEquals(Double.NEGATIVE_INFINITY, DoubleParser.parseDouble("-inf"), 0.0);
+    assertEquals(Double.NEGATIVE_INFINITY, DoubleParser.parseDouble("-infinity"), 0.0);
+    assertEquals(Double.NEGATIVE_INFINITY, DoubleParser.parseDouble("-INF"), 0.0);
+
+    assertEquals(Double.NaN, DoubleParser.parseDouble("NaN"), 0.0);
+    assertEquals(Double.NaN, DoubleParser.parseDouble("nan"), 0.0);
+    assertEquals(Double.NaN, DoubleParser.parseDouble("NAN"), 0.0);
+
+    assertEquals(3.14, DoubleParser.parseDouble("3.14"), 0.0);
+    assertEquals(-3.14, DoubleParser.parseDouble("-3.14"), 0.0);
+    assertEquals(0.0, DoubleParser.parseDouble("0.0"), 0.0);
+
+    assertThrows(PGException.class, () -> DoubleParser.parseDouble(""));
+    assertThrows(PGException.class, () -> DoubleParser.parseDouble("  "));
+    assertThrows(PGException.class, () -> DoubleParser.parseDouble("foo"));
+    assertThrows(PGException.class, () -> DoubleParser.parseDouble(null));
+  }
+
+  @Test
+  public void testToValue() {
+    assertEquals(Value.float64(3.14), DoubleParser.toValue(3.14));
+
+    assertEquals(Value.string("NaN"), DoubleParser.toValue(Double.NaN));
+    assertEquals(Value.string("Infinity"), DoubleParser.toValue(Double.POSITIVE_INFINITY));
+    assertEquals(Value.string("-Infinity"), DoubleParser.toValue(Double.NEGATIVE_INFINITY));
+
+    assertEquals(Value.string("NaN"), DoubleParser.toValue(DoubleParser.parseDouble("NaN")));
+    assertEquals(Value.string("Infinity"), DoubleParser.toValue(DoubleParser.parseDouble("Inf")));
+  }
 
   @Test
   public void testToDouble() {
@@ -51,5 +93,22 @@ public class DoubleParserTest {
     assertThrows(
         PGException.class,
         () -> new DoubleParser("foo".getBytes(StandardCharsets.UTF_8), FormatCode.TEXT));
+
+    assertEquals("NaN", new DoubleParser(Double.NaN).stringParse());
+    assertEquals("Infinity", new DoubleParser(Double.POSITIVE_INFINITY).stringParse());
+    assertEquals("-Infinity", new DoubleParser(Double.NEGATIVE_INFINITY).stringParse());
+  }
+
+  @Test
+  public void testBind() {
+    ImmutableMap.Builder<String, Value> builder = ImmutableMap.builder();
+    new DoubleParser(Double.NaN).bind(builder, "nan");
+    new DoubleParser(Double.POSITIVE_INFINITY).bind(builder, "inf");
+    new DoubleParser(Double.NEGATIVE_INFINITY).bind(builder, "-inf");
+
+    ImmutableMap<String, Value> parameters = builder.build();
+    assertEquals(Value.string("NaN"), parameters.get("nan"));
+    assertEquals(Value.string("Infinity"), parameters.get("inf"));
+    assertEquals(Value.string("-Infinity"), parameters.get("-inf"));
   }
 }

--- a/src/test/java/com/google/cloud/spanner/pgadapter/parsers/FloatParserTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/parsers/FloatParserTest.java
@@ -20,8 +20,10 @@ import static org.junit.Assert.assertThrows;
 
 import com.google.cloud.spanner.ErrorCode;
 import com.google.cloud.spanner.SpannerException;
+import com.google.cloud.spanner.Value;
 import com.google.cloud.spanner.pgadapter.error.PGException;
 import com.google.cloud.spanner.pgadapter.parsers.Parser.FormatCode;
+import com.google.common.collect.ImmutableMap;
 import java.nio.charset.StandardCharsets;
 import java.util.Random;
 import org.junit.Test;
@@ -31,6 +33,34 @@ import org.postgresql.util.ByteConverter;
 
 @RunWith(JUnit4.class)
 public class FloatParserTest {
+
+  @Test
+  public void testParseFloat() {
+    assertEquals(Float.POSITIVE_INFINITY, FloatParser.parseFloat("inf"), 0.0f);
+    assertEquals(Float.POSITIVE_INFINITY, FloatParser.parseFloat("+inf"), 0.0f);
+    assertEquals(Float.POSITIVE_INFINITY, FloatParser.parseFloat("infinity"), 0.0f);
+    assertEquals(Float.POSITIVE_INFINITY, FloatParser.parseFloat("+infinity"), 0.0f);
+    assertEquals(Float.POSITIVE_INFINITY, FloatParser.parseFloat("INF"), 0.0f);
+    assertEquals(Float.POSITIVE_INFINITY, FloatParser.parseFloat("Infinity"), 0.0f);
+    assertEquals(Float.POSITIVE_INFINITY, FloatParser.parseFloat("+INF"), 0.0f);
+
+    assertEquals(Float.NEGATIVE_INFINITY, FloatParser.parseFloat("-inf"), 0.0f);
+    assertEquals(Float.NEGATIVE_INFINITY, FloatParser.parseFloat("-infinity"), 0.0f);
+    assertEquals(Float.NEGATIVE_INFINITY, FloatParser.parseFloat("-INF"), 0.0f);
+
+    assertEquals(Float.NaN, FloatParser.parseFloat("NaN"), 0.0f);
+    assertEquals(Float.NaN, FloatParser.parseFloat("nan"), 0.0f);
+    assertEquals(Float.NaN, FloatParser.parseFloat("NAN"), 0.0f);
+
+    assertEquals(3.14f, FloatParser.parseFloat("3.14"), 0.0f);
+    assertEquals(-3.14f, FloatParser.parseFloat("-3.14"), 0.0f);
+    assertEquals(0.0f, FloatParser.parseFloat("0.0"), 0.0f);
+
+    assertThrows(PGException.class, () -> FloatParser.parseFloat(""));
+    assertThrows(PGException.class, () -> FloatParser.parseFloat("  "));
+    assertThrows(PGException.class, () -> FloatParser.parseFloat("foo"));
+    assertThrows(PGException.class, () -> FloatParser.parseFloat(null));
+  }
 
   @Test
   public void testToFloat() {
@@ -54,5 +84,34 @@ public class FloatParserTest {
     assertThrows(
         PGException.class,
         () -> new FloatParser("foo".getBytes(StandardCharsets.UTF_8), FormatCode.TEXT));
+
+    assertEquals("NaN", new FloatParser(Float.NaN).stringParse());
+    assertEquals("Infinity", new FloatParser(Float.POSITIVE_INFINITY).stringParse());
+    assertEquals("-Infinity", new FloatParser(Float.NEGATIVE_INFINITY).stringParse());
+  }
+
+  @Test
+  public void testToValue() {
+    assertEquals(Value.float32(3.14f), FloatParser.toValue(3.14f));
+
+    assertEquals(Value.string("NaN"), FloatParser.toValue(Float.NaN));
+    assertEquals(Value.string("Infinity"), FloatParser.toValue(Float.POSITIVE_INFINITY));
+    assertEquals(Value.string("-Infinity"), FloatParser.toValue(Float.NEGATIVE_INFINITY));
+
+    assertEquals(Value.string("NaN"), FloatParser.toValue(FloatParser.parseFloat("NaN")));
+    assertEquals(Value.string("Infinity"), FloatParser.toValue(FloatParser.parseFloat("Inf")));
+  }
+
+  @Test
+  public void testBind() {
+    ImmutableMap.Builder<String, Value> builder = ImmutableMap.builder();
+    new FloatParser(Float.NaN).bind(builder, "nan");
+    new FloatParser(Float.POSITIVE_INFINITY).bind(builder, "inf");
+    new FloatParser(Float.NEGATIVE_INFINITY).bind(builder, "-inf");
+
+    ImmutableMap<String, Value> parameters = builder.build();
+    assertEquals(Value.string("NaN"), parameters.get("nan"));
+    assertEquals(Value.string("Infinity"), parameters.get("inf"));
+    assertEquals(Value.string("-Infinity"), parameters.get("-inf"));
   }
 }


### PR DESCRIPTION
Previously, an error was returned in the form "google.protobuf.Value cannot encode double values for infinity or nan, because they would be parsed as a string."