### PR TITLE
perf: move cache used for described statements from connection to server

### DIFF
--- a/src/main/java/com/google/cloud/spanner/pgadapter/ConnectionHandler.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/ConnectionHandler.java
@@ -69,8 +69,6 @@ import com.google.cloud.spanner.pgadapter.wireprotocol.WireMessage;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
-import com.google.common.cache.Cache;
-import com.google.common.cache.CacheBuilder;
 import com.google.common.collect.ImmutableList;
 import com.google.spanner.admin.database.v1.InstanceName;
 import com.google.spanner.v1.DatabaseName;
@@ -82,7 +80,6 @@ import java.net.Socket;
 import java.net.SocketException;
 import java.security.SecureRandom;
 import java.text.MessageFormat;
-import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
@@ -120,12 +117,6 @@ public class ConnectionHandler implements Runnable {
   private final ProxyServer server;
   private Socket socket;
   private final Map<String, IntermediatePreparedStatement> statementsMap = new HashMap<>();
-  private final Cache<String, Future<DescribeResult>> autoDescribedStatementsCache =
-      CacheBuilder.newBuilder()
-          .expireAfterWrite(Duration.ofMinutes(30L))
-          .maximumSize(5000L)
-          .concurrencyLevel(1)
-          .build();
   private final Map<String, IntermediatePortalStatement> portalsMap = new HashMap<>();
   private volatile ConnectionStatus status = ConnectionStatus.UNAUTHENTICATED;
   private Thread thread;
@@ -147,6 +138,7 @@ public class ConnectionHandler implements Runnable {
   private int invalidMessagesCount;
   private Connection spannerConnection;
   private DatabaseId databaseId;
+  private String databaseName;
   private WellKnownClient wellKnownClient = WellKnownClient.UNSPECIFIED;
   private boolean hasDeterminedClientUsingQuery;
 
@@ -285,6 +277,7 @@ public class ConnectionHandler implements Runnable {
     spannerConnection.setSavepointSupport(SavepointSupport.ENABLED);
     this.spannerConnection = spannerConnection;
     this.databaseId = connectionOptions.getDatabaseId();
+    this.databaseName = databaseId.getName();
     this.extendedQueryProtocolHandler = new ExtendedQueryProtocolHandler(this);
   }
 
@@ -818,12 +811,18 @@ public class ConnectionHandler implements Runnable {
    * in the cache.
    */
   public Future<DescribeResult> getAutoDescribedStatement(String sql) {
-    return this.autoDescribedStatementsCache.getIfPresent(sql);
+    if (this.databaseName == null) {
+      return null;
+    }
+    return this.server.autoDescribedStatementsCache.getIfPresent(this.databaseName + sql);
   }
 
   /** Stores the parameter types of an auto-described statement in the cache. */
   public void registerAutoDescribedStatement(String sql, Future<DescribeResult> describeResult) {
-    this.autoDescribedStatementsCache.put(sql, describeResult);
+    if (this.databaseName == null) {
+      return;
+    }
+    this.server.autoDescribedStatementsCache.put(this.databaseName + sql, describeResult);
   }
 
   private boolean shouldSkipForClientDetection(

--- a/src/main/java/com/google/cloud/spanner/pgadapter/ProxyServer.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/ProxyServer.java
@@ -22,6 +22,7 @@ import com.google.cloud.spanner.SpannerExceptionFactory;
 import com.google.cloud.spanner.ThreadFactoryUtil;
 import com.google.cloud.spanner.connection.SpannerPool;
 import com.google.cloud.spanner.pgadapter.ConnectionHandler.QueryMode;
+import com.google.cloud.spanner.pgadapter.metadata.DescribeResult;
 import com.google.cloud.spanner.pgadapter.metadata.OptionsMetadata;
 import com.google.cloud.spanner.pgadapter.metadata.OptionsMetadata.TextFormat;
 import com.google.cloud.spanner.pgadapter.statements.IntermediateStatement;
@@ -29,6 +30,8 @@ import com.google.cloud.spanner.pgadapter.utils.Metrics;
 import com.google.cloud.spanner.pgadapter.wireprotocol.MessageReader;
 import com.google.cloud.spanner.pgadapter.wireprotocol.WireMessage;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
 import com.google.common.collect.ImmutableList;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.trace.Tracer;
@@ -39,6 +42,7 @@ import java.net.InetAddress;
 import java.net.ServerSocket;
 import java.net.Socket;
 import java.net.SocketException;
+import java.time.Duration;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
@@ -49,6 +53,7 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.ThreadPoolExecutor;
@@ -70,6 +75,8 @@ public class ProxyServer extends AbstractApiService {
 
   @VisibleForTesting
   static final Map<Integer, ConnectionHandler> CONNECTION_HANDLERS = new ConcurrentHashMap<>();
+
+  final Cache<String, Future<DescribeResult>> autoDescribedStatementsCache;
 
   private final OptionsMetadata options;
   private final OpenTelemetry openTelemetry;
@@ -171,6 +178,13 @@ public class ProxyServer extends AbstractApiService {
       OptionsMetadata optionsMetadata, OpenTelemetry openTelemetry, Properties properties) {
     this.options = optionsMetadata;
     this.messageReader = new MessageReader(optionsMetadata);
+    this.autoDescribedStatementsCache =
+        CacheBuilder.newBuilder()
+            .expireAfterWrite(Duration.ofMinutes(optionsMetadata.getDescribeCacheExpireMinutes()))
+            .maximumSize(optionsMetadata.getDescribeCacheMaxSize())
+            .concurrencyLevel(1)
+            .build();
+
     this.openTelemetry = openTelemetry;
     this.metrics =
         optionsMetadata.isEnableOpenTelemetryMetrics()

--- a/src/main/java/com/google/cloud/spanner/pgadapter/metadata/OptionsMetadata.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/metadata/OptionsMetadata.java
@@ -117,6 +117,8 @@ public class OptionsMetadata {
     private String clientCertificate;
     private String clientKey;
     private boolean isExperimentalHost = false;
+    private Long describeCacheExpireMinutes;
+    private Long describeCacheMaxSize;
 
     Builder() {}
 
@@ -448,6 +450,22 @@ public class OptionsMetadata {
       return this;
     }
 
+    /**
+     * (Optional) The number of minutes that described statements are cached. Described statements
+     * are queries executed in PLAN mode to determine parameter types and metadata. Caching these
+     * results can improve performance by avoiding repeated PLAN executions. Defaults to 30 minutes.
+     */
+    public Builder setDescribeCacheExpireMinutes(long minutes) {
+      this.describeCacheExpireMinutes = minutes;
+      return this;
+    }
+
+    /** (Optional) The maximum number of described statements that are cached. Defaults to 5000. */
+    public Builder setDescribeCacheMaxSize(long maxSize) {
+      this.describeCacheMaxSize = maxSize;
+      return this;
+    }
+
     public OptionsMetadata build() {
       if (Strings.isNullOrEmpty(project) && !Strings.isNullOrEmpty(instance)) {
         throw SpannerExceptionFactory.newSpannerException(
@@ -468,6 +486,13 @@ public class OptionsMetadata {
       ImmutableList.Builder<String> args = ImmutableList.builder();
       if (!Strings.isNullOrEmpty(project)) {
         addOption(args, OPTION_PROJECT_ID, project);
+      }
+      if (describeCacheExpireMinutes != null) {
+        addLongOption(
+            args, OPTION_DESCRIBE_CACHE_EXPIRE_MINUTES, String.valueOf(describeCacheExpireMinutes));
+      }
+      if (describeCacheMaxSize != null) {
+        addLongOption(args, OPTION_DESCRIBE_CACHE_MAX_SIZE, String.valueOf(describeCacheMaxSize));
       }
       if (!Strings.isNullOrEmpty(instance)) {
         addOption(args, OPTION_INSTANCE_ID, instance);
@@ -674,6 +699,11 @@ public class OptionsMetadata {
   private static final String OPTION_LOG_GRPC_MESSAGES = "log_grpc_messages";
   private static final String OPTION_ALLOW_SHUTDOWN_STATEMENT = "allow_shutdown_statement";
   private static final String OPTION_COMMAND = "cmd";
+  private static final String OPTION_DESCRIBE_CACHE_EXPIRE_MINUTES =
+      "describe_cache_expire_minutes";
+  private static final String OPTION_DESCRIBE_CACHE_MAX_SIZE = "describe_cache_max_size";
+  private static final long DEFAULT_DESCRIBE_CACHE_EXPIRE_MINUTES = 30L;
+  private static final long DEFAULT_DESCRIBE_CACHE_MAX_SIZE = 5000L;
 
   private final Map<String, String> environment;
   private final String osName;
@@ -708,6 +738,8 @@ public class OptionsMetadata {
   private final boolean logGrpcMessages;
   private final boolean allowShutdownStatement;
   private final String command;
+  private final long describeCacheExpireMinutes;
+  private final long describeCacheMaxSize;
 
   /**
    * Creates a new instance of {@link OptionsMetadata} from the given arguments.
@@ -787,6 +819,8 @@ public class OptionsMetadata {
     this.proxyPort = buildProxyPort(commandLine);
     this.socketFile = buildSocketFile(commandLine);
     this.maxBacklog = buildMaxBacklog(commandLine);
+    this.describeCacheExpireMinutes = buildDescribeCacheExpireMinutes(commandLine);
+    this.describeCacheMaxSize = buildDescribeCacheMaxSize(commandLine);
     this.textFormat = TextFormat.POSTGRESQL;
     this.binaryFormat = commandLine.hasOption(OPTION_BINARY_FORMAT);
     this.authenticate = commandLine.hasOption(OPTION_AUTHENTICATE);
@@ -870,6 +904,8 @@ public class OptionsMetadata {
     this.proxyPort = proxyPort;
     this.socketFile = isWindows() ? "" : DEFAULT_SOCKET_DIR + File.separatorChar + SOCKET_FILE_NAME;
     this.maxBacklog = DEFAULT_MAX_BACKLOG;
+    this.describeCacheExpireMinutes = DEFAULT_DESCRIBE_CACHE_EXPIRE_MINUTES;
+    this.describeCacheMaxSize = DEFAULT_DESCRIBE_CACHE_MAX_SIZE;
     this.textFormat = textFormat;
     this.binaryFormat = forceBinary;
     this.authenticate = authenticate;
@@ -1011,6 +1047,33 @@ public class OptionsMetadata {
       throw new IllegalArgumentException("Max backlog must be greater than 0");
     }
     return backlog;
+  }
+
+  private long buildDescribeCacheExpireMinutes(CommandLine commandLine) {
+    long expireMinutes =
+        Long.parseLong(
+            commandLine
+                .getOptionValue(
+                    OPTION_DESCRIBE_CACHE_EXPIRE_MINUTES,
+                    String.valueOf(DEFAULT_DESCRIBE_CACHE_EXPIRE_MINUTES))
+                .trim());
+    if (expireMinutes <= 0) {
+      throw new IllegalArgumentException("Describe cache expire minutes must be greater than 0");
+    }
+    return expireMinutes;
+  }
+
+  private long buildDescribeCacheMaxSize(CommandLine commandLine) {
+    long maxSize =
+        Long.parseLong(
+            commandLine
+                .getOptionValue(
+                    OPTION_DESCRIBE_CACHE_MAX_SIZE, String.valueOf(DEFAULT_DESCRIBE_CACHE_MAX_SIZE))
+                .trim());
+    if (maxSize <= 0) {
+      throw new IllegalArgumentException("Describe cache max size must be greater than 0");
+    }
+    return maxSize;
   }
 
   /**
@@ -1292,6 +1355,20 @@ public class OptionsMetadata {
         "authenticate",
         false,
         "Whether you wish the proxy to perform an authentication step.");
+    options.addOption(
+        null,
+        OPTION_DESCRIBE_CACHE_EXPIRE_MINUTES,
+        true,
+        String.format(
+            "The number of minutes that described statements are cached. Defaults to %d.",
+            DEFAULT_DESCRIBE_CACHE_EXPIRE_MINUTES));
+    options.addOption(
+        null,
+        OPTION_DESCRIBE_CACHE_MAX_SIZE,
+        true,
+        String.format(
+            "The maximum number of described statements that are cached. Defaults to %d.",
+            DEFAULT_DESCRIBE_CACHE_MAX_SIZE));
     options.addOption(null, OPTION_ENABLE_OPEN_TELEMETRY, false, "Enable OpenTelemetry tracing.");
     options.addOption(
         null, OPTION_ENABLE_OPEN_TELEMETRY_METRICS, false, "Enable OpenTelemetry metrics.");
@@ -1671,6 +1748,14 @@ public class OptionsMetadata {
 
   public int getMaxBacklog() {
     return this.maxBacklog;
+  }
+
+  public long getDescribeCacheExpireMinutes() {
+    return this.describeCacheExpireMinutes;
+  }
+
+  public long getDescribeCacheMaxSize() {
+    return this.describeCacheMaxSize;
   }
 
   public TextFormat getTextFormat() {

--- a/src/test/java/com/google/cloud/spanner/pgadapter/AbstractMockServerTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/AbstractMockServerTest.java
@@ -1465,6 +1465,7 @@ public abstract class AbstractMockServerTest {
     mockInstanceAdmin.reset();
     if (pgServer != null) {
       pgServer.clearDebugMessages();
+      pgServer.autoDescribedStatementsCache.invalidateAll();
     }
   }
 

--- a/src/test/java/com/google/cloud/spanner/pgadapter/JdbcMockServerTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/JdbcMockServerTest.java
@@ -1757,6 +1757,9 @@ public class JdbcMockServerTest extends AbstractMockServerTest {
 
         mockSpanner.clearRequests();
       }
+      // Invalidate the described statement cache to get predictable results
+      // across multiple tests.
+      pgServer.autoDescribedStatementsCache.invalidateAll();
     }
   }
 

--- a/src/test/java/com/google/cloud/spanner/pgadapter/metadata/OptionsMetadataTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/metadata/OptionsMetadataTest.java
@@ -98,6 +98,34 @@ public class OptionsMetadataTest {
   }
 
   @Test
+  public void testDefaultDescribeCacheOptions() {
+    OptionsMetadata options =
+        new OptionsMetadata(new String[] {"-p", "p", "-i", "i", "-c", "credentials.json"});
+    assertEquals(30L, options.getDescribeCacheExpireMinutes());
+    assertEquals(5000L, options.getDescribeCacheMaxSize());
+  }
+
+  @Test
+  public void testCustomDescribeCacheOptions() {
+    OptionsMetadata options =
+        new OptionsMetadata(
+            new String[] {
+              "-p",
+              "p",
+              "-i",
+              "i",
+              "-describe_cache_expire_minutes",
+              "10",
+              "-describe_cache_max_size",
+              "1000",
+              "-c",
+              "credentials.json"
+            });
+    assertEquals(10L, options.getDescribeCacheExpireMinutes());
+    assertEquals(1000L, options.getDescribeCacheMaxSize());
+  }
+
+  @Test
   public void testDatabaseName() {
     assertFalse(
         new OptionsMetadata(new String[] {"-c", "credentials.json"}).hasDefaultConnectionUrl());


### PR DESCRIPTION
Moves the cache that is used for described statements from the individual connections to the ProxyServer, and use the database name as a prefix for the cache entries. This improves cache usage for applications that do not use connection pooling, or for other reasons spread their statements across a large number of different connections.

This change also adds options for setting the cache size and expiration time.