### PR TITLE
chore: improve waitForPort implementation for Go wrapper

### DIFF
--- a/wrappers/golang/pgadapter.go
+++ b/wrappers/golang/pgadapter.go
@@ -431,6 +431,18 @@ func waitForPort(port int, initialWait, waitInterval time.Duration, maxAttempts 
 			time.Sleep(waitInterval)
 			continue
 		} else {
+			_ = conn.SetReadDeadline(time.Now().Add(10 * time.Millisecond))
+			var singleByte [1]byte
+			_, err := conn.Read(singleByte[:])
+			if err != nil {
+				if networkError, ok := err.(net.Error); ok && networkError.Timeout() {
+					_ = conn.Close()
+					return nil
+				}
+				_ = conn.Close()
+				time.Sleep(waitInterval)
+				continue
+			}
 			_ = conn.Close()
 			return nil
 		}

--- a/wrappers/golang/pgadapter_test.go
+++ b/wrappers/golang/pgadapter_test.go
@@ -84,23 +84,23 @@ func TestStart(t *testing.T) {
 			buf = append(buf, tmp[:n]...)
 		}
 		if g, w := len(buf), 42; g != w {
-			t.Fatalf("Received unexpected buffer length\nGot:  %v\nWant: %v", g, w)
+			t.Fatalf("%d: Received unexpected buffer length\nGot:  %v\nWant: %v", i, g, w)
 		}
 		if g, w := string(buf[0]), "E"; g != w {
-			t.Fatalf("Received unexpected server response type\nGot:  %v\nWant: %v", g, w)
+			t.Fatalf("%d: Received unexpected server response type\nGot:  %v\nWant: %v", i, g, w)
 		}
 		// The encoded message length does not include the message type, which is 1 byte long.
 		if g, w := binary.BigEndian.Uint32(buf[1:5]), uint32(36); g != w {
-			t.Fatalf("Received unexpected server response length\nGot:  %v\nWant: %v", g, w)
+			t.Fatalf("%d: Received unexpected server response length\nGot:  %v\nWant: %v", i, g, w)
 		}
 		if g, w := string(buf[20:35]), "Unknown message"; g != w {
-			t.Fatalf("Received unexpected error message\nGot:  %v\nWant: %v", g, w)
+			t.Fatalf("%d: Received unexpected error message\nGot:  %v\nWant: %v", i, g, w)
 		}
 		if g, w := string(buf[37]), "X"; g != w {
-			t.Fatalf("Missing terminate message\nGot:  %v\nWant: %v", g, w)
+			t.Fatalf("%d: Missing terminate message\nGot:  %v\nWant: %v", i, g, w)
 		}
 		if g, w := binary.BigEndian.Uint32(buf[38:]), uint32(4); g != w {
-			t.Fatalf("Received unexpected server response length\nGot:  %v\nWant: %v", g, w)
+			t.Fatalf("%d: Received unexpected server response length\nGot:  %v\nWant: %v", i, g, w)
 		}
 		err = pgadapter.Stop(context.Background())
 		if err != nil {


### PR DESCRIPTION
Improve the waitForPort implementation for the Go wrapper by trying to actually read something from the socket that we connect to. If that times out, then that is a good indication that we are actually connected to PGAdapter, as PGAdapter won't return any data unless the client writes something first.