### PR TITLE
test: Add America/Vancouver to problematic timezone ignore list

### DIFF
--- a/src/test/java/com/google/cloud/spanner/pgadapter/ITPsqlTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/ITPsqlTest.java
@@ -964,6 +964,8 @@ public class ITPsqlTest implements IntegrationTest {
           // Nuuk stopped using DST in 2023. This is unknown to older JDKs.
           ZoneId.of("America/Nuuk"),
           ZoneId.of("America/Godthab"),
+          // Vancouver DST rules differ for future timestamps in some timezone databases.
+          ZoneId.of("America/Vancouver"),
           // Antarctica has multiple differences between databases.
           ZoneId.of("Antarctica/Vostok"),
           ZoneId.of("Antarctica/Casey"),


### PR DESCRIPTION
Fixes #4473

Adds `America/Vancouver` to the `ITPsqlTest` problematic timezone ignore list because PostgreSQL and PGAdapter can produce different offsets for future timestamps depending on the timezone database.

Verification:
- `mvn com.spotify.fmt:fmt-maven-plugin:check -B -ntp`