### PR TITLE
fix: uuid[] param values were sent as text[] to Spanner

### DIFF
--- a/src/main/java/com/google/cloud/spanner/pgadapter/parsers/ArrayParser.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/parsers/ArrayParser.java
@@ -38,6 +38,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.UUID;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -426,6 +427,8 @@ public class ArrayParser extends Parser<List<?>> {
         parametersBuilder.put(name, Value.float64Array((List<Double>) list));
         break;
       case Oid.UUID:
+        parametersBuilder.put(name, Value.uuidArray((List<UUID>) list));
+        break;
       case Oid.VARCHAR:
       case Oid.TEXT:
         parametersBuilder.put(name, Value.stringArray((List<String>) list));

--- a/src/test/golang/pgadapter_pgx5_tests/pgx.go
+++ b/src/test/golang/pgadapter_pgx5_tests/pgx.go
@@ -288,6 +288,35 @@ func TestInsertAllDataTypes(connString string) *C.char {
 	return nil
 }
 
+//export TestInsertUUIDArray
+func TestInsertUUIDArray(connString string) *C.char {
+	ctx := context.Background()
+	conn, err := pgx.Connect(ctx, connString)
+	if err != nil {
+		return C.CString(err.Error())
+	}
+	defer func() { _ = conn.Close(ctx) }()
+
+	insertSql := "INSERT INTO my_test_table (id, uuid_arr) VALUES ($1, $2)"
+	id := "fe99a057-814d-4634-8f4f-e5807d89a34c"
+	uuid1 := "f6a94ced-78da-4142-9fe2-17afec5ad252"
+	uuid2 := "9e1e8554-1e2a-46b1-9778-f9167dabb4c7"
+	uuidArr := []string{uuid1, uuid2}
+
+	tag, err := conn.Exec(ctx, insertSql, id, uuidArr)
+	if err != nil {
+		return C.CString(fmt.Sprintf("failed to execute insert statement: %v", err))
+	}
+	if !tag.Insert() {
+		return C.CString("statement was not recognized as an insert")
+	}
+	if tag.RowsAffected() != 1 {
+		return C.CString(fmt.Sprintf("rows affected mismatch:\n Got: %v\nWant: 1", tag.RowsAffected()))
+	}
+
+	return nil
+}
+
 //export TestInsertNullsAllDataTypes
 func TestInsertNullsAllDataTypes(connString string) *C.char {
 	ctx := context.Background()

--- a/src/test/java/com/google/cloud/spanner/pgadapter/JdbcMockServerTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/JdbcMockServerTest.java
@@ -5067,6 +5067,62 @@ public class JdbcMockServerTest extends AbstractMockServerTest {
   }
 
   @Test
+  public void testUUIDArrayParameter() throws SQLException {
+    String jdbcSql = "INSERT INTO my_test_table (id, uuid_arr) VALUES (?, ?)";
+    String pgSql = "INSERT INTO my_test_table (id, uuid_arr) VALUES ($1, $2)";
+    UUID id = UUID.randomUUID();
+    UUID uuid1 = UUID.randomUUID();
+    UUID uuid2 = UUID.randomUUID();
+
+    mockSpanner.putStatementResult(
+        StatementResult.query(
+            Statement.of(pgSql),
+            com.google.spanner.v1.ResultSet.newBuilder()
+                .setMetadata(
+                    com.google.spanner.v1.ResultSetMetadata.newBuilder()
+                        .setUndeclaredParameters(
+                            StructType.newBuilder()
+                                .addFields(
+                                    Field.newBuilder()
+                                        .setName("p1")
+                                        .setType(Type.newBuilder().setCode(TypeCode.UUID).build())
+                                        .build())
+                                .addFields(
+                                    Field.newBuilder()
+                                        .setName("p2")
+                                        .setType(
+                                            Type.newBuilder()
+                                                .setCode(TypeCode.ARRAY)
+                                                .setArrayElementType(
+                                                    Type.newBuilder()
+                                                        .setCode(TypeCode.UUID)
+                                                        .build())
+                                                .build())
+                                        .build())
+                                .build()))
+                .build()));
+
+    mockSpanner.putPartialStatementResult(StatementResult.update(Statement.of(pgSql), 1L));
+
+    try (Connection connection = DriverManager.getConnection(createUrl())) {
+      try (PreparedStatement statement = connection.prepareStatement(jdbcSql)) {
+        statement.setObject(1, id);
+        statement.setArray(2, connection.createArrayOf("uuid", new UUID[] {uuid1, uuid2}));
+        assertEquals(1, statement.executeUpdate());
+      }
+    }
+
+    assertEquals(1, mockSpanner.countRequestsOfType(ExecuteSqlRequest.class));
+    ExecuteSqlRequest executeRequest =
+        mockSpanner.getRequestsOfType(ExecuteSqlRequest.class).get(0);
+    assertEquals(QueryMode.NORMAL, executeRequest.getQueryMode());
+    assertTrue(executeRequest.getParamTypesMap().containsKey("p2"));
+    assertEquals(TypeCode.ARRAY, executeRequest.getParamTypesMap().get("p2").getCode());
+    assertEquals(
+        TypeCode.UUID, executeRequest.getParamTypesMap().get("p2").getArrayElementType().getCode());
+  }
+
+  @Test
   public void testVacuumStatement_noTables() throws SQLException {
     try (Connection connection = DriverManager.getConnection(createUrl())) {
       connection.createStatement().execute("vacuum");

--- a/src/test/java/com/google/cloud/spanner/pgadapter/golang/Pgx5MockServerTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/golang/Pgx5MockServerTest.java
@@ -60,6 +60,7 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.Base64;
 import java.util.List;
+import java.util.UUID;
 import java.util.stream.Collectors;
 import org.junit.BeforeClass;
 import org.junit.Ignore;
@@ -450,6 +451,65 @@ public class Pgx5MockServerTest extends AbstractMockServerTest {
     ExecuteSqlRequest executeRequest = requests.get(1);
     assertEquals(sql, executeRequest.getSql());
     assertEquals(QueryMode.NORMAL, executeRequest.getQueryMode());
+  }
+
+  @Test
+  public void testInsertUUIDArray() {
+    String sql = "INSERT INTO my_test_table (id, uuid_arr) VALUES ($1, $2)";
+    UUID id = UUID.fromString("fe99a057-814d-4634-8f4f-e5807d89a34c");
+    UUID uuid1 = UUID.fromString("f6a94ced-78da-4142-9fe2-17afec5ad252");
+    UUID uuid2 = UUID.fromString("9e1e8554-1e2a-46b1-9778-f9167dabb4c7");
+
+    // Put PLAN result to tell pgx and PGAdapter the parameter types (uuid and uuid[])
+    mockSpanner.putStatementResult(
+        StatementResult.query(
+            Statement.of(sql),
+            com.google.spanner.v1.ResultSet.newBuilder()
+                .setMetadata(
+                    com.google.spanner.v1.ResultSetMetadata.newBuilder()
+                        .setUndeclaredParameters(
+                            StructType.newBuilder()
+                                .addFields(
+                                    Field.newBuilder()
+                                        .setName("p1")
+                                        .setType(Type.newBuilder().setCode(TypeCode.UUID).build())
+                                        .build())
+                                .addFields(
+                                    Field.newBuilder()
+                                        .setName("p2")
+                                        .setType(
+                                            Type.newBuilder()
+                                                .setCode(TypeCode.ARRAY)
+                                                .setArrayElementType(
+                                                    Type.newBuilder()
+                                                        .setCode(TypeCode.UUID)
+                                                        .build())
+                                                .build())
+                                        .build())
+                                .build()))
+                .setStats(com.google.spanner.v1.ResultSetStats.newBuilder().build())
+                .build()));
+
+    // Put actual update result using partial matching
+    mockSpanner.putPartialStatementResult(StatementResult.update(Statement.of(sql), 1L));
+
+    String res = pgxTest.TestInsertUUIDArray(createConnString());
+
+    assertNull(res);
+    List<ExecuteSqlRequest> requests = mockSpanner.getRequestsOfType(ExecuteSqlRequest.class);
+    assertEquals(2, requests.size());
+    ExecuteSqlRequest describeParamsRequest = requests.get(0);
+    assertEquals(sql, describeParamsRequest.getSql());
+    assertEquals(QueryMode.PLAN, describeParamsRequest.getQueryMode());
+    ExecuteSqlRequest executeRequest = requests.get(1);
+    assertEquals(sql, executeRequest.getSql());
+    assertEquals(QueryMode.NORMAL, executeRequest.getQueryMode());
+
+    // Explicitly verify the type codes received by Spanner for p2
+    assertTrue(executeRequest.getParamTypesMap().containsKey("p2"));
+    assertEquals(TypeCode.ARRAY, executeRequest.getParamTypesMap().get("p2").getCode());
+    assertEquals(
+        TypeCode.UUID, executeRequest.getParamTypesMap().get("p2").getArrayElementType().getCode());
   }
 
   @Test

--- a/src/test/java/com/google/cloud/spanner/pgadapter/golang/PgxTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/golang/PgxTest.java
@@ -31,6 +31,8 @@ public interface PgxTest extends Library {
 
   String TestInsertAllDataTypes(GoString connString);
 
+  String TestInsertUUIDArray(GoString connString);
+
   String TestInsertNullsAllDataTypes(GoString connString);
 
   String TestInsertAllDataTypesReturning(GoString connString);


### PR DESCRIPTION
UUID array parameter values were sent to Spanner as text array values. Spanner would subsequently reject the value, as there is no implicit conversion from text[] to uuid[] in Spanner.