### PR TITLE
test: ignore 'connection reset by peer' errors

### DIFF
--- a/wrappers/golang/pgadapter_test.go
+++ b/wrappers/golang/pgadapter_test.go
@@ -76,7 +76,7 @@ func TestStart(t *testing.T) {
 		for {
 			n, err := conn.Read(tmp)
 			if err != nil {
-				if err != io.EOF {
+				if err != io.EOF && !strings.Contains(err.Error(), "connection reset by peer") {
 					t.Fatalf("%d: Read failed: %v", i, err)
 				}
 				break


### PR DESCRIPTION
Accept 'connection reset by peer' errors as a valid 'this connection broke' error, in addition to the existing check for EOF errors.

Fixes flaky test failures like this: https://github.com/GoogleCloudPlatform/pgadapter/actions/runs/24131441650/job/70408789572?pr=4299