### PR TITLE
fix: emit variant-specific command tag for DEALLOCATE ALL and DISCARD

### DIFF
--- a/src/main/java/com/google/cloud/spanner/pgadapter/statements/DeallocateStatement.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/statements/DeallocateStatement.java
@@ -64,7 +64,7 @@ public class DeallocateStatement extends IntermediatePortalStatement {
 
   @Override
   public String getCommandTag() {
-    return "DEALLOCATE";
+    return deallocateStatement.name == null ? "DEALLOCATE ALL" : "DEALLOCATE";
   }
 
   @Override

--- a/src/main/java/com/google/cloud/spanner/pgadapter/statements/DiscardStatement.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/statements/DiscardStatement.java
@@ -70,7 +70,18 @@ public class DiscardStatement extends IntermediatePortalStatement {
 
   @Override
   public String getCommandTag() {
-    return "DISCARD";
+    switch (discardStatement.type) {
+      case ALL:
+        return "DISCARD ALL";
+      case PLANS:
+        return "DISCARD PLANS";
+      case SEQUENCES:
+        return "DISCARD SEQUENCES";
+      case TEMPORARY:
+        return "DISCARD TEMP";
+      default:
+        return "DISCARD";
+    }
   }
 
   @Override

--- a/src/test/java/com/google/cloud/spanner/pgadapter/statements/DeallocateStatementTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/statements/DeallocateStatementTest.java
@@ -18,8 +18,16 @@ import static com.google.cloud.spanner.pgadapter.statements.DeallocateStatement.
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
+import com.google.cloud.spanner.Dialect;
+import com.google.cloud.spanner.Statement;
+import com.google.cloud.spanner.connection.AbstractStatementParser;
+import com.google.cloud.spanner.pgadapter.ConnectionHandler;
 import com.google.cloud.spanner.pgadapter.error.PGException;
+import com.google.cloud.spanner.pgadapter.metadata.ConnectionMetadata;
+import com.google.cloud.spanner.pgadapter.metadata.OptionsMetadata;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -46,5 +54,23 @@ public class DeallocateStatementTest {
     assertThrows(PGException.class, () -> parse("deallocate prepare"));
     assertThrows(PGException.class, () -> parse("deallocate foo bar"));
     assertThrows(PGException.class, () -> parse("deallocate foo.bar"));
+  }
+
+  @Test
+  public void testGetCommandTag() {
+    assertEquals("DEALLOCATE", createStatement("deallocate foo").getCommandTag());
+    assertEquals("DEALLOCATE", createStatement("deallocate prepare foo").getCommandTag());
+    assertEquals("DEALLOCATE ALL", createStatement("deallocate all").getCommandTag());
+  }
+
+  private static DeallocateStatement createStatement(String sql) {
+    ConnectionHandler connectionHandler = mock(ConnectionHandler.class);
+    when(connectionHandler.getConnectionMetadata()).thenReturn(mock(ConnectionMetadata.class));
+    return new DeallocateStatement(
+        connectionHandler,
+        mock(OptionsMetadata.class),
+        "",
+        AbstractStatementParser.getInstance(Dialect.POSTGRESQL).parse(Statement.of(sql)),
+        Statement.of(sql));
   }
 }

--- a/src/test/java/com/google/cloud/spanner/pgadapter/statements/DiscardStatementTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/statements/DiscardStatementTest.java
@@ -17,8 +17,16 @@ package com.google.cloud.spanner.pgadapter.statements;
 import static com.google.cloud.spanner.pgadapter.statements.DiscardStatement.parse;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
+import com.google.cloud.spanner.Dialect;
+import com.google.cloud.spanner.Statement;
+import com.google.cloud.spanner.connection.AbstractStatementParser;
+import com.google.cloud.spanner.pgadapter.ConnectionHandler;
 import com.google.cloud.spanner.pgadapter.error.PGException;
+import com.google.cloud.spanner.pgadapter.metadata.ConnectionMetadata;
+import com.google.cloud.spanner.pgadapter.metadata.OptionsMetadata;
 import com.google.cloud.spanner.pgadapter.statements.DiscardStatement.ParsedDiscardStatement.DiscardType;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -40,5 +48,25 @@ public class DiscardStatementTest {
     assertThrows(PGException.class, () -> parse("discard"));
     assertThrows(PGException.class, () -> parse("deallocate all foo"));
     assertThrows(PGException.class, () -> parse("discard temp all"));
+  }
+
+  @Test
+  public void testGetCommandTag() {
+    assertEquals("DISCARD ALL", createStatement("discard all").getCommandTag());
+    assertEquals("DISCARD PLANS", createStatement("discard plans").getCommandTag());
+    assertEquals("DISCARD SEQUENCES", createStatement("discard sequences").getCommandTag());
+    assertEquals("DISCARD TEMP", createStatement("discard temp").getCommandTag());
+    assertEquals("DISCARD TEMP", createStatement("discard temporary").getCommandTag());
+  }
+
+  private static DiscardStatement createStatement(String sql) {
+    ConnectionHandler connectionHandler = mock(ConnectionHandler.class);
+    when(connectionHandler.getConnectionMetadata()).thenReturn(mock(ConnectionMetadata.class));
+    return new DiscardStatement(
+        connectionHandler,
+        mock(OptionsMetadata.class),
+        "",
+        AbstractStatementParser.getInstance(Dialect.POSTGRESQL).parse(Statement.of(sql)),
+        Statement.of(sql));
   }
 }


### PR DESCRIPTION
## Problem
When processing `DEALLOCATE ALL`, PGAdapter replies with `DEALLOCATE` - unlike a real postgres, which replies with `DEALLOCATE ALL`. A similar problem exists for `DISCARD`.

This matters for clients that validate the response against the expected string; for some clients (in particular: pgbouncer), it causes the client to think that PGAdapter has not actually processed the `DEALLOCATE`, which causes incorrect client behavior later on.

## Fix
Emit the full tag on each response, e.g: `DEALLOCATE ALL`, rather than `DEALLOCATE`.

## Tests
New unit tests to validate this behavior.
