### PR TITLE
chore: deprecate experimental host option/parameter

### DIFF
--- a/src/main/java/com/google/cloud/spanner/pgadapter/metadata/OptionsMetadata.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/metadata/OptionsMetadata.java
@@ -33,14 +33,13 @@ import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import com.google.spanner.v1.DatabaseName;
-import io.grpc.ExperimentalApi;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.time.Duration;
-import java.util.HashMap;
 import java.util.Map;
+import java.util.TreeMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.annotation.Nullable;
@@ -445,20 +444,6 @@ public class OptionsMetadata {
     Builder useClientCert(String clientCertificate, String clientKey) {
       this.clientCertificate = clientCertificate;
       this.clientKey = clientKey;
-      return this;
-    }
-
-    /**
-     * Configures connection to an experimental host endpoint
-     *
-     * @param experimentalHost url of the experimental host endpoint
-     * @deprecated Use {@link #setType(String)} and {@link #setEndpoint(String)} instead.
-     */
-    @ExperimentalApi("https://github.com/googleapis/java-spanner/pull/3574")
-    @Deprecated
-    Builder setExperimentalHost(String experimentalHost) {
-      setEndpoint(experimentalHost);
-      setType(SPANNER_OMNI_TYPE);
       return this;
     }
 
@@ -947,7 +932,7 @@ public class OptionsMetadata {
     this.ddlTransactionMode = DdlTransactionMode.AutocommitImplicitTransaction;
     this.replaceJdbcMetadataQueries = replaceJdbcMetadataQueries;
     this.commandMetadataJSON = commandMetadata;
-    this.propertyMap = new HashMap<>();
+    this.propertyMap = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
     this.disableLocalhostCheck = false;
     this.serverVersion = DEFAULT_SERVER_VERSION;
     this.debugMode = false;
@@ -958,7 +943,7 @@ public class OptionsMetadata {
   }
 
   private Map<String, String> parseProperties(String propertyOptions) {
-    Map<String, String> properties = new HashMap<>();
+    Map<String, String> properties = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
     if (!propertyOptions.isEmpty()) {
       String[] propertyList = propertyOptions.split(";");
       for (int i = 0; i < propertyList.length; ++i) {

--- a/src/main/java/com/google/cloud/spanner/pgadapter/metadata/OptionsMetadata.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/metadata/OptionsMetadata.java
@@ -65,10 +65,15 @@ public class OptionsMetadata {
 
   static Duration DEFAULT_STARTUP_TIMEOUT = Duration.ofSeconds(30L);
 
-  private static final String EXTERNAL_HOST_PROJECT = "default";
-  private static final String EXTERNAL_HOST_INSTANCE = "default";
+  private static final String SPANNER_OMNI_PROJECT = "default";
+  private static final String SPANNER_OMNI_INSTANCE = "default";
 
-  private static final String IS_EXPERIMENTAL_HOST_PROPERTY_NAME = "isExperimentalHost";
+  /**
+   * @deprecated use {@link #TYPE_PROPERTY_NAME} instead.
+   */
+  private static final String TYPE_PROPERTY_NAME = "type";
+
+  private static final String SPANNER_OMNI_TYPE = "omni";
 
   /**
    * Builder class for creating an instance of {@link OptionsMetadata}.
@@ -116,7 +121,8 @@ public class OptionsMetadata {
     private Duration startupTimeout = DEFAULT_STARTUP_TIMEOUT;
     private String clientCertificate;
     private String clientKey;
-    private boolean isExperimentalHost = false;
+
+    private String type = null;
     private Long describeCacheExpireMinutes;
     private Long describeCacheMaxSize;
 
@@ -431,27 +437,38 @@ public class OptionsMetadata {
 
     /**
      * Configures mTLS authentication using the provided client certificate and key files. mTLS is
-     * only supported for experimental spanner hosts.
+     * only supported for Spanner Omni endpoints.
      *
      * @param clientCertificate Path to the client certificate file.
      * @param clientKey Path to the client private key file.
      */
-    @ExperimentalApi("https://github.com/googleapis/java-spanner/pull/3574")
     Builder useClientCert(String clientCertificate, String clientKey) {
       this.clientCertificate = clientCertificate;
       this.clientKey = clientKey;
       return this;
     }
 
-    /*
+    /**
      * Configures connection to an experimental host endpoint
      *
-     * @params experimentalHost url of the experimental host endpoint
+     * @param experimentalHost url of the experimental host endpoint
+     * @deprecated Use {@link #setType(String)} and {@link #setEndpoint(String)} instead.
      */
     @ExperimentalApi("https://github.com/googleapis/java-spanner/pull/3574")
+    @Deprecated
     Builder setExperimentalHost(String experimentalHost) {
       setEndpoint(experimentalHost);
-      this.isExperimentalHost = true;
+      setType(SPANNER_OMNI_TYPE);
+      return this;
+    }
+
+    /**
+     * Configures the connection instance type.
+     *
+     * @param type connection type, e.g., "OMNI"
+     */
+    Builder setType(String type) {
+      this.type = type;
       return this;
     }
 
@@ -546,7 +563,7 @@ public class OptionsMetadata {
           || useVirtualGrpcTransportThreads
           || enableEndToEndTracing
           || (clientKey != null && clientCertificate != null)
-          || isExperimentalHost) {
+          || SPANNER_OMNI_TYPE.equalsIgnoreCase(this.type)) {
         StringBuilder jdbcOptionBuilder = new StringBuilder();
         if (usePlainText) {
           jdbcOptionBuilder.append("usePlainText=true;");
@@ -572,8 +589,8 @@ public class OptionsMetadata {
           jdbcOptionBuilder.append("clientCertificate=").append(clientCertificate).append(";");
           jdbcOptionBuilder.append("clientKey=").append(clientKey).append(";");
         }
-        if (isExperimentalHost) {
-          jdbcOptionBuilder.append("isExperimentalHost=true;");
+        if (SPANNER_OMNI_TYPE.equalsIgnoreCase(this.type)) {
+          jdbcOptionBuilder.append("type=omni;");
         }
         addOption(args, OPTION_JDBC_PROPERTIES, jdbcOptionBuilder.toString());
       }
@@ -789,7 +806,7 @@ public class OptionsMetadata {
     if (!propertyMap.containsKey("defaultSequenceKind")) {
       propertyMap.put("defaultSequenceKind", "bit_reversed_positive");
     }
-    boolean usesExperimentalHost = isExperimentalHost(commandLine, propertyMap);
+    boolean usesOmniType = hasOmniType(commandLine, propertyMap);
 
     this.environment = environment;
     this.osName = osName;
@@ -807,7 +824,7 @@ public class OptionsMetadata {
               + "OR use -c to set the credentials in PGAdapter and use these credentials for all connections.");
     }
     if (this.commandLine.hasOption(OPTION_DATABASE_NAME)
-        && !usesExperimentalHost
+        && !usesOmniType
         && !(this.commandLine.hasOption(OPTION_PROJECT_ID)
             && this.commandLine.hasOption(OPTION_INSTANCE_ID))) {
       throw SpannerExceptionFactory.newSpannerException(
@@ -816,7 +833,7 @@ public class OptionsMetadata {
               + "Use the options -p <project-id> -i <instance-id> -d <database-id> to specify the "
               + "database that all connections to this instance of PGAdapter should use.");
     }
-    if ((usesExperimentalHost
+    if ((usesOmniType
             || (this.commandLine.hasOption(OPTION_PROJECT_ID)
                 && this.commandLine.hasOption(OPTION_INSTANCE_ID)))
         && this.commandLine.hasOption(OPTION_DATABASE_NAME)) {
@@ -1109,7 +1126,7 @@ public class OptionsMetadata {
    */
   public String buildCredentialsFile() {
     // Skip if a com.google.auth.Credentials instance has been set.
-    if (isExperimentalHost() || credentials != null) {
+    if (hasOmniType() || credentials != null) {
       return null;
     }
     if (!commandLine.hasOption(OPTION_CREDENTIALS_FILE)) {
@@ -1199,23 +1216,23 @@ public class OptionsMetadata {
         || isAutoConfigEmulator(propertyMap);
   }
 
-  private boolean isExperimentalHost() {
+  private boolean hasOmniType() {
     if (this.propertyMap == null) {
-      return isExperimentalHost(
+      return hasOmniType(
           this.commandLine,
           parseProperties(this.commandLine.getOptionValue(OPTION_JDBC_PROPERTIES, "")));
     }
-    return isExperimentalHost(this.commandLine, this.propertyMap);
+    return hasOmniType(this.commandLine, this.propertyMap);
   }
 
-  private static boolean isExperimentalHost(
-      CommandLine commandLine, Map<String, String> propertyMap) {
+  private static boolean hasOmniType(CommandLine commandLine, Map<String, String> propertyMap) {
     if (propertyMap == null) {
       return false;
     }
     return commandLine.hasOption(OPTION_SPANNER_ENDPOINT)
-        && commandLine.hasOption(OPTION_JDBC_PROPERTIES)
-        && propertyMap.containsKey(IS_EXPERIMENTAL_HOST_PROPERTY_NAME);
+        && (commandLine.hasOption(OPTION_JDBC_PROPERTIES)
+            && (propertyMap.containsKey("isExperimentalHost")
+                || SPANNER_OMNI_TYPE.equalsIgnoreCase(propertyMap.get(TYPE_PROPERTY_NAME))));
   }
 
   /** Returns the fully qualified database name based on the given database id or name. */
@@ -1227,8 +1244,8 @@ public class OptionsMetadata {
       String projectId;
       if (commandLine.hasOption(OPTION_PROJECT_ID)) {
         projectId = commandLine.getOptionValue(OPTION_PROJECT_ID);
-      } else if (isExperimentalHost()) {
-        projectId = EXTERNAL_HOST_PROJECT;
+      } else if (hasOmniType()) {
+        projectId = SPANNER_OMNI_PROJECT;
       } else {
         projectId = getDefaultProjectId();
       }
@@ -1242,8 +1259,8 @@ public class OptionsMetadata {
       String instanceId;
       if (commandLine.hasOption(OPTION_INSTANCE_ID)) {
         instanceId = commandLine.getOptionValue(OPTION_INSTANCE_ID);
-      } else if (isExperimentalHost()) {
-        instanceId = EXTERNAL_HOST_INSTANCE;
+      } else if (hasOmniType()) {
+        instanceId = SPANNER_OMNI_INSTANCE;
       } else {
         throw SpannerExceptionFactory.newSpannerException(
             ErrorCode.FAILED_PRECONDITION,
@@ -1682,11 +1699,11 @@ public class OptionsMetadata {
   public DatabaseId getDefaultDatabaseId() {
     return this.hasDefaultConnectionUrl()
         ? DatabaseId.of(
-            !commandLine.hasOption(OPTION_PROJECT_ID) && isExperimentalHost()
-                ? EXTERNAL_HOST_PROJECT
+            !commandLine.hasOption(OPTION_PROJECT_ID) && hasOmniType()
+                ? SPANNER_OMNI_PROJECT
                 : commandLine.getOptionValue(OPTION_PROJECT_ID),
-            !commandLine.hasOption(OPTION_INSTANCE_ID) && isExperimentalHost()
-                ? EXTERNAL_HOST_INSTANCE
+            !commandLine.hasOption(OPTION_INSTANCE_ID) && hasOmniType()
+                ? SPANNER_OMNI_INSTANCE
                 : commandLine.getOptionValue(OPTION_INSTANCE_ID),
             commandLine.getOptionValue(OPTION_DATABASE_NAME))
         : null;
@@ -1694,7 +1711,7 @@ public class OptionsMetadata {
 
   /** Returns true if these options contain a default instance id. */
   public boolean hasDefaultInstanceId() {
-    return isExperimentalHost()
+    return hasOmniType()
         || (commandLine.hasOption(OPTION_PROJECT_ID) && commandLine.hasOption(OPTION_INSTANCE_ID));
   }
 
@@ -1702,11 +1719,11 @@ public class OptionsMetadata {
   public InstanceId getDefaultInstanceId() {
     if (hasDefaultInstanceId()) {
       return InstanceId.of(
-          !commandLine.hasOption(OPTION_PROJECT_ID) && isExperimentalHost()
-              ? EXTERNAL_HOST_PROJECT
+          !commandLine.hasOption(OPTION_PROJECT_ID) && hasOmniType()
+              ? SPANNER_OMNI_PROJECT
               : commandLine.getOptionValue(OPTION_PROJECT_ID),
-          !commandLine.hasOption(OPTION_INSTANCE_ID) && isExperimentalHost()
-              ? EXTERNAL_HOST_INSTANCE
+          !commandLine.hasOption(OPTION_INSTANCE_ID) && hasOmniType()
+              ? SPANNER_OMNI_INSTANCE
               : commandLine.getOptionValue(OPTION_INSTANCE_ID));
     }
     return null;

--- a/src/test/java/com/google/cloud/spanner/pgadapter/ITAuthTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/ITAuthTest.java
@@ -55,7 +55,7 @@ public class ITAuthTest implements IntegrationTest {
 
   @BeforeClass
   public static void setup() throws ClassNotFoundException {
-    IntegrationTest.skipOnExperimentalHost("Cloud auth is not applicable for experimental host");
+    IntegrationTest.skipOnSpannerOmni("Cloud auth is not applicable for Spanner Omni");
     // Make sure the PG JDBC driver is loaded.
     Class.forName("org.postgresql.Driver");
 

--- a/src/test/java/com/google/cloud/spanner/pgadapter/ITOpenTelemetryTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/ITOpenTelemetryTest.java
@@ -56,7 +56,7 @@ public class ITOpenTelemetryTest implements IntegrationTest {
   @BeforeClass
   public static void setup() throws IOException {
     IntegrationTest.skipOnEmulator("This test requires credentials");
-    IntegrationTest.skipOnExperimentalHost("Cloud auth is not applicable for experimental host");
+    IntegrationTest.skipOnSpannerOmni("Cloud auth is not applicable for Spanner Omni");
 
     OptionsMetadata.Builder openTelemetryOptionsBuilder =
         OptionsMetadata.newBuilder()

--- a/src/test/java/com/google/cloud/spanner/pgadapter/IntegrationTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/IntegrationTest.java
@@ -22,15 +22,15 @@ public interface IntegrationTest {
     assumeFalse(reason, isRunningOnEmulator());
   }
 
-  static void skipOnExperimentalHost(String reason) {
-    assumeFalse(reason, isRunningOnExperimentalHost());
+  static void skipOnSpannerOmni(String reason) {
+    assumeFalse(reason, isRunningOnSpannerOmni());
   }
 
   static boolean isRunningOnEmulator() {
     return System.getenv("SPANNER_EMULATOR_HOST") != null;
   }
 
-  static boolean isRunningOnExperimentalHost() {
-    return System.getProperty("SPANNER_EXPERIMENTAL_HOST") != null;
+  static boolean isRunningOnSpannerOmni() {
+    return System.getProperty("SPANNER_OMNI_HOST") != null;
   }
 }

--- a/src/test/java/com/google/cloud/spanner/pgadapter/PgAdapterTestEnv.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/PgAdapterTestEnv.java
@@ -43,7 +43,6 @@ import com.google.common.collect.Iterables;
 import com.google.common.primitives.Bytes;
 import com.google.spanner.admin.database.v1.CreateDatabaseMetadata;
 import com.google.spanner.admin.database.v1.UpdateDatabaseDdlMetadata;
-import io.grpc.ManagedChannelBuilder;
 import io.opentelemetry.api.OpenTelemetry;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
@@ -114,8 +113,13 @@ public class PgAdapterTestEnv {
   // Default Spanner url. Null indicates that the default URL should be used.
   static final String DEFAULT_SPANNER_URL = null;
 
-  public static final String SPANNER_EXPERIMENTAL_HOST =
-      System.getProperty("SPANNER_EXPERIMENTAL_HOST", null);
+  public static final String SPANNER_OMNI_HOST = System.getProperty("SPANNER_OMNI_HOST", null);
+  private static final boolean USE_PLAIN_TEXT =
+      Boolean.parseBoolean(System.getProperty("USE_PLAIN_TEXT", "false"));
+  public static final String SPANNER_OMNI_CLIENT_KEY =
+      System.getProperty("SPANNER_OMNI_CLIENT_KEY", null);
+  public static final String SPANNER_OMNI_CLIENT_CERT =
+      System.getProperty("SPANNER_OMNI_CLIENT_CERT", null);
 
   public static final ImmutableList<String> DEFAULT_DATA_MODEL =
       ImmutableList.of(
@@ -239,7 +243,7 @@ public class PgAdapterTestEnv {
 
   private void startPGAdapterServer(
       String databaseId, Iterable<String> additionalPGAdapterOptions, OpenTelemetry openTelemetry) {
-    if (PG_ADAPTER_ADDRESS == null && SPANNER_EXPERIMENTAL_HOST == null) {
+    if (PG_ADAPTER_ADDRESS == null && SPANNER_OMNI_HOST == null) {
       additionalPGAdapterOptions = maybeAddAutoConfigEmulator(additionalPGAdapterOptions);
       String credentials = getCredentials();
       ImmutableList.Builder<String> argsListBuilder =
@@ -262,14 +266,20 @@ public class PgAdapterTestEnv {
       String[] args = argsListBuilder.build().toArray(new String[0]);
       server = new ProxyServer(new OptionsMetadata(args), openTelemetry);
       server.startServer();
-    } else if (SPANNER_EXPERIMENTAL_HOST != null) {
+    } else if (SPANNER_OMNI_HOST != null) {
+      StringBuilder rOption = new StringBuilder();
+      if (USE_PLAIN_TEXT) {
+        rOption.append("usePlainText=true;");
+      }
+      if (SPANNER_OMNI_CLIENT_CERT != null && SPANNER_OMNI_CLIENT_KEY != null) {
+        rOption.append(
+            String.format(
+                "clientCertificate=%s;clientKey=%s;",
+                SPANNER_OMNI_CLIENT_CERT, SPANNER_OMNI_CLIENT_KEY));
+      }
+      rOption.append("type=omni");
       ImmutableList.Builder<String> argsListBuilder =
-          ImmutableList.<String>builder()
-              .add(
-                  "-e",
-                  SPANNER_EXPERIMENTAL_HOST,
-                  "-r",
-                  "isExperimentalHost=true;usePlainText=true");
+          ImmutableList.<String>builder().add("-e", SPANNER_OMNI_HOST, "-r", rOption.toString());
       if (databaseId != null) {
         argsListBuilder.add("-d", databaseId);
       }
@@ -369,8 +379,8 @@ public class PgAdapterTestEnv {
     if (hostUrl == null) {
       hostUrl = System.getProperty(TEST_SPANNER_URL_PROPERTY, DEFAULT_SPANNER_URL);
     }
-    if (SPANNER_EXPERIMENTAL_HOST != null) {
-      hostUrl = SPANNER_EXPERIMENTAL_HOST;
+    if (SPANNER_OMNI_HOST != null) {
+      hostUrl = SPANNER_OMNI_HOST;
     }
     return hostUrl;
   }
@@ -383,7 +393,7 @@ public class PgAdapterTestEnv {
     if (projectId == null) {
       projectId = System.getProperty(TEST_PROJECT_PROPERTY, DEFAULT_PROJECT_ID);
     }
-    if (SPANNER_EXPERIMENTAL_HOST != null) {
+    if (SPANNER_OMNI_HOST != null) {
       projectId = "default";
     }
     return projectId;
@@ -393,7 +403,7 @@ public class PgAdapterTestEnv {
     if (instanceId == null) {
       instanceId = System.getProperty(TEST_INSTANCE_PROPERTY, DEFAULT_INSTANCE_ID);
     }
-    if (SPANNER_EXPERIMENTAL_HOST != null) {
+    if (SPANNER_OMNI_HOST != null) {
       instanceId = "default";
     }
     return instanceId;
@@ -545,7 +555,7 @@ public class PgAdapterTestEnv {
     Map<String, String> env = System.getenv();
     gcpCredentials = env.get(GCP_CREDENTIALS);
     GoogleCredentials credentials = null;
-    if (!Strings.isNullOrEmpty(gcpCredentials) && SPANNER_EXPERIMENTAL_HOST == null) {
+    if (!Strings.isNullOrEmpty(gcpCredentials) && SPANNER_OMNI_HOST == null) {
       try {
         credentials = GoogleCredentials.fromStream(new FileInputStream(gcpCredentials));
       } catch (IOException e) {
@@ -580,15 +590,18 @@ public class PgAdapterTestEnv {
       builder.setHost(spannerHost);
     }
 
-    if (SPANNER_EXPERIMENTAL_HOST != null) {
-      if (!SPANNER_EXPERIMENTAL_HOST.startsWith("http")) {
-        builder.setExperimentalHost("http://" + SPANNER_EXPERIMENTAL_HOST);
+    if (SPANNER_OMNI_HOST != null) {
+      if (!SPANNER_OMNI_HOST.startsWith("http")) {
+        builder.setHost("http://" + SPANNER_OMNI_HOST).setType(SpannerOptions.InstanceType.OMNI);
       } else {
-        builder.setExperimentalHost(SPANNER_EXPERIMENTAL_HOST);
+        builder.setHost(SPANNER_OMNI_HOST).setType(SpannerOptions.InstanceType.OMNI);
       }
-      builder
-          .setChannelConfigurator(ManagedChannelBuilder::usePlaintext)
-          .setCredentials(NoCredentials.getInstance());
+      if (USE_PLAIN_TEXT) {
+        builder.usePlainText();
+      }
+      if (SPANNER_OMNI_CLIENT_CERT != null && SPANNER_OMNI_CLIENT_KEY != null) {
+        builder.useClientCert(SPANNER_OMNI_CLIENT_CERT, SPANNER_OMNI_CLIENT_KEY);
+      }
       credentials = null;
     }
 

--- a/src/test/java/com/google/cloud/spanner/pgadapter/PgAdapterTestEnv.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/PgAdapterTestEnv.java
@@ -17,6 +17,7 @@ package com.google.cloud.spanner.pgadapter;
 import static org.junit.Assert.assertEquals;
 
 import com.google.api.gax.longrunning.OperationFuture;
+import com.google.auth.Credentials;
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.cloud.NoCredentials;
 import com.google.cloud.spanner.Database;
@@ -554,7 +555,7 @@ public class PgAdapterTestEnv {
 
     Map<String, String> env = System.getenv();
     gcpCredentials = env.get(GCP_CREDENTIALS);
-    GoogleCredentials credentials = null;
+    Credentials credentials = null;
     if (!Strings.isNullOrEmpty(gcpCredentials) && SPANNER_OMNI_HOST == null) {
       try {
         credentials = GoogleCredentials.fromStream(new FileInputStream(gcpCredentials));
@@ -591,18 +592,16 @@ public class PgAdapterTestEnv {
     }
 
     if (SPANNER_OMNI_HOST != null) {
-      if (!SPANNER_OMNI_HOST.startsWith("http")) {
-        builder.setHost("http://" + SPANNER_OMNI_HOST).setType(SpannerOptions.InstanceType.OMNI);
-      } else {
-        builder.setHost(SPANNER_OMNI_HOST).setType(SpannerOptions.InstanceType.OMNI);
-      }
+      builder
+          .setHost((USE_PLAIN_TEXT ? "http://" : "https://") + SPANNER_OMNI_HOST)
+          .setType(SpannerOptions.InstanceType.OMNI);
       if (USE_PLAIN_TEXT) {
         builder.usePlainText();
       }
       if (SPANNER_OMNI_CLIENT_CERT != null && SPANNER_OMNI_CLIENT_KEY != null) {
         builder.useClientCert(SPANNER_OMNI_CLIENT_CERT, SPANNER_OMNI_CLIENT_KEY);
       }
-      credentials = null;
+      credentials = NoCredentials.getInstance();
     }
 
     if (System.getProperty(CHANNEL_PROVIDER_PROPERTY) == null && credentials != null) {

--- a/src/test/java/com/google/cloud/spanner/pgadapter/liquibase/ITLiquibaseTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/liquibase/ITLiquibaseTest.java
@@ -224,24 +224,20 @@ public class ITLiquibaseTest {
         ImmutableList.<String>builder().add("mvn", "-B").add(commands).build();
     builder.command(liquibaseCommand);
     builder.directory(new File(LIQUIBASE_SAMPLE_DIRECTORY));
+    builder.redirectErrorStream(true);
     Process process = builder.start();
 
-    String errors;
     String output;
 
     try (BufferedReader reader =
-            new BufferedReader(new InputStreamReader(process.getInputStream()));
-        BufferedReader errorReader =
-            new BufferedReader(new InputStreamReader(process.getErrorStream()))) {
-      errors = errorReader.lines().collect(Collectors.joining("\n"));
+        new BufferedReader(new InputStreamReader(process.getInputStream()))) {
       output = reader.lines().collect(Collectors.joining("\n"));
     }
 
-    LOGGER.warning(errors);
     LOGGER.info(output);
 
     int res = process.waitFor();
-    assertEquals(errors, 0, res);
+    assertEquals(output, 0, res);
   }
 
   private static int getJavaMajorVersion() {

--- a/src/test/java/com/google/cloud/spanner/pgadapter/metadata/OptionsMetadataTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/metadata/OptionsMetadataTest.java
@@ -669,7 +669,7 @@ public class OptionsMetadataTest {
   }
 
   @Test
-  public void testExternalHostConfigurations() {
+  public void testExperimentalHostConfigurations() {
     assertEquals(
         DatabaseId.of("default", "default", "test_db"),
         (new OptionsMetadata(
@@ -717,6 +717,60 @@ public class OptionsMetadataTest {
         OptionsMetadata.newBuilder()
             .setEnvironment(ImmutableMap.of("SPANNER_EMULATOR_HOST", "localhost:9010"))
             .setExperimentalHost("localhost:8000")
+            .setDatabase("test_db")
+            .build()
+            .getDefaultDatabaseId());
+  }
+
+  @Test
+  public void testSpannerOmniConfigurations() {
+    assertEquals(
+        DatabaseId.of("default", "default", "test_db"),
+        (new OptionsMetadata(
+                new String[] {"-d", "test_db", "-e", "localhost:8000", "-r", "type=omni"}))
+            .getDefaultDatabaseId());
+    SpannerException spannerException =
+        assertThrows(
+            SpannerException.class,
+            () ->
+                new OptionsMetadata(
+                    new String[] {
+                      "-d", "test_db", "-e", "spanner.googleapis.com:443", "-c", "credentials.json"
+                    }));
+    assertEquals(ErrorCode.INVALID_ARGUMENT, spannerException.getErrorCode());
+    assertEquals(
+        DatabaseId.of("default", "default", "test_db"),
+        OptionsMetadata.newBuilder()
+            .setEndpoint("localhost:8000")
+            .setType("OMNI")
+            .setDatabase("test_db")
+            .build()
+            .getDefaultDatabaseId());
+    spannerException =
+        assertThrows(
+            SpannerException.class,
+            () ->
+                OptionsMetadata.newBuilder()
+                    .setEndpoint("spanner.googleapis.com")
+                    .setDatabase("test_db")
+                    .build());
+    assertEquals(ErrorCode.INVALID_ARGUMENT, spannerException.getErrorCode());
+    spannerException =
+        assertThrows(
+            SpannerException.class,
+            () ->
+                OptionsMetadata.newBuilder()
+                    .setEnvironment(ImmutableMap.of("SPANNER_EMULATOR_HOST", "localhost:9010"))
+                    .setEndpoint("localhost:8000")
+                    .setDatabase("test_db")
+                    .build());
+    assertEquals(ErrorCode.INVALID_ARGUMENT, spannerException.getErrorCode());
+    assertEquals(
+        DatabaseId.of("default", "default", "test_db"),
+        OptionsMetadata.newBuilder()
+            .setEnvironment(ImmutableMap.of("SPANNER_EMULATOR_HOST", "localhost:9010"))
+            .setEndpoint("localhost:8000")
+            .setType("OMNI")
             .setDatabase("test_db")
             .build()
             .getDefaultDatabaseId());

--- a/src/test/java/com/google/cloud/spanner/pgadapter/metadata/OptionsMetadataTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/metadata/OptionsMetadataTest.java
@@ -689,7 +689,8 @@ public class OptionsMetadataTest {
     assertEquals(
         DatabaseId.of("default", "default", "test_db"),
         OptionsMetadata.newBuilder()
-            .setExperimentalHost("localhost:8000")
+            .setEndpoint("localhost:8000")
+            .setType("omni")
             .setDatabase("test_db")
             .build()
             .getDefaultDatabaseId());
@@ -716,7 +717,8 @@ public class OptionsMetadataTest {
         DatabaseId.of("default", "default", "test_db"),
         OptionsMetadata.newBuilder()
             .setEnvironment(ImmutableMap.of("SPANNER_EMULATOR_HOST", "localhost:9010"))
-            .setExperimentalHost("localhost:8000")
+            .setEndpoint("localhost:8000")
+            .setType("omni")
             .setDatabase("test_db")
             .build()
             .getDefaultDatabaseId());
@@ -728,6 +730,18 @@ public class OptionsMetadataTest {
         DatabaseId.of("default", "default", "test_db"),
         (new OptionsMetadata(
                 new String[] {"-d", "test_db", "-e", "localhost:8000", "-r", "type=omni"}))
+            .getDefaultDatabaseId());
+    assertEquals(
+        DatabaseId.of("default", "default", "test_db"),
+        (new OptionsMetadata(
+                new String[] {"-d", "test_db", "-e", "localhost:8000", "-r", "Type=OMNI"}))
+            .getDefaultDatabaseId());
+    assertEquals(
+        DatabaseId.of("default", "default", "test_db"),
+        (new OptionsMetadata(
+                new String[] {
+                  "-d", "test_db", "-e", "localhost:8000", "-r", "IsExperimentalHost=true"
+                }))
             .getDefaultDatabaseId());
     SpannerException spannerException =
         assertThrows(


### PR DESCRIPTION
Uptaking change in https://github.com/googleapis/google-cloud-java/pull/13236 to deprecate (experimental host / external host) parameters / options to uptake the new Type parameter

To run Integration test against Spanner Omni use below parameters:
```
-DUSE_PLAIN_TEXT=true
-DSPANNER_OMNI_HOST=localhost:15000
-DSPANNER_OMNI_CLIENT_CERT=/path/to/client/cert -DSPANNER_OMNI_CLIENT_KEY=/path/to/client/key
-Djavax.net.ssl.trustStore=$JAVA_HOME/lib/security/cacerts -Djavax.net.ssl.trustStoreType=JKS
```

Additional change in ITLiquibaseTest


Fix ProcessBuilder Deadlock in ITLiquibaseTest
Problem: ITLiquibaseTest was prone to freezing indefinitely when executing the mvn liquibase subprocess. The test code attempted to read the process's stderr stream to completion before reading stdout. Because the Liquibase Maven plugin generates a massive amount of stdout logs (fetching dependencies, evaluating changelogs), the OS stdout buffer would fill up, causing the subprocess to pause. This resulted in an I/O deadlock: Java was waiting for stderr to finish, while the subprocess was waiting for Java to clear stdout.

Solution: Merged the error and output streams by setting builder.redirectErrorStream(true) on the ProcessBuilder. This routes all stderr output directly into stdout, allowing the test thread to continuously drain a single unified stream. This prevents the buffer from filling up and completely eliminates the deadlock.
