### PR TITLE
perf: use a static method for binding bool params

### DIFF
--- a/src/main/java/com/google/cloud/spanner/pgadapter/parsers/BooleanParser.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/parsers/BooleanParser.java
@@ -63,18 +63,22 @@ public class BooleanParser extends Parser<Boolean> {
   }
 
   BooleanParser(byte[] item, FormatCode formatCode) {
-    if (item != null) {
-      switch (formatCode) {
-        case TEXT:
-          String stringValue = new String(item, UTF8).toLowerCase(Locale.ENGLISH);
-          this.item = toBoolean(stringValue);
-          break;
-        case BINARY:
-          this.item = toBoolean(item);
-          break;
-        default:
-          throw new IllegalArgumentException("Unsupported format: " + formatCode);
-      }
+    this.item = toBoolean(item, formatCode);
+  }
+
+  /** Converts the given data to a boolean value based on the format code. */
+  public static Boolean toBoolean(byte[] item, FormatCode formatCode) {
+    if (item == null) {
+      return null;
+    }
+    switch (formatCode) {
+      case TEXT:
+        String stringValue = new String(item, UTF8).toLowerCase(Locale.ENGLISH);
+        return toBoolean(stringValue);
+      case BINARY:
+        return toBoolean(item);
+      default:
+        throw new IllegalArgumentException("Unsupported format: " + formatCode);
     }
   }
 
@@ -138,6 +142,14 @@ public class BooleanParser extends Parser<Boolean> {
       default:
         throw new IllegalArgumentException("unknown data format: " + format);
     }
+  }
+
+  public static void bind(
+      ImmutableMap.Builder<String, Value> parametersBuilder,
+      String name,
+      byte[] item,
+      FormatCode formatCode) {
+    parametersBuilder.put(name, Value.bool(toBoolean(item, formatCode)));
   }
 
   @Override

--- a/src/main/java/com/google/cloud/spanner/pgadapter/parsers/Parser.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/parsers/Parser.java
@@ -259,6 +259,25 @@ public abstract class Parser<T> {
     }
   }
 
+  /** Binds a parameter value to a statement builder without necessarily instantiating a parser. */
+  public static void bind(
+      ImmutableMap.Builder<String, Value> parametersBuilder,
+      String name,
+      byte[] item,
+      int oidType,
+      FormatCode formatCode,
+      SessionState sessionState) {
+    switch (oidType) {
+      case Oid.BOOL:
+      case Oid.BIT:
+        BooleanParser.bind(parametersBuilder, name, item, formatCode);
+        break;
+      default:
+        // Fallback to instance creation until all types are optimized with static bind methods.
+        create(sessionState, item, oidType, formatCode).bind(parametersBuilder, name);
+    }
+  }
+
   /**
    * Translates the given Cloud Spanner {@link Type} to a PostgreSQL OID constant.
    *

--- a/src/main/java/com/google/cloud/spanner/pgadapter/statements/IntermediatePortalStatement.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/statements/IntermediatePortalStatement.java
@@ -117,16 +117,16 @@ public class IntermediatePortalStatement extends IntermediatePreparedStatement {
     for (int index = 0; index < this.parameters.length; index++) {
       short formatCode = getParameterFormatCode(index);
       int type = preparedStatement.getParameterDataType(index);
-      Parser<?> parser =
-          Parser.create(
-              connectionHandler
-                  .getExtendedQueryProtocolHandler()
-                  .getBackendConnection()
-                  .getSessionState(),
-              this.parameters[index],
-              type,
-              FormatCode.of(formatCode));
-      parser.bind(parametersBuilder, "p" + (index + 1));
+      Parser.bind(
+          parametersBuilder,
+          "p" + (index + 1),
+          this.parameters[index],
+          type,
+          FormatCode.of(formatCode),
+          connectionHandler
+              .getExtendedQueryProtocolHandler()
+              .getBackendConnection()
+              .getSessionState());
     }
     return Statement.of(statement.getSql(), parametersBuilder.build());
   }


### PR DESCRIPTION
Reduce memory and garbage collection pressure by using a static bind(..) method for binding parameter values. This implementation adds this optimization for boolean parameters. Follow-up pull requests will implement the same for the other supported data types.