### PR TITLE
perf: use static binders for paramter values

### DIFF
--- a/src/main/java/com/google/cloud/spanner/pgadapter/parsers/ArrayParser.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/parsers/ArrayParser.java
@@ -345,76 +345,112 @@ public class ArrayParser extends Parser<List<?>> {
     }
   }
 
+  public static void bind(
+      ImmutableMap.Builder<String, Value> parametersBuilder,
+      String name,
+      byte[] item,
+      int oidType,
+      FormatCode formatCode,
+      SessionState sessionState) {
+    int elementOid = Parser.getArrayElementOid(oidType);
+    List<?> list;
+    if (item == null) {
+      list = null;
+    } else {
+      switch (formatCode) {
+        case TEXT:
+          list =
+              stringArrayToList(
+                  new String(item, StandardCharsets.UTF_8), elementOid, sessionState, false);
+          break;
+        case BINARY:
+          list = binaryArrayToList(item, false);
+          break;
+        default:
+          throw new IllegalArgumentException("Unsupported format: " + formatCode);
+      }
+    }
+    bind(parametersBuilder, name, list, elementOid);
+  }
+
   @SuppressWarnings("unchecked")
-  @Override
-  public void bind(ImmutableMap.Builder<String, Value> parametersBuilder, String name) {
+  public static void bind(
+      ImmutableMap.Builder<String, Value> parametersBuilder,
+      String name,
+      List<?> list,
+      int elementOid) {
     switch (elementOid) {
       case Oid.BIT:
       case Oid.BOOL:
-        parametersBuilder.put(name, Value.boolArray((List<Boolean>) this.item));
+        parametersBuilder.put(name, Value.boolArray((List<Boolean>) list));
         break;
       case Oid.INT2:
-        if (this.item == null) {
+        if (list == null) {
           parametersBuilder.put(name, Value.int64Array((long[]) null));
         } else {
           parametersBuilder.put(
               name,
               Value.int64Array(
-                  ((List<Short>) this.item)
+                  ((List<Short>) list)
                       .stream()
                           .map(s -> s == null ? null : s.longValue())
                           .collect(Collectors.toList())));
         }
         break;
       case Oid.INT4:
-        if (this.item == null) {
+        if (list == null) {
           parametersBuilder.put(name, Value.int64Array((long[]) null));
         } else {
           parametersBuilder.put(
               name,
               Value.int64Array(
-                  ((List<Integer>) this.item)
+                  ((List<Integer>) list)
                       .stream()
                           .map(i -> i == null ? null : i.longValue())
                           .collect(Collectors.toList())));
         }
         break;
       case Oid.INT8:
-        parametersBuilder.put(name, Value.int64Array((List<Long>) this.item));
+        parametersBuilder.put(name, Value.int64Array((List<Long>) list));
         break;
       case Oid.OID:
-        parametersBuilder.put(name, Value.pgOidArray((List<Long>) this.item));
+        parametersBuilder.put(name, Value.pgOidArray((List<Long>) list));
         break;
       case Oid.NUMERIC:
-        parametersBuilder.put(name, Value.pgNumericArray((List<String>) this.item));
+        parametersBuilder.put(name, Value.pgNumericArray((List<String>) list));
         break;
       case Oid.FLOAT4:
-        parametersBuilder.put(name, Value.float32Array((List<Float>) this.item));
+        parametersBuilder.put(name, Value.float32Array((List<Float>) list));
         break;
       case Oid.FLOAT8:
-        parametersBuilder.put(name, Value.float64Array((List<Double>) this.item));
+        parametersBuilder.put(name, Value.float64Array((List<Double>) list));
         break;
       case Oid.UUID:
       case Oid.VARCHAR:
       case Oid.TEXT:
-        parametersBuilder.put(name, Value.stringArray((List<String>) this.item));
+        parametersBuilder.put(name, Value.stringArray((List<String>) list));
         break;
       case Oid.JSONB:
-        parametersBuilder.put(name, Value.pgJsonbArray((List<String>) this.item));
+        parametersBuilder.put(name, Value.pgJsonbArray((List<String>) list));
         break;
       case Oid.BYTEA:
-        parametersBuilder.put(name, Value.bytesArray((List<ByteArray>) this.item));
+        parametersBuilder.put(name, Value.bytesArray((List<ByteArray>) list));
         break;
       case Oid.TIMESTAMPTZ:
       case Oid.TIMESTAMP:
-        parametersBuilder.put(name, Value.timestampArray((List<Timestamp>) this.item));
+        parametersBuilder.put(name, Value.timestampArray((List<Timestamp>) list));
         break;
       case Oid.DATE:
-        parametersBuilder.put(name, Value.dateArray((List<Date>) this.item));
+        parametersBuilder.put(name, Value.dateArray((List<Date>) list));
         break;
       default:
         throw PGExceptionFactory.newPGException(
-            "Unsupported array element type: " + arrayElementType, SQLState.InvalidParameterValue);
+            "Unsupported array element type: " + elementOid, SQLState.InvalidParameterValue);
     }
+  }
+
+  @Override
+  public void bind(ImmutableMap.Builder<String, Value> parametersBuilder, String name) {
+    bind(parametersBuilder, name, this.item, this.elementOid);
   }
 }

--- a/src/main/java/com/google/cloud/spanner/pgadapter/parsers/BinaryParser.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/parsers/BinaryParser.java
@@ -50,23 +50,27 @@ public class BinaryParser extends Parser<ByteArray> {
   }
 
   BinaryParser(byte[] item, FormatCode formatCode) {
-    if (item != null) {
-      switch (formatCode) {
-        case TEXT:
-          try {
-            this.item = ByteArray.copyFrom(PGbytea.toBytes(item));
-            break;
-          } catch (Exception exception) {
-            throw PGExceptionFactory.newPGException(
-                "Invalid binary value: " + new String(item, StandardCharsets.UTF_8),
-                SQLState.SyntaxError);
-          }
-        case BINARY:
-          this.item = toByteArray(item);
-          break;
-        default:
-          throw new IllegalArgumentException("Unsupported format: " + formatCode);
-      }
+    this.item = toByteArray(item, formatCode);
+  }
+
+  /** Converts the given data to a {@link ByteArray} based on the format code. */
+  public static ByteArray toByteArray(byte[] item, FormatCode formatCode) {
+    if (item == null) {
+      return null;
+    }
+    switch (formatCode) {
+      case TEXT:
+        try {
+          return ByteArray.copyFrom(PGbytea.toBytes(item));
+        } catch (Exception exception) {
+          throw PGExceptionFactory.newPGException(
+              "Invalid binary value: " + new String(item, StandardCharsets.UTF_8),
+              SQLState.SyntaxError);
+        }
+      case BINARY:
+        return toByteArray(item);
+      default:
+        throw new IllegalArgumentException("Unsupported format: " + formatCode);
     }
   }
 
@@ -180,6 +184,14 @@ public class BinaryParser extends Parser<ByteArray> {
       length += 2;
     }
     return length;
+  }
+
+  public static void bind(
+      ImmutableMap.Builder<String, Value> parametersBuilder,
+      String name,
+      byte[] item,
+      FormatCode formatCode) {
+    parametersBuilder.put(name, Value.bytes(toByteArray(item, formatCode)));
   }
 
   @Override

--- a/src/main/java/com/google/cloud/spanner/pgadapter/parsers/DateParser.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/parsers/DateParser.java
@@ -45,25 +45,27 @@ public class DateParser extends Parser<Date> {
   }
 
   DateParser(byte[] item, FormatCode formatCode) {
-    if (item != null) {
-      switch (formatCode) {
-        case TEXT:
-          String stringValue = new String(item, UTF8);
-          // Use the first 10 characters of the date string, as the string might contain a timezone
-          // identifier, which is not supported by parseDate(String).
-          if (stringValue.length() >= 10) {
-            this.item = Date.parseDate(stringValue.substring(0, 10));
-          } else {
-            throw PGExceptionFactory.newPGException(
-                "Invalid date value: " + stringValue, SQLState.SyntaxError);
-          }
-          break;
-        case BINARY:
-          this.item = toDate(item);
-          break;
-        default:
-          throw new IllegalArgumentException("Unsupported format: " + formatCode);
-      }
+    this.item = toDate(item, formatCode);
+  }
+
+  /** Converts the given data to a {@link Date} based on the format code. */
+  public static Date toDate(byte[] item, FormatCode formatCode) {
+    if (item == null) {
+      return null;
+    }
+    switch (formatCode) {
+      case TEXT:
+        String stringValue = new String(item, UTF8);
+        if (stringValue.length() >= 10) {
+          return Date.parseDate(stringValue.substring(0, 10));
+        } else {
+          throw PGExceptionFactory.newPGException(
+              "Invalid date value: " + stringValue, SQLState.SyntaxError);
+        }
+      case BINARY:
+        return toDate(item);
+      default:
+        throw new IllegalArgumentException("Unsupported format: " + formatCode);
     }
   }
 
@@ -176,6 +178,14 @@ public class DateParser extends Parser<Date> {
       throw new IllegalArgumentException("Date is out of range, epoch day=" + days);
     }
     return (int) days;
+  }
+
+  public static void bind(
+      ImmutableMap.Builder<String, Value> parametersBuilder,
+      String name,
+      byte[] item,
+      FormatCode formatCode) {
+    parametersBuilder.put(name, Value.date(toDate(item, formatCode)));
   }
 
   @Override

--- a/src/main/java/com/google/cloud/spanner/pgadapter/parsers/DoubleParser.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/parsers/DoubleParser.java
@@ -44,18 +44,22 @@ public class DoubleParser extends Parser<Double> {
   }
 
   DoubleParser(byte[] item, FormatCode formatCode) {
-    if (item != null) {
-      switch (formatCode) {
-        case TEXT:
-          String stringValue = new String(item, StandardCharsets.UTF_8);
-          this.item = parseDouble(stringValue);
-          break;
-        case BINARY:
-          this.item = toDouble(item);
-          break;
-        default:
-          throw new IllegalArgumentException("Unsupported format: " + formatCode);
-      }
+    this.item = toDouble(item, formatCode);
+  }
+
+  /** Converts the given data to a double based on the format code. */
+  public static Double toDouble(byte[] item, FormatCode formatCode) {
+    if (item == null) {
+      return null;
+    }
+    switch (formatCode) {
+      case TEXT:
+        String stringValue = new String(item, StandardCharsets.UTF_8);
+        return parseDouble(stringValue);
+      case BINARY:
+        return toDouble(item);
+      default:
+        throw new IllegalArgumentException("Unsupported format: " + formatCode);
     }
   }
 
@@ -101,6 +105,14 @@ public class DoubleParser extends Parser<Double> {
       default:
         throw new IllegalArgumentException("unknown data format: " + format);
     }
+  }
+
+  public static void bind(
+      ImmutableMap.Builder<String, Value> parametersBuilder,
+      String name,
+      byte[] item,
+      FormatCode formatCode) {
+    parametersBuilder.put(name, toValue(toDouble(item, formatCode)));
   }
 
   @Override

--- a/src/main/java/com/google/cloud/spanner/pgadapter/parsers/FloatParser.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/parsers/FloatParser.java
@@ -42,18 +42,26 @@ public class FloatParser extends Parser<Float> {
   }
 
   FloatParser(byte[] item, FormatCode formatCode) {
-    if (item != null) {
-      switch (formatCode) {
-        case TEXT:
-          String stringValue = new String(item);
-          this.item = parseFloat(stringValue);
-          break;
-        case BINARY:
-          this.item = ByteConverter.float4(item, 0);
-          break;
-        default:
-          throw new IllegalArgumentException("Unsupported format: " + formatCode);
-      }
+    this.item = toFloat(item, formatCode);
+  }
+
+  /** Converts the given data to a float based on the format code. */
+  public static Float toFloat(byte[] item, FormatCode formatCode) {
+    if (item == null) {
+      return null;
+    }
+    switch (formatCode) {
+      case TEXT:
+        String stringValue = new String(item);
+        return parseFloat(stringValue);
+      case BINARY:
+        if (item.length < 4) {
+          throw SpannerExceptionFactory.newSpannerException(
+              ErrorCode.INVALID_ARGUMENT, "Invalid length for float4: " + item.length);
+        }
+        return ByteConverter.float4(item, 0);
+      default:
+        throw new IllegalArgumentException("Unsupported format: " + formatCode);
     }
   }
 
@@ -98,6 +106,14 @@ public class FloatParser extends Parser<Float> {
       default:
         throw new IllegalArgumentException("unknown data format: " + format);
     }
+  }
+
+  public static void bind(
+      ImmutableMap.Builder<String, Value> parametersBuilder,
+      String name,
+      byte[] item,
+      FormatCode formatCode) {
+    parametersBuilder.put(name, toValue(toFloat(item, formatCode)));
   }
 
   @Override

--- a/src/main/java/com/google/cloud/spanner/pgadapter/parsers/IntegerParser.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/parsers/IntegerParser.java
@@ -35,24 +35,27 @@ class IntegerParser extends Parser<Integer> {
   }
 
   IntegerParser(byte[] item, FormatCode formatCode) {
-    if (item != null) {
-      switch (formatCode) {
-        case TEXT:
-          String stringValue = new String(item);
-          try {
-            this.item =
-                new BigDecimal(stringValue).setScale(0, RoundingMode.HALF_UP).intValueExact();
-          } catch (Exception exception) {
-            throw PGExceptionFactory.newPGException(
-                "Invalid int4 value: " + stringValue, SQLState.SyntaxError);
-          }
-          break;
-        case BINARY:
-          this.item = ByteConverter.int4(item, 0);
-          break;
-        default:
-          throw new IllegalArgumentException("Unsupported format: " + formatCode);
-      }
+    this.item = toInteger(item, formatCode);
+  }
+
+  /** Converts the given data to an integer based on the format code. */
+  public static Integer toInteger(byte[] item, FormatCode formatCode) {
+    if (item == null) {
+      return null;
+    }
+    switch (formatCode) {
+      case TEXT:
+        String stringValue = new String(item);
+        try {
+          return new BigDecimal(stringValue).setScale(0, RoundingMode.HALF_UP).intValueExact();
+        } catch (Exception exception) {
+          throw PGExceptionFactory.newPGException(
+              "Invalid int4 value: " + stringValue, SQLState.SyntaxError);
+        }
+      case BINARY:
+        return ByteConverter.int4(item, 0);
+      default:
+        throw new IllegalArgumentException("Unsupported format: " + formatCode);
     }
   }
 
@@ -70,6 +73,15 @@ class IntegerParser extends Parser<Integer> {
     byte[] result = new byte[4];
     ByteConverter.int4(result, 0, value);
     return result;
+  }
+
+  public static void bind(
+      ImmutableMap.Builder<String, Value> parametersBuilder,
+      String name,
+      byte[] item,
+      FormatCode formatCode) {
+    Integer value = toInteger(item, formatCode);
+    parametersBuilder.put(name, Value.int64(value == null ? null : value.longValue()));
   }
 
   @Override

--- a/src/main/java/com/google/cloud/spanner/pgadapter/parsers/IntervalParser.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/parsers/IntervalParser.java
@@ -65,17 +65,21 @@ public class IntervalParser extends Parser<Interval> {
   }
 
   IntervalParser(byte[] item, FormatCode formatCode) {
-    if (item != null) {
-      switch (formatCode) {
-        case TEXT:
-          this.item = toInterval(new String(item, StandardCharsets.UTF_8));
-          break;
-        case BINARY:
-          this.item = toInterval(item);
-          break;
-        default:
-          throw new IllegalArgumentException("Unsupported format: " + formatCode);
-      }
+    this.item = toInterval(item, formatCode);
+  }
+
+  /** Converts the given data to an {@link Interval} based on the format code. */
+  public static Interval toInterval(byte[] item, FormatCode formatCode) {
+    if (item == null) {
+      return null;
+    }
+    switch (formatCode) {
+      case TEXT:
+        return toInterval(new String(item, StandardCharsets.UTF_8));
+      case BINARY:
+        return toInterval(item);
+      default:
+        throw new IllegalArgumentException("Unsupported format: " + formatCode);
     }
   }
 
@@ -174,6 +178,14 @@ public class IntervalParser extends Parser<Interval> {
         minutes[0],
         seconds[0],
         micros);
+  }
+
+  public static void bind(
+      ImmutableMap.Builder<String, Value> parametersBuilder,
+      String name,
+      byte[] item,
+      FormatCode formatCode) {
+    parametersBuilder.put(name, Value.interval(toInterval(item, formatCode)));
   }
 
   @Override

--- a/src/main/java/com/google/cloud/spanner/pgadapter/parsers/JsonbParser.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/parsers/JsonbParser.java
@@ -43,16 +43,21 @@ public class JsonbParser extends Parser<String> {
   }
 
   JsonbParser(byte[] item, FormatCode formatCode) {
-    if (item != null) {
-      switch (formatCode) {
-        case TEXT:
-          this.item = new String(item, UTF8);
-          break;
-        case BINARY:
-          this.item = toString(item);
-          break;
-        default:
-      }
+    this.item = toJsonbString(item, formatCode);
+  }
+
+  /** Converts the given data to a jsonb string based on the format code. */
+  public static String toJsonbString(byte[] item, FormatCode formatCode) {
+    if (item == null) {
+      return null;
+    }
+    switch (formatCode) {
+      case TEXT:
+        return new String(item, UTF8);
+      case BINARY:
+        return toString(item);
+      default:
+        throw new IllegalArgumentException("Unsupported format: " + formatCode);
     }
   }
 
@@ -124,6 +129,14 @@ public class JsonbParser extends Parser<String> {
       return ((ProtobufResultSet) resultSet).getProtobufValue(column).getStringValue();
     }
     return resultSet.getPgJsonb(column);
+  }
+
+  public static void bind(
+      ImmutableMap.Builder<String, Value> parametersBuilder,
+      String name,
+      byte[] item,
+      FormatCode formatCode) {
+    parametersBuilder.put(name, Value.pgJsonb(toJsonbString(item, formatCode)));
   }
 
   @Override

--- a/src/main/java/com/google/cloud/spanner/pgadapter/parsers/LongParser.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/parsers/LongParser.java
@@ -45,24 +45,27 @@ public class LongParser extends Parser<Long> {
   }
 
   LongParser(byte[] item, FormatCode formatCode) {
-    if (item != null) {
-      switch (formatCode) {
-        case TEXT:
-          String stringValue = new String(item);
-          try {
-            this.item =
-                new BigDecimal(stringValue).setScale(0, RoundingMode.HALF_UP).longValueExact();
-          } catch (Exception exception) {
-            throw PGExceptionFactory.newPGException(
-                "Invalid int8 value: " + stringValue, SQLState.SyntaxError);
-          }
-          break;
-        case BINARY:
-          this.item = toLong(item);
-          break;
-        default:
-          throw new IllegalArgumentException("Unsupported format: " + formatCode);
-      }
+    this.item = toLong(item, formatCode);
+  }
+
+  /** Converts the given data to a long based on the format code. */
+  public static Long toLong(byte[] item, FormatCode formatCode) {
+    if (item == null) {
+      return null;
+    }
+    switch (formatCode) {
+      case TEXT:
+        String stringValue = new String(item);
+        try {
+          return new BigDecimal(stringValue).setScale(0, RoundingMode.HALF_UP).longValueExact();
+        } catch (Exception exception) {
+          throw PGExceptionFactory.newPGException(
+              "Invalid int8 value: " + stringValue, SQLState.SyntaxError);
+        }
+      case BINARY:
+        return toLong(item);
+      default:
+        throw new IllegalArgumentException("Unsupported format: " + formatCode);
     }
   }
 
@@ -139,6 +142,14 @@ public class LongParser extends Parser<Long> {
       return ((ProtobufResultSet) resultSet).getProtobufValue(column).getStringValue();
     }
     return Long.toString(resultSet.getLong(column));
+  }
+
+  public static void bind(
+      ImmutableMap.Builder<String, Value> parametersBuilder,
+      String name,
+      byte[] item,
+      FormatCode formatCode) {
+    parametersBuilder.put(name, Value.int64(toLong(item, formatCode)));
   }
 
   @Override

--- a/src/main/java/com/google/cloud/spanner/pgadapter/parsers/NumericParser.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/parsers/NumericParser.java
@@ -44,17 +44,21 @@ public class NumericParser extends Parser<String> {
   }
 
   NumericParser(byte[] item, FormatCode formatCode) {
-    if (item != null) {
-      switch (formatCode) {
-        case TEXT:
-          this.item = new String(item);
-          break;
-        case BINARY:
-          this.item = toNumericString(item);
-          break;
-        default:
-          throw new IllegalArgumentException("Unsupported format: " + formatCode);
-      }
+    this.item = toNumericString(item, formatCode);
+  }
+
+  /** Converts the given data to a string representation of the numeric value. */
+  public static String toNumericString(byte[] item, FormatCode formatCode) {
+    if (item == null) {
+      return null;
+    }
+    switch (formatCode) {
+      case TEXT:
+        return new String(item);
+      case BINARY:
+        return toNumericString(item);
+      default:
+        throw new IllegalArgumentException("Unsupported format: " + formatCode);
     }
   }
 
@@ -106,6 +110,14 @@ public class NumericParser extends Parser<String> {
       default:
         throw new IllegalArgumentException("unknown data format: " + format);
     }
+  }
+
+  public static void bind(
+      ImmutableMap.Builder<String, Value> parametersBuilder,
+      String name,
+      byte[] item,
+      FormatCode formatCode) {
+    parametersBuilder.put(name, Value.pgNumeric(toNumericString(item, formatCode)));
   }
 
   @Override

--- a/src/main/java/com/google/cloud/spanner/pgadapter/parsers/Parser.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/parsers/Parser.java
@@ -272,6 +272,68 @@ public abstract class Parser<T> {
       case Oid.BIT:
         BooleanParser.bind(parametersBuilder, name, item, formatCode);
         break;
+      case Oid.BYTEA:
+      case Oid.BIT_ARRAY:
+        BinaryParser.bind(parametersBuilder, name, item, formatCode);
+        break;
+      case Oid.DATE:
+        DateParser.bind(parametersBuilder, name, item, formatCode);
+        break;
+      case Oid.FLOAT4:
+        FloatParser.bind(parametersBuilder, name, item, formatCode);
+        break;
+      case Oid.FLOAT8:
+        DoubleParser.bind(parametersBuilder, name, item, formatCode);
+        break;
+      case Oid.INT8:
+      case Oid.OID:
+        LongParser.bind(parametersBuilder, name, item, formatCode);
+        break;
+      case Oid.INT2:
+        ShortParser.bind(parametersBuilder, name, item, formatCode);
+        break;
+      case Oid.INT4:
+        IntegerParser.bind(parametersBuilder, name, item, formatCode);
+        break;
+      case Oid.NUMERIC:
+        NumericParser.bind(parametersBuilder, name, item, formatCode);
+        break;
+      case Oid.TEXT:
+      case Oid.VARCHAR:
+        StringParser.bind(parametersBuilder, name, item, formatCode);
+        break;
+      case Oid.UUID:
+        UuidParser.bind(parametersBuilder, name, item, formatCode);
+        break;
+      case Oid.TIMESTAMP:
+      case Oid.TIMESTAMPTZ:
+        TimestampParser.bind(parametersBuilder, name, item, formatCode, sessionState);
+        break;
+      case Oid.INTERVAL:
+        IntervalParser.bind(parametersBuilder, name, item, formatCode);
+        break;
+      case Oid.JSONB:
+        JsonbParser.bind(parametersBuilder, name, item, formatCode);
+        break;
+      case Oid.BOOL_ARRAY:
+      case Oid.BYTEA_ARRAY:
+      case Oid.DATE_ARRAY:
+      case Oid.FLOAT4_ARRAY:
+      case Oid.FLOAT8_ARRAY:
+      case Oid.INT2_ARRAY:
+      case Oid.INT4_ARRAY:
+      case Oid.INT8_ARRAY:
+      case Oid.OID_ARRAY:
+      case Oid.NUMERIC_ARRAY:
+      case Oid.TEXT_ARRAY:
+      case Oid.VARCHAR_ARRAY:
+      case Oid.UUID_ARRAY:
+      case Oid.TIMESTAMP_ARRAY:
+      case Oid.TIMESTAMPTZ_ARRAY:
+      case Oid.INTERVAL_ARRAY:
+      case Oid.JSONB_ARRAY:
+        ArrayParser.bind(parametersBuilder, name, item, oidType, formatCode, sessionState);
+        break;
       default:
         // Fallback to instance creation until all types are optimized with static bind methods.
         create(sessionState, item, oidType, formatCode).bind(parametersBuilder, name);

--- a/src/main/java/com/google/cloud/spanner/pgadapter/parsers/ShortParser.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/parsers/ShortParser.java
@@ -30,24 +30,27 @@ class ShortParser extends Parser<Short> {
   }
 
   ShortParser(byte[] item, FormatCode formatCode) {
-    if (item != null) {
-      switch (formatCode) {
-        case TEXT:
-          String stringValue = new String(item);
-          try {
-            this.item =
-                new BigDecimal(stringValue).setScale(0, RoundingMode.HALF_UP).shortValueExact();
-          } catch (Exception exception) {
-            throw PGExceptionFactory.newPGException(
-                "Invalid int2 value: " + stringValue, SQLState.SyntaxError);
-          }
-          break;
-        case BINARY:
-          this.item = ByteConverter.int2(item, 0);
-          break;
-        default:
-          throw new IllegalArgumentException("Unsupported format: " + formatCode);
-      }
+    this.item = toShort(item, formatCode);
+  }
+
+  /** Converts the given data to a short based on the format code. */
+  public static Short toShort(byte[] item, FormatCode formatCode) {
+    if (item == null) {
+      return null;
+    }
+    switch (formatCode) {
+      case TEXT:
+        String stringValue = new String(item);
+        try {
+          return new BigDecimal(stringValue).setScale(0, RoundingMode.HALF_UP).shortValueExact();
+        } catch (Exception exception) {
+          throw PGExceptionFactory.newPGException(
+              "Invalid int2 value: " + stringValue, SQLState.SyntaxError);
+        }
+      case BINARY:
+        return ByteConverter.int2(item, 0);
+      default:
+        throw new IllegalArgumentException("Unsupported format: " + formatCode);
     }
   }
 
@@ -65,6 +68,15 @@ class ShortParser extends Parser<Short> {
     byte[] result = new byte[2];
     ByteConverter.int2(result, 0, value);
     return result;
+  }
+
+  public static void bind(
+      ImmutableMap.Builder<String, Value> parametersBuilder,
+      String name,
+      byte[] item,
+      FormatCode formatCode) {
+    Short value = toShort(item, formatCode);
+    parametersBuilder.put(name, Value.int64(value == null ? null : value.longValue()));
   }
 
   @Override

--- a/src/main/java/com/google/cloud/spanner/pgadapter/parsers/StringParser.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/parsers/StringParser.java
@@ -115,6 +115,14 @@ public class StringParser extends Parser<String> {
     }
   }
 
+  public static void bind(
+      ImmutableMap.Builder<String, Value> parametersBuilder,
+      String name,
+      byte[] item,
+      FormatCode formatCode) {
+    parametersBuilder.put(name, Value.string(item == null ? null : toString(item)));
+  }
+
   @Override
   public void bind(ImmutableMap.Builder<String, Value> parametersBuilder, String name) {
     parametersBuilder.put(name, Value.string(this.item));

--- a/src/main/java/com/google/cloud/spanner/pgadapter/parsers/TimestampParser.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/parsers/TimestampParser.java
@@ -95,18 +95,22 @@ public class TimestampParser extends Parser<Timestamp> {
 
   TimestampParser(byte[] item, FormatCode formatCode, SessionState sessionState) {
     this.sessionState = sessionState;
-    if (item != null) {
-      switch (formatCode) {
-        case TEXT:
-          this.item =
-              toTimestamp(new String(item, StandardCharsets.UTF_8), sessionState.getTimezone());
-          break;
-        case BINARY:
-          this.item = toTimestamp(item);
-          break;
-        default:
-          throw new IllegalArgumentException("Unsupported format: " + formatCode);
-      }
+    this.item = toTimestamp(item, formatCode, sessionState);
+  }
+
+  /** Converts the given data to a {@link Timestamp} based on the format code. */
+  public static Timestamp toTimestamp(
+      byte[] item, FormatCode formatCode, SessionState sessionState) {
+    if (item == null) {
+      return null;
+    }
+    switch (formatCode) {
+      case TEXT:
+        return toTimestamp(new String(item, StandardCharsets.UTF_8), sessionState.getTimezone());
+      case BINARY:
+        return toTimestamp(item);
+      default:
+        throw new IllegalArgumentException("Unsupported format: " + formatCode);
     }
   }
 
@@ -243,6 +247,15 @@ public class TimestampParser extends Parser<Timestamp> {
         OffsetDateTime.ofInstant(
             Instant.ofEpochSecond(value.getSeconds(), value.getNanos()), zoneId);
     return TIMESTAMP_OUTPUT_FORMATTER.format(offsetDateTime);
+  }
+
+  public static void bind(
+      ImmutableMap.Builder<String, Value> parametersBuilder,
+      String name,
+      byte[] item,
+      FormatCode formatCode,
+      SessionState sessionState) {
+    parametersBuilder.put(name, Value.timestamp(toTimestamp(item, formatCode, sessionState)));
   }
 
   @Override

--- a/src/main/java/com/google/cloud/spanner/pgadapter/parsers/UnspecifiedParser.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/parsers/UnspecifiedParser.java
@@ -56,6 +56,21 @@ class UnspecifiedParser extends Parser<Value> {
         : this.item.getString().getBytes(StandardCharsets.UTF_8);
   }
 
+  public static void bind(
+      ImmutableMap.Builder<String, Value> parametersBuilder,
+      String name,
+      byte[] item,
+      FormatCode formatCode) {
+    parametersBuilder.put(
+        name,
+        item == null
+            ? NULL_VALUE
+            : Value.untyped(
+                com.google.protobuf.Value.newBuilder()
+                    .setStringValue(new String(item, StandardCharsets.UTF_8))
+                    .build()));
+  }
+
   @Override
   public void bind(ImmutableMap.Builder<String, Value> parametersBuilder, String name) {
     parametersBuilder.put(name, this.item == null ? NULL_VALUE : this.item);

--- a/src/main/java/com/google/cloud/spanner/pgadapter/parsers/UuidParser.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/parsers/UuidParser.java
@@ -40,16 +40,19 @@ public class UuidParser extends Parser<UUID> {
   }
 
   UuidParser(byte[] item, FormatCode formatCode) {
+    this.item = toUuid(item, formatCode);
+  }
+
+  /** Converts the given data to a UUID based on the format code. */
+  public static UUID toUuid(byte[] item, FormatCode formatCode) {
     switch (formatCode) {
       case TEXT:
-        this.item =
-            item == null ? null : verifyStringValue(new String(item, StandardCharsets.UTF_8));
-        break;
+        return item == null ? null : verifyStringValue(new String(item, StandardCharsets.UTF_8));
       case BINARY:
-        this.item = verifyBinaryValue(item);
-        break;
+        return verifyBinaryValue(item);
       default:
         handleInvalidFormat(formatCode);
+        return null;
     }
   }
 
@@ -131,6 +134,20 @@ public class UuidParser extends Parser<UUID> {
       default:
         throw new IllegalArgumentException("unknown data format: " + format);
     }
+  }
+
+  public static void bind(
+      ImmutableMap.Builder<String, Value> parametersBuilder,
+      String name,
+      byte[] item,
+      FormatCode formatCode) {
+    UUID uuid = toUuid(item, formatCode);
+    parametersBuilder.put(
+        name,
+        uuid == null
+            ? NULL_VALUE
+            : Value.untyped(
+                com.google.protobuf.Value.newBuilder().setStringValue(uuid.toString()).build()));
   }
 
   @Override


### PR DESCRIPTION
Use a static bind method for all parameter values. This reduces garbage collection pressure, as it does not create a Parser instance for each parameter value that is assigned.