### PR TITLE
perf: write remaining data types directly to the stream

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -119,15 +119,8 @@ jobs:
       - name: Create PostgreSQL test database
         run: |
           psql -h /pg -U postgres -c "CREATE DATABASE pgadapter"
-      - name: Run unit tests
-        run: mvn test -B -Ptest-all -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
-        env:
-          POSTGRES_HOST: /pg
-          POSTGRES_PORT: 5432
-          POSTGRES_USER: postgres
-          POSTGRES_DATABASE: pgadapter
-      - name: Run unit tests with virtual threads
-        run: mvn test -Dpgadapter.use_virtual_threads=true -Dpgadapter.use_virtual_grpc_transport_threads=true -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -B -Ptest-all
+      - name: Run CopyInMockServerTest with local PostgreSQL
+        run: mvn test -B -Dtest=CopyInMockServerTest -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
         env:
           POSTGRES_HOST: /pg
           POSTGRES_PORT: 5432

--- a/src/main/java/com/google/cloud/spanner/pgadapter/parsers/BinaryParser.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/parsers/BinaryParser.java
@@ -18,7 +18,6 @@ import com.google.api.core.InternalApi;
 import com.google.cloud.ByteArray;
 import com.google.cloud.spanner.ProtobufResultSet;
 import com.google.cloud.spanner.ResultSet;
-import com.google.cloud.spanner.SpannerExceptionFactory;
 import com.google.cloud.spanner.Value;
 import com.google.cloud.spanner.pgadapter.ProxyServer.DataFormat;
 import com.google.cloud.spanner.pgadapter.error.PGExceptionFactory;
@@ -109,39 +108,50 @@ public class BinaryParser extends Parser<ByteArray> {
   }
 
   public static byte[] convertToPG(
-      SessionState sessionState,
+      @Nonnull SessionState sessionState,
       DataOutputStream dataOutputStream,
       ResultSet resultSet,
       int position,
-      DataFormat format) {
+      DataFormat format)
+      throws IOException {
+    writeToPG(sessionState, dataOutputStream, resultSet, position, format);
+    return null;
+  }
+
+  static void writeToPG(
+      @Nonnull SessionState sessionState,
+      DataOutputStream dataOutputStream,
+      ResultSet resultSet,
+      int position,
+      DataFormat format)
+      throws IOException {
     int bufferSize = sessionState.getBinaryConversionBufferSize();
-    try {
-      String base64 = getBase64(resultSet, position);
-      switch (format) {
-        case SPANNER:
-        case POSTGRESQL_BINARY:
-          int length = base64ByteLength(base64);
-          dataOutputStream.writeInt(length);
-          if (bufferSize > 0 && length > bufferSize) {
-            try (InputStream inputStream =
-                Base64.getDecoder()
-                    .wrap(
-                        CharSource.wrap(base64)
-                            .asByteSource(StandardCharsets.ISO_8859_1)
-                            .openStream())) {
-              copy(length, inputStream, dataOutputStream, bufferSize);
-            }
-          } else {
-            dataOutputStream.write(Base64.getDecoder().decode(base64));
+    String base64 = getBase64(resultSet, position);
+    switch (format) {
+      case SPANNER:
+      case POSTGRESQL_BINARY:
+        int length = base64ByteLength(base64);
+        dataOutputStream.writeInt(length);
+        if (bufferSize > 0 && length > bufferSize) {
+          try (InputStream inputStream =
+              Base64.getDecoder()
+                  .wrap(
+                      CharSource.wrap(base64)
+                          .asByteSource(StandardCharsets.ISO_8859_1)
+                          .openStream())) {
+            copy(length, inputStream, dataOutputStream, bufferSize);
           }
-          return null;
-        case POSTGRESQL_TEXT:
-          return bytesToHex(Base64.getDecoder().decode(base64));
-        default:
-          throw new IllegalArgumentException("unknown data format: " + format);
-      }
-    } catch (IOException ioException) {
-      throw SpannerExceptionFactory.asSpannerException(ioException);
+        } else {
+          dataOutputStream.write(Base64.getDecoder().decode(base64));
+        }
+        break;
+      case POSTGRESQL_TEXT:
+        byte[] hexBytes = bytesToHex(Base64.getDecoder().decode(base64));
+        dataOutputStream.writeInt(hexBytes.length);
+        dataOutputStream.write(hexBytes);
+        break;
+      default:
+        throw new IllegalArgumentException("unknown data format: " + format);
     }
   }
 

--- a/src/main/java/com/google/cloud/spanner/pgadapter/parsers/BooleanParser.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/parsers/BooleanParser.java
@@ -22,8 +22,11 @@ import com.google.cloud.spanner.Value;
 import com.google.cloud.spanner.pgadapter.ProxyServer.DataFormat;
 import com.google.cloud.spanner.pgadapter.error.PGExceptionFactory;
 import com.google.cloud.spanner.pgadapter.error.SQLState;
+import com.google.cloud.spanner.pgadapter.session.SessionState;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import java.io.DataOutputStream;
+import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Locale;
 import java.util.Set;
@@ -42,6 +45,8 @@ public class BooleanParser extends Parser<Boolean> {
   private static final byte[] FALSE_VALUE_BYTES = new byte[] {'f'};
   private static final byte[] TRUE_VALUE_BYTES_BINARY = new byte[1];
   private static final byte[] FALSE_VALUE_BYTES_BINARY = new byte[1];
+  private static final byte[] TRUE_SPANNER_BYTES = "true".getBytes(StandardCharsets.UTF_8);
+  private static final byte[] FALSE_SPANNER_BYTES = "false".getBytes(StandardCharsets.UTF_8);
 
   static {
     ByteConverter.bool(TRUE_VALUE_BYTES_BINARY, 0, true);
@@ -131,10 +136,47 @@ public class BooleanParser extends Parser<Boolean> {
     return result;
   }
 
+  public static byte[] convertToPG(
+      @Nonnull SessionState sessionState,
+      DataOutputStream outputStream,
+      ResultSet resultSet,
+      int position,
+      DataFormat format)
+      throws IOException {
+    writeToPG(sessionState, outputStream, resultSet, position, format);
+    return null;
+  }
+
+  static void writeToPG(
+      @Nonnull SessionState sessionState,
+      DataOutputStream outputStream,
+      ResultSet resultSet,
+      int position,
+      DataFormat format)
+      throws IOException {
+    switch (format) {
+      case SPANNER:
+        byte[] bytes = resultSet.getBoolean(position) ? TRUE_SPANNER_BYTES : FALSE_SPANNER_BYTES;
+        outputStream.writeInt(bytes.length);
+        outputStream.write(bytes);
+        break;
+      case POSTGRESQL_TEXT:
+        outputStream.writeInt(1);
+        outputStream.writeByte(resultSet.getBoolean(position) ? 't' : 'f');
+        break;
+      case POSTGRESQL_BINARY:
+        outputStream.writeInt(1);
+        outputStream.writeByte(resultSet.getBoolean(position) ? 1 : 0);
+        break;
+      default:
+        throw new IllegalArgumentException("unknown data format: " + format);
+    }
+  }
+
   public static byte[] convertToPG(ResultSet resultSet, int position, DataFormat format) {
     switch (format) {
       case SPANNER:
-        return Boolean.toString(resultSet.getBoolean(position)).getBytes(StandardCharsets.UTF_8);
+        return resultSet.getBoolean(position) ? TRUE_SPANNER_BYTES : FALSE_SPANNER_BYTES;
       case POSTGRESQL_TEXT:
         return resultSet.getBoolean(position) ? TRUE_VALUE_BYTES : FALSE_VALUE_BYTES;
       case POSTGRESQL_BINARY:

--- a/src/main/java/com/google/cloud/spanner/pgadapter/parsers/DoubleParser.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/parsers/DoubleParser.java
@@ -23,6 +23,7 @@ import com.google.cloud.spanner.pgadapter.ProxyServer.DataFormat;
 import com.google.cloud.spanner.pgadapter.error.PGException;
 import com.google.cloud.spanner.pgadapter.error.PGExceptionFactory;
 import com.google.cloud.spanner.pgadapter.error.SQLState;
+import com.google.cloud.spanner.pgadapter.session.SessionState;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMap;
 import java.io.DataOutputStream;
@@ -92,16 +93,33 @@ public class DoubleParser extends Parser<Double> {
   }
 
   public static byte[] convertToPG(
-      DataOutputStream outputStream, ResultSet resultSet, int position, DataFormat format)
+      @Nonnull SessionState sessionState,
+      DataOutputStream outputStream,
+      ResultSet resultSet,
+      int position,
+      DataFormat format)
+      throws IOException {
+    writeToPG(sessionState, outputStream, resultSet, position, format);
+    return null;
+  }
+
+  static void writeToPG(
+      @Nonnull SessionState sessionState,
+      DataOutputStream outputStream,
+      ResultSet resultSet,
+      int position,
+      DataFormat format)
       throws IOException {
     switch (format) {
       case SPANNER:
       case POSTGRESQL_TEXT:
-        return Double.toString(resultSet.getDouble(position)).getBytes(StandardCharsets.UTF_8);
+        StringParser.writeToPG(
+            sessionState, outputStream, Double.toString(resultSet.getDouble(position)));
+        break;
       case POSTGRESQL_BINARY:
         outputStream.writeInt(8);
         outputStream.writeDouble(resultSet.getDouble(position));
-        return null;
+        break;
       default:
         throw new IllegalArgumentException("unknown data format: " + format);
     }

--- a/src/main/java/com/google/cloud/spanner/pgadapter/parsers/FloatParser.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/parsers/FloatParser.java
@@ -22,11 +22,11 @@ import com.google.cloud.spanner.pgadapter.ProxyServer.DataFormat;
 import com.google.cloud.spanner.pgadapter.error.PGException;
 import com.google.cloud.spanner.pgadapter.error.PGExceptionFactory;
 import com.google.cloud.spanner.pgadapter.error.SQLState;
+import com.google.cloud.spanner.pgadapter.session.SessionState;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMap;
 import java.io.DataOutputStream;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import javax.annotation.Nonnull;
 import org.postgresql.util.ByteConverter;
 
@@ -93,16 +93,33 @@ public class FloatParser extends Parser<Float> {
   }
 
   public static byte[] convertToPG(
-      DataOutputStream outputStream, ResultSet resultSet, int position, DataFormat format)
+      @Nonnull SessionState sessionState,
+      DataOutputStream outputStream,
+      ResultSet resultSet,
+      int position,
+      DataFormat format)
+      throws IOException {
+    writeToPG(sessionState, outputStream, resultSet, position, format);
+    return null;
+  }
+
+  static void writeToPG(
+      @Nonnull SessionState sessionState,
+      DataOutputStream outputStream,
+      ResultSet resultSet,
+      int position,
+      DataFormat format)
       throws IOException {
     switch (format) {
       case SPANNER:
       case POSTGRESQL_TEXT:
-        return Float.toString(resultSet.getFloat(position)).getBytes(StandardCharsets.UTF_8);
+        StringParser.writeToPG(
+            sessionState, outputStream, Float.toString(resultSet.getFloat(position)));
+        break;
       case POSTGRESQL_BINARY:
         outputStream.writeInt(4);
         outputStream.writeFloat(resultSet.getFloat(position));
-        return null;
+        break;
       default:
         throw new IllegalArgumentException("unknown data format: " + format);
     }

--- a/src/main/java/com/google/cloud/spanner/pgadapter/parsers/IntervalParser.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/parsers/IntervalParser.java
@@ -23,7 +23,10 @@ import com.google.cloud.spanner.Value;
 import com.google.cloud.spanner.pgadapter.ProxyServer.DataFormat;
 import com.google.cloud.spanner.pgadapter.error.PGExceptionFactory;
 import com.google.cloud.spanner.pgadapter.error.SQLState;
+import com.google.cloud.spanner.pgadapter.session.SessionState;
 import com.google.common.collect.ImmutableMap;
+import java.io.DataOutputStream;
+import java.io.IOException;
 import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
 import java.sql.SQLException;
@@ -146,6 +149,45 @@ public class IntervalParser extends Parser<Interval> {
     ByteConverter.int4(result, 8, days);
     ByteConverter.int4(result, 12, months);
     return result;
+  }
+
+  public static byte[] convertToPG(
+      @Nonnull SessionState sessionState,
+      DataOutputStream outputStream,
+      ResultSet resultSet,
+      int position,
+      DataFormat format)
+      throws IOException {
+    writeToPG(sessionState, outputStream, resultSet, position, format);
+    return null;
+  }
+
+  static void writeToPG(
+      @Nonnull SessionState sessionState,
+      DataOutputStream outputStream,
+      ResultSet resultSet,
+      int position,
+      DataFormat format)
+      throws IOException {
+    switch (format) {
+      case SPANNER:
+      case POSTGRESQL_TEXT:
+        StringParser.writeToPG(
+            sessionState, outputStream, toPGString(resultSet.getInterval(position)));
+        break;
+      case POSTGRESQL_BINARY:
+        Interval value = resultSet.getInterval(position);
+        long microseconds = value.getNanos().divide(NANOS_PER_MICRO_BIG_INTEGER).longValue();
+        int days = value.getDays();
+        int months = value.getMonths();
+        outputStream.writeInt(16);
+        outputStream.writeLong(microseconds);
+        outputStream.writeInt(days);
+        outputStream.writeInt(months);
+        break;
+      default:
+        throw new IllegalArgumentException("unknown data format: " + format);
+    }
   }
 
   public static byte[] convertToPG(ResultSet resultSet, int position, DataFormat format) {

--- a/src/main/java/com/google/cloud/spanner/pgadapter/parsers/NumericParser.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/parsers/NumericParser.java
@@ -16,11 +16,15 @@ package com.google.cloud.spanner.pgadapter.parsers;
 
 import com.google.api.core.InternalApi;
 import com.google.cloud.spanner.ErrorCode;
+import com.google.cloud.spanner.ProtobufResultSet;
 import com.google.cloud.spanner.ResultSet;
 import com.google.cloud.spanner.SpannerExceptionFactory;
 import com.google.cloud.spanner.Value;
 import com.google.cloud.spanner.pgadapter.ProxyServer.DataFormat;
+import com.google.cloud.spanner.pgadapter.session.SessionState;
 import com.google.common.collect.ImmutableMap;
+import java.io.DataOutputStream;
+import java.io.IOException;
 import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
 import javax.annotation.Nonnull;
@@ -98,6 +102,47 @@ public class NumericParser extends Parser<String> {
       throw SpannerExceptionFactory.newSpannerException(
           ErrorCode.INVALID_ARGUMENT, "Invalid numeric value: " + value);
     }
+  }
+
+  public static byte[] convertToPG(
+      @Nonnull SessionState sessionState,
+      DataOutputStream outputStream,
+      ResultSet resultSet,
+      int position,
+      DataFormat format)
+      throws IOException {
+    writeToPG(sessionState, outputStream, resultSet, position, format);
+    return null;
+  }
+
+  static void writeToPG(
+      @Nonnull SessionState sessionState,
+      DataOutputStream outputStream,
+      ResultSet resultSet,
+      int position,
+      DataFormat format)
+      throws IOException {
+    switch (format) {
+      case SPANNER:
+      case POSTGRESQL_TEXT:
+        StringParser.writeToPG(sessionState, outputStream, getNumericAsString(resultSet, position));
+        break;
+      case POSTGRESQL_BINARY:
+        byte[] value = convertToPG(getNumericAsString(resultSet, position));
+        outputStream.writeInt(value.length);
+        outputStream.write(value);
+        break;
+      default:
+        throw new IllegalArgumentException("unknown data format: " + format);
+    }
+  }
+
+  static String getNumericAsString(ResultSet resultSet, int column) {
+    if (resultSet instanceof ProtobufResultSet
+        && ((ProtobufResultSet) resultSet).canGetProtobufValue(column)) {
+      return ((ProtobufResultSet) resultSet).getProtobufValue(column).getStringValue();
+    }
+    return resultSet.getString(column);
   }
 
   public static byte[] convertToPG(ResultSet resultSet, int position, DataFormat format) {

--- a/src/main/java/com/google/cloud/spanner/pgadapter/parsers/StringParser.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/parsers/StringParser.java
@@ -75,7 +75,7 @@ public class StringParser extends Parser<String> {
   }
 
   public static byte[] convertToPG(
-      SessionState sessionState,
+      @Nonnull SessionState sessionState,
       DataOutputStream dataOutputStream,
       ResultSet resultSet,
       int position) {
@@ -84,12 +84,15 @@ public class StringParser extends Parser<String> {
   }
 
   static void writeToPG(
-      SessionState sessionState, DataOutputStream dataOutputStream, String value) {
+      @Nonnull SessionState sessionState, DataOutputStream dataOutputStream, String value) {
     writeToPG(sessionState, dataOutputStream, value, HEADER);
   }
 
   static void writeToPG(
-      SessionState sessionState, DataOutputStream dataOutputStream, String value, byte[] header) {
+      @Nonnull SessionState sessionState,
+      DataOutputStream dataOutputStream,
+      String value,
+      byte[] header) {
     int bufferSize = sessionState.getStringConversionBufferSize();
     int length = value.length();
     try {

--- a/src/main/java/com/google/cloud/spanner/pgadapter/parsers/TimestampParser.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/parsers/TimestampParser.java
@@ -26,6 +26,8 @@ import com.google.cloud.spanner.pgadapter.error.SQLState;
 import com.google.cloud.spanner.pgadapter.metadata.OptionsMetadata;
 import com.google.cloud.spanner.pgadapter.session.SessionState;
 import com.google.common.collect.ImmutableMap;
+import java.io.DataOutputStream;
+import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.time.LocalDate;
@@ -215,6 +217,47 @@ public class TimestampParser extends Parser<Timestamp> {
     byte[] result = new byte[8];
     ByteConverter.int8(result, 0, microseconds);
     return result;
+  }
+
+  public static byte[] convertToPG(
+      @Nonnull SessionState sessionState,
+      DataOutputStream outputStream,
+      ResultSet resultSet,
+      int position,
+      DataFormat format)
+      throws IOException {
+    writeToPG(sessionState, outputStream, resultSet, position, format);
+    return null;
+  }
+
+  static void writeToPG(
+      @Nonnull SessionState sessionState,
+      DataOutputStream outputStream,
+      ResultSet resultSet,
+      int position,
+      DataFormat format)
+      throws IOException {
+    switch (format) {
+      case SPANNER:
+        StringParser.writeToPG(
+            sessionState, outputStream, resultSet.getTimestamp(position).toString());
+        break;
+      case POSTGRESQL_TEXT:
+        ZoneId zoneId = sessionState.getTimezone();
+        StringParser.writeToPG(
+            sessionState, outputStream, toPGString(resultSet.getTimestamp(position), zoneId));
+        break;
+      case POSTGRESQL_BINARY:
+        Timestamp value = resultSet.getTimestamp(position);
+        long microseconds =
+            ((value.getSeconds() - PG_EPOCH_SECONDS) * MICROSECONDS_IN_SECOND)
+                + (value.getNanos() / NANOSECONDS_IN_MICROSECONDS);
+        outputStream.writeInt(8);
+        outputStream.writeLong(microseconds);
+        break;
+      default:
+        throw new IllegalArgumentException("unknown data format: " + format);
+    }
   }
 
   public static byte[] convertToPG(

--- a/src/main/java/com/google/cloud/spanner/pgadapter/parsers/UuidParser.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/parsers/UuidParser.java
@@ -15,14 +15,18 @@
 package com.google.cloud.spanner.pgadapter.parsers;
 
 import com.google.api.core.InternalApi;
+import com.google.cloud.spanner.ProtobufResultSet;
 import com.google.cloud.spanner.ResultSet;
 import com.google.cloud.spanner.Value;
 import com.google.cloud.spanner.pgadapter.ProxyServer.DataFormat;
 import com.google.cloud.spanner.pgadapter.error.PGException;
 import com.google.cloud.spanner.pgadapter.error.SQLState;
 import com.google.cloud.spanner.pgadapter.error.Severity;
+import com.google.cloud.spanner.pgadapter.session.SessionState;
 import com.google.common.collect.ImmutableMap;
 import com.google.protobuf.NullValue;
+import java.io.DataOutputStream;
+import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.UUID;
 import javax.annotation.Nonnull;
@@ -122,6 +126,48 @@ public class UuidParser extends Parser<UUID> {
         .setSQLState(SQLState.InvalidParameterValue)
         .setCause(cause)
         .build();
+  }
+
+  public static byte[] convertToPG(
+      @Nonnull SessionState sessionState,
+      DataOutputStream outputStream,
+      ResultSet resultSet,
+      int position,
+      DataFormat format)
+      throws IOException {
+    writeToPG(sessionState, outputStream, resultSet, position, format);
+    return null;
+  }
+
+  static void writeToPG(
+      @Nonnull SessionState sessionState,
+      DataOutputStream outputStream,
+      ResultSet resultSet,
+      int position,
+      DataFormat format)
+      throws IOException {
+    switch (format) {
+      case SPANNER:
+      case POSTGRESQL_TEXT:
+        StringParser.writeToPG(sessionState, outputStream, getUuidAsString(resultSet, position));
+        break;
+      case POSTGRESQL_BINARY:
+        UUID uuid = resultSet.getUuid(position);
+        outputStream.writeInt(16);
+        outputStream.writeLong(uuid.getMostSignificantBits());
+        outputStream.writeLong(uuid.getLeastSignificantBits());
+        break;
+      default:
+        throw new IllegalArgumentException("unknown data format: " + format);
+    }
+  }
+
+  static String getUuidAsString(ResultSet resultSet, int column) {
+    if (resultSet instanceof ProtobufResultSet
+        && ((ProtobufResultSet) resultSet).canGetProtobufValue(column)) {
+      return ((ProtobufResultSet) resultSet).getProtobufValue(column).getStringValue();
+    }
+    return resultSet.getUuid(column).toString();
   }
 
   public static byte[] convertToPG(ResultSet resultSet, int position, DataFormat format) {

--- a/src/main/java/com/google/cloud/spanner/pgadapter/utils/Converter.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/utils/Converter.java
@@ -120,7 +120,7 @@ public class Converter implements AutoCloseable {
         DataFormat format = this.columnFormats[column_index];
         byte[] column =
             Converter.convertToPG(outputStream, this.resultSet, column_index, format, sessionState);
-        // TODO: Remove this if statement and write statements once all data types are written
+        // TODO: Remove this if statement and write statements once ARRAY data types are written
         // directly to the output stream.
         if (column != null) {
           outputStream.writeInt(column.length);
@@ -148,7 +148,8 @@ public class Converter implements AutoCloseable {
    * @return a byte array containing the data in the specified format or null if the data was
    *     written directly to the output stream.
    */
-  // TODO: Rename this method to writeToPG and change return type to void once all data types write
+  // TODO: Rename this method to writeToPG and change return type to void once ARRAY data types
+  // write
   // directly to the output stream.
   public static byte[] convertToPG(
       DataOutputStream outputStream,
@@ -161,28 +162,28 @@ public class Converter implements AutoCloseable {
     Type type = result.getColumnType(position);
     switch (type.getCode()) {
       case BOOL:
-        return BooleanParser.convertToPG(result, position, format);
+        return BooleanParser.convertToPG(sessionState, outputStream, result, position, format);
       case BYTES:
         return BinaryParser.convertToPG(sessionState, outputStream, result, position, format);
       case DATE:
         return DateParser.convertToPG(sessionState, outputStream, result, position, format);
       case FLOAT32:
-        return FloatParser.convertToPG(outputStream, result, position, format);
+        return FloatParser.convertToPG(sessionState, outputStream, result, position, format);
       case FLOAT64:
-        return DoubleParser.convertToPG(outputStream, result, position, format);
+        return DoubleParser.convertToPG(sessionState, outputStream, result, position, format);
       case INT64:
       case PG_OID:
         return LongParser.convertToPG(sessionState, outputStream, result, position, format);
       case PG_NUMERIC:
-        return NumericParser.convertToPG(result, position, format);
+        return NumericParser.convertToPG(sessionState, outputStream, result, position, format);
       case STRING:
         return StringParser.convertToPG(sessionState, outputStream, result, position);
       case UUID:
-        return UuidParser.convertToPG(result, position, format);
+        return UuidParser.convertToPG(sessionState, outputStream, result, position, format);
       case TIMESTAMP:
-        return TimestampParser.convertToPG(result, position, format, sessionState.getTimezone());
+        return TimestampParser.convertToPG(sessionState, outputStream, result, position, format);
       case INTERVAL:
-        return IntervalParser.convertToPG(result, position, format);
+        return IntervalParser.convertToPG(sessionState, outputStream, result, position, format);
       case PG_JSONB:
         return JsonbParser.convertToPG(sessionState, outputStream, result, position, format);
       case ARRAY:

--- a/src/test/java/com/google/cloud/spanner/pgadapter/parsers/BinaryParserTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/parsers/BinaryParserTest.java
@@ -15,13 +15,25 @@
 package com.google.cloud.spanner.pgadapter.parsers;
 
 import static junit.framework.TestCase.assertNull;
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import com.google.cloud.ByteArray;
+import com.google.cloud.spanner.ProtobufResultSet;
+import com.google.cloud.spanner.ResultSet;
+import com.google.cloud.spanner.Value;
+import com.google.cloud.spanner.pgadapter.ProxyServer.DataFormat;
 import com.google.cloud.spanner.pgadapter.error.PGException;
 import com.google.cloud.spanner.pgadapter.parsers.Parser.FormatCode;
+import com.google.cloud.spanner.pgadapter.session.SessionState;
+import java.io.ByteArrayOutputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 import java.util.Random;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -55,5 +67,53 @@ public class BinaryParserTest {
     byte[] value = new byte[random.nextInt(1024) + 1];
     random.nextBytes(value);
     assertEquals("\\x" + Utils.toHexString(value), new String(BinaryParser.bytesToHex(value)));
+  }
+
+  @Test
+  public void testConvertToPG() throws IOException {
+    byte[] rawBytes = new byte[] {1, 2, 3, 4};
+    ResultSet resultSet = mock(ResultSet.class);
+    Value value = mock(Value.class);
+    when(value.getAsString()).thenReturn(Base64.getEncoder().encodeToString(rawBytes));
+    when(resultSet.getValue(0)).thenReturn(value);
+
+    SessionState sessionState = mock(SessionState.class);
+    ByteArrayOutputStream output = new ByteArrayOutputStream();
+    DataOutputStream dataOutputStream = new DataOutputStream(output);
+
+    // Text format
+    assertNull(
+        BinaryParser.convertToPG(
+            sessionState, dataOutputStream, resultSet, 0, DataFormat.POSTGRESQL_TEXT));
+    assertArrayEquals(
+        new byte[] {0, 0, 0, 10, '\\', 'x', '0', '1', '0', '2', '0', '3', '0', '4'},
+        output.toByteArray());
+    output.reset();
+
+    // Binary format
+    assertNull(
+        BinaryParser.convertToPG(
+            sessionState, dataOutputStream, resultSet, 0, DataFormat.POSTGRESQL_BINARY));
+    assertArrayEquals(new byte[] {0, 0, 0, 4, 1, 2, 3, 4}, output.toByteArray());
+  }
+
+  @Test
+  public void testConvertToPGProtobufResultSet() throws IOException {
+    byte[] rawBytes = new byte[] {5, 6, 7, 8};
+    String base64 = Base64.getEncoder().encodeToString(rawBytes);
+    ProtobufResultSet resultSet = mock(ProtobufResultSet.class);
+    when(resultSet.canGetProtobufValue(0)).thenReturn(true);
+    com.google.protobuf.Value protoValue =
+        com.google.protobuf.Value.newBuilder().setStringValue(base64).build();
+    when(resultSet.getProtobufValue(0)).thenReturn(protoValue);
+
+    SessionState sessionState = mock(SessionState.class);
+    ByteArrayOutputStream output = new ByteArrayOutputStream();
+    DataOutputStream dataOutputStream = new DataOutputStream(output);
+
+    assertNull(
+        BinaryParser.convertToPG(
+            sessionState, dataOutputStream, resultSet, 0, DataFormat.POSTGRESQL_BINARY));
+    assertArrayEquals(new byte[] {0, 0, 0, 4, 5, 6, 7, 8}, output.toByteArray());
   }
 }

--- a/src/test/java/com/google/cloud/spanner/pgadapter/parsers/BooleanParserTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/parsers/BooleanParserTest.java
@@ -20,11 +20,19 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import com.google.cloud.spanner.ErrorCode;
+import com.google.cloud.spanner.ResultSet;
 import com.google.cloud.spanner.SpannerException;
+import com.google.cloud.spanner.pgadapter.ProxyServer.DataFormat;
 import com.google.cloud.spanner.pgadapter.error.PGException;
 import com.google.cloud.spanner.pgadapter.parsers.Parser.FormatCode;
+import com.google.cloud.spanner.pgadapter.session.SessionState;
+import java.io.ByteArrayOutputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -123,5 +131,68 @@ public class BooleanParserTest {
     assertEquals("true", new BooleanParser(Boolean.TRUE).spannerParse());
     assertEquals("false", new BooleanParser(Boolean.FALSE).spannerParse());
     assertNull(new BooleanParser(null).spannerParse());
+  }
+
+  @Test
+  public void testConvertToPG() throws IOException {
+    ResultSet resultSet = mock(ResultSet.class);
+    when(resultSet.getBoolean(0)).thenReturn(true);
+    when(resultSet.getBoolean(1)).thenReturn(false);
+
+    ByteArrayOutputStream output = new ByteArrayOutputStream();
+    DataOutputStream dataOutputStream = new DataOutputStream(output);
+    SessionState sessionState = mock(SessionState.class);
+
+    // Text format
+    assertNull(
+        BooleanParser.convertToPG(
+            sessionState, dataOutputStream, resultSet, 0, DataFormat.POSTGRESQL_TEXT));
+    assertArrayEquals(new byte[] {0, 0, 0, 1, 't'}, output.toByteArray());
+    output.reset();
+    assertNull(
+        BooleanParser.convertToPG(
+            sessionState, dataOutputStream, resultSet, 1, DataFormat.POSTGRESQL_TEXT));
+    assertArrayEquals(new byte[] {0, 0, 0, 1, 'f'}, output.toByteArray());
+    output.reset();
+
+    // Binary format
+    assertNull(
+        BooleanParser.convertToPG(
+            sessionState, dataOutputStream, resultSet, 0, DataFormat.POSTGRESQL_BINARY));
+    assertArrayEquals(new byte[] {0, 0, 0, 1, 1}, output.toByteArray());
+    output.reset();
+    assertNull(
+        BooleanParser.convertToPG(
+            sessionState, dataOutputStream, resultSet, 1, DataFormat.POSTGRESQL_BINARY));
+    assertArrayEquals(new byte[] {0, 0, 0, 1, 0}, output.toByteArray());
+    output.reset();
+
+    // Spanner format
+    assertNull(
+        BooleanParser.convertToPG(
+            sessionState, dataOutputStream, resultSet, 0, DataFormat.SPANNER));
+    assertArrayEquals(new byte[] {0, 0, 0, 4, 't', 'r', 'u', 'e'}, output.toByteArray());
+    output.reset();
+    assertNull(
+        BooleanParser.convertToPG(
+            sessionState, dataOutputStream, resultSet, 1, DataFormat.SPANNER));
+    assertArrayEquals(new byte[] {0, 0, 0, 5, 'f', 'a', 'l', 's', 'e'}, output.toByteArray());
+    output.reset();
+
+    // Verify backward compatibility method
+    assertArrayEquals(
+        new byte[] {'t'}, BooleanParser.convertToPG(resultSet, 0, DataFormat.POSTGRESQL_TEXT));
+    assertArrayEquals(
+        new byte[] {'f'}, BooleanParser.convertToPG(resultSet, 1, DataFormat.POSTGRESQL_TEXT));
+    assertArrayEquals(
+        new byte[] {1}, BooleanParser.convertToPG(resultSet, 0, DataFormat.POSTGRESQL_BINARY));
+    assertArrayEquals(
+        new byte[] {0}, BooleanParser.convertToPG(resultSet, 1, DataFormat.POSTGRESQL_BINARY));
+    assertArrayEquals(
+        "true".getBytes(StandardCharsets.UTF_8),
+        BooleanParser.convertToPG(resultSet, 0, DataFormat.SPANNER));
+    assertArrayEquals(
+        "false".getBytes(StandardCharsets.UTF_8),
+        BooleanParser.convertToPG(resultSet, 1, DataFormat.SPANNER));
   }
 }

--- a/src/test/java/com/google/cloud/spanner/pgadapter/parsers/DoubleParserTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/parsers/DoubleParserTest.java
@@ -14,16 +14,25 @@
 
 package com.google.cloud.spanner.pgadapter.parsers;
 
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import com.google.cloud.spanner.ErrorCode;
+import com.google.cloud.spanner.ResultSet;
 import com.google.cloud.spanner.SpannerException;
 import com.google.cloud.spanner.Value;
+import com.google.cloud.spanner.pgadapter.ProxyServer.DataFormat;
 import com.google.cloud.spanner.pgadapter.error.PGException;
 import com.google.cloud.spanner.pgadapter.parsers.Parser.FormatCode;
+import com.google.cloud.spanner.pgadapter.session.SessionState;
 import com.google.common.collect.ImmutableMap;
+import java.io.ByteArrayOutputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Random;
 import org.junit.Test;
@@ -110,5 +119,81 @@ public class DoubleParserTest {
     assertEquals(Value.string("NaN"), parameters.get("nan"));
     assertEquals(Value.string("Infinity"), parameters.get("inf"));
     assertEquals(Value.string("-Infinity"), parameters.get("-inf"));
+  }
+
+  @Test
+  public void testConvertToPG() throws IOException {
+    ResultSet resultSet = mock(ResultSet.class);
+    when(resultSet.getDouble(0)).thenReturn(3.14);
+
+    ByteArrayOutputStream output = new ByteArrayOutputStream();
+    DataOutputStream dataOutputStream = new DataOutputStream(output);
+    SessionState sessionState = mock(SessionState.class);
+
+    // Text format
+    assertNull(
+        DoubleParser.convertToPG(
+            sessionState, dataOutputStream, resultSet, 0, DataFormat.POSTGRESQL_TEXT));
+    assertArrayEquals(new byte[] {0, 0, 0, 4, '3', '.', '1', '4'}, output.toByteArray());
+    output.reset();
+
+    // Binary format
+    assertNull(
+        DoubleParser.convertToPG(
+            sessionState, dataOutputStream, resultSet, 0, DataFormat.POSTGRESQL_BINARY));
+    assertArrayEquals(
+        new byte[] {
+          0, 0, 0, 8, 0x40, 0x09, 0x1e, (byte) 0xb8, 0x51, (byte) 0xeb, (byte) 0x85, 0x1f
+        },
+        output.toByteArray());
+    output.reset();
+
+    // Spanner format
+    assertNull(
+        DoubleParser.convertToPG(sessionState, dataOutputStream, resultSet, 0, DataFormat.SPANNER));
+    assertArrayEquals(new byte[] {0, 0, 0, 4, '3', '.', '1', '4'}, output.toByteArray());
+  }
+
+  @Test
+  public void testConvertToPGSpecialValues() throws IOException {
+    SessionState sessionState = mock(SessionState.class);
+    ByteArrayOutputStream output = new ByteArrayOutputStream();
+    DataOutputStream dataOutputStream = new DataOutputStream(output);
+
+    double[] specialValues =
+        new double[] {0.0, -0.0, Double.POSITIVE_INFINITY, Double.NEGATIVE_INFINITY, Double.NaN};
+    byte[][] expectedBinary =
+        new byte[][] {
+          {0, 0, 0, 8, 0, 0, 0, 0, 0, 0, 0, 0},
+          {0, 0, 0, 8, (byte) 0x80, 0, 0, 0, 0, 0, 0, 0},
+          {0, 0, 0, 8, 0x7f, (byte) 0xf0, 0, 0, 0, 0, 0, 0},
+          {0, 0, 0, 8, (byte) 0xff, (byte) 0xf0, 0, 0, 0, 0, 0, 0},
+          {0, 0, 0, 8, 0x7f, (byte) 0xf8, 0, 0, 0, 0, 0, 0},
+        };
+    byte[][] expectedText =
+        new byte[][] {
+          {0, 0, 0, 3, '0', '.', '0'},
+          {0, 0, 0, 4, '-', '0', '.', '0'},
+          {0, 0, 0, 8, 'I', 'n', 'f', 'i', 'n', 'i', 't', 'y'},
+          {0, 0, 0, 9, '-', 'I', 'n', 'f', 'i', 'n', 'i', 't', 'y'},
+          {0, 0, 0, 3, 'N', 'a', 'N'},
+        };
+
+    for (int i = 0; i < specialValues.length; i++) {
+      ResultSet resultSet = mock(ResultSet.class);
+      when(resultSet.getDouble(0)).thenReturn(specialValues[i]);
+
+      output.reset();
+      assertNull(
+          DoubleParser.convertToPG(
+              sessionState, dataOutputStream, resultSet, 0, DataFormat.POSTGRESQL_BINARY));
+      assertArrayEquals(expectedBinary[i], output.toByteArray());
+
+      output.reset();
+      assertNull(
+          DoubleParser.convertToPG(
+              sessionState, dataOutputStream, resultSet, 0, DataFormat.POSTGRESQL_TEXT));
+      assertArrayEquals(expectedText[i], output.toByteArray());
+    }
   }
 }

--- a/src/test/java/com/google/cloud/spanner/pgadapter/parsers/FloatParserTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/parsers/FloatParserTest.java
@@ -14,16 +14,25 @@
 
 package com.google.cloud.spanner.pgadapter.parsers;
 
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import com.google.cloud.spanner.ErrorCode;
+import com.google.cloud.spanner.ResultSet;
 import com.google.cloud.spanner.SpannerException;
 import com.google.cloud.spanner.Value;
+import com.google.cloud.spanner.pgadapter.ProxyServer.DataFormat;
 import com.google.cloud.spanner.pgadapter.error.PGException;
 import com.google.cloud.spanner.pgadapter.parsers.Parser.FormatCode;
+import com.google.cloud.spanner.pgadapter.session.SessionState;
 import com.google.common.collect.ImmutableMap;
+import java.io.ByteArrayOutputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Random;
 import org.junit.Test;
@@ -113,5 +122,78 @@ public class FloatParserTest {
     assertEquals(Value.string("NaN"), parameters.get("nan"));
     assertEquals(Value.string("Infinity"), parameters.get("inf"));
     assertEquals(Value.string("-Infinity"), parameters.get("-inf"));
+  }
+
+  @Test
+  public void testConvertToPG() throws IOException {
+    ResultSet resultSet = mock(ResultSet.class);
+    when(resultSet.getFloat(0)).thenReturn(3.14f);
+
+    ByteArrayOutputStream output = new ByteArrayOutputStream();
+    DataOutputStream dataOutputStream = new DataOutputStream(output);
+    SessionState sessionState = mock(SessionState.class);
+
+    // Text format
+    assertNull(
+        FloatParser.convertToPG(
+            sessionState, dataOutputStream, resultSet, 0, DataFormat.POSTGRESQL_TEXT));
+    assertArrayEquals(new byte[] {0, 0, 0, 4, '3', '.', '1', '4'}, output.toByteArray());
+    output.reset();
+
+    // Binary format
+    assertNull(
+        FloatParser.convertToPG(
+            sessionState, dataOutputStream, resultSet, 0, DataFormat.POSTGRESQL_BINARY));
+    assertArrayEquals(
+        new byte[] {0, 0, 0, 4, 0x40, 0x48, (byte) 0xf5, (byte) 0xc3}, output.toByteArray());
+    output.reset();
+
+    // Spanner format
+    assertNull(
+        FloatParser.convertToPG(sessionState, dataOutputStream, resultSet, 0, DataFormat.SPANNER));
+    assertArrayEquals(new byte[] {0, 0, 0, 4, '3', '.', '1', '4'}, output.toByteArray());
+  }
+
+  @Test
+  public void testConvertToPGSpecialValues() throws IOException {
+    SessionState sessionState = mock(SessionState.class);
+    ByteArrayOutputStream output = new ByteArrayOutputStream();
+    DataOutputStream dataOutputStream = new DataOutputStream(output);
+
+    float[] specialValues =
+        new float[] {0.0f, -0.0f, Float.POSITIVE_INFINITY, Float.NEGATIVE_INFINITY, Float.NaN};
+    byte[][] expectedBinary =
+        new byte[][] {
+          {0, 0, 0, 4, 0, 0, 0, 0},
+          {0, 0, 0, 4, (byte) 0x80, 0, 0, 0},
+          {0, 0, 0, 4, 0x7f, (byte) 0x80, 0, 0},
+          {0, 0, 0, 4, (byte) 0xff, (byte) 0x80, 0, 0},
+          {0, 0, 0, 4, 0x7f, (byte) 0xc0, 0, 0},
+        };
+    byte[][] expectedText =
+        new byte[][] {
+          {0, 0, 0, 3, '0', '.', '0'},
+          {0, 0, 0, 4, '-', '0', '.', '0'},
+          {0, 0, 0, 8, 'I', 'n', 'f', 'i', 'n', 'i', 't', 'y'},
+          {0, 0, 0, 9, '-', 'I', 'n', 'f', 'i', 'n', 'i', 't', 'y'},
+          {0, 0, 0, 3, 'N', 'a', 'N'},
+        };
+
+    for (int i = 0; i < specialValues.length; i++) {
+      ResultSet resultSet = mock(ResultSet.class);
+      when(resultSet.getFloat(0)).thenReturn(specialValues[i]);
+
+      output.reset();
+      assertNull(
+          FloatParser.convertToPG(
+              sessionState, dataOutputStream, resultSet, 0, DataFormat.POSTGRESQL_BINARY));
+      assertArrayEquals(expectedBinary[i], output.toByteArray());
+
+      output.reset();
+      assertNull(
+          FloatParser.convertToPG(
+              sessionState, dataOutputStream, resultSet, 0, DataFormat.POSTGRESQL_TEXT));
+      assertArrayEquals(expectedText[i], output.toByteArray());
+    }
   }
 }

--- a/src/test/java/com/google/cloud/spanner/pgadapter/parsers/IntervalParserTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/parsers/IntervalParserTest.java
@@ -1,0 +1,134 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.cloud.spanner.pgadapter.parsers;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.google.cloud.spanner.Interval;
+import com.google.cloud.spanner.ResultSet;
+import com.google.cloud.spanner.pgadapter.ProxyServer.DataFormat;
+import com.google.cloud.spanner.pgadapter.parsers.Parser.FormatCode;
+import com.google.cloud.spanner.pgadapter.session.SessionState;
+import java.io.ByteArrayOutputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.math.BigInteger;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class IntervalParserTest {
+
+  @Test
+  public void testConvertToPG() throws IOException {
+    Interval interval =
+        Interval.fromMonthsDaysNanos(
+            2, 5, BigInteger.valueOf((3 * 3600 + 4 * 60 + 5) * 1_000_000_000L + 123456000L));
+    ResultSet resultSet = mock(ResultSet.class);
+    when(resultSet.getInterval(0)).thenReturn(interval);
+
+    ByteArrayOutputStream output = new ByteArrayOutputStream();
+    DataOutputStream dataOutputStream = new DataOutputStream(output);
+    SessionState sessionState = mock(SessionState.class);
+
+    // Text format
+    assertNull(
+        IntervalParser.convertToPG(
+            sessionState, dataOutputStream, resultSet, 0, DataFormat.POSTGRESQL_TEXT));
+    byte[] textBytes = IntervalParser.convertToPG(resultSet, 0, DataFormat.POSTGRESQL_TEXT);
+    ByteArrayOutputStream expectedText = new ByteArrayOutputStream();
+    DataOutputStream expectedTextStream = new DataOutputStream(expectedText);
+    expectedTextStream.writeInt(textBytes.length);
+    expectedTextStream.write(textBytes);
+    assertArrayEquals(expectedText.toByteArray(), output.toByteArray());
+    output.reset();
+
+    // Binary format
+    assertNull(
+        IntervalParser.convertToPG(
+            sessionState, dataOutputStream, resultSet, 0, DataFormat.POSTGRESQL_BINARY));
+    byte[] binaryBytes = IntervalParser.convertToPG(resultSet, 0, DataFormat.POSTGRESQL_BINARY);
+    ByteArrayOutputStream expectedBinary = new ByteArrayOutputStream();
+    DataOutputStream expectedBinaryStream = new DataOutputStream(expectedBinary);
+    expectedBinaryStream.writeInt(16);
+    expectedBinaryStream.write(binaryBytes);
+    assertArrayEquals(expectedBinary.toByteArray(), output.toByteArray());
+    output.reset();
+
+    // Spanner format
+    assertNull(
+        IntervalParser.convertToPG(
+            sessionState, dataOutputStream, resultSet, 0, DataFormat.SPANNER));
+    assertArrayEquals(expectedText.toByteArray(), output.toByteArray());
+  }
+
+  @Test
+  public void testBinaryAndTextParse() {
+    Interval interval =
+        Interval.fromMonthsDaysNanos(
+            1, 2, BigInteger.valueOf((10 * 3600 + 20 * 60 + 30) * 1_000_000_000L));
+    byte[] binary = IntervalParser.convertToPGBinary(interval);
+    Interval parsedFromBinary = IntervalParser.toInterval(binary, FormatCode.BINARY);
+    assertEquals(interval, parsedFromBinary);
+
+    IntervalParser parser = new IntervalParser(binary, FormatCode.BINARY);
+    assertArrayEquals(binary, parser.binaryParse());
+
+    parser = new IntervalParser(null, FormatCode.BINARY);
+    assertNull(parser.binaryParse());
+    assertNull(parser.stringParse());
+  }
+
+  @Test
+  public void testConvertToPGNegativeInterval() throws IOException {
+    Interval negativeInterval =
+        Interval.fromMonthsDaysNanos(
+            -2, -5, BigInteger.valueOf((-3 * 3600 - 4 * 60 - 5) * 1_000_000_000L));
+    ResultSet resultSet = mock(ResultSet.class);
+    when(resultSet.getInterval(0)).thenReturn(negativeInterval);
+
+    ByteArrayOutputStream output = new ByteArrayOutputStream();
+    DataOutputStream dataOutputStream = new DataOutputStream(output);
+    SessionState sessionState = mock(SessionState.class);
+
+    // Text format
+    assertNull(
+        IntervalParser.convertToPG(
+            sessionState, dataOutputStream, resultSet, 0, DataFormat.POSTGRESQL_TEXT));
+    byte[] textBytes = IntervalParser.convertToPG(resultSet, 0, DataFormat.POSTGRESQL_TEXT);
+    ByteArrayOutputStream expectedText = new ByteArrayOutputStream();
+    DataOutputStream expectedTextStream = new DataOutputStream(expectedText);
+    expectedTextStream.writeInt(textBytes.length);
+    expectedTextStream.write(textBytes);
+    assertArrayEquals(expectedText.toByteArray(), output.toByteArray());
+    output.reset();
+
+    // Binary format
+    assertNull(
+        IntervalParser.convertToPG(
+            sessionState, dataOutputStream, resultSet, 0, DataFormat.POSTGRESQL_BINARY));
+    byte[] binaryBytes = IntervalParser.convertToPG(resultSet, 0, DataFormat.POSTGRESQL_BINARY);
+    ByteArrayOutputStream expectedBinary = new ByteArrayOutputStream();
+    DataOutputStream expectedBinaryStream = new DataOutputStream(expectedBinary);
+    expectedBinaryStream.writeInt(16);
+    expectedBinaryStream.write(binaryBytes);
+    assertArrayEquals(expectedBinary.toByteArray(), output.toByteArray());
+  }
+}

--- a/src/test/java/com/google/cloud/spanner/pgadapter/parsers/NumericParserTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/parsers/NumericParserTest.java
@@ -14,13 +14,23 @@
 
 package com.google.cloud.spanner.pgadapter.parsers;
 
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import com.google.cloud.spanner.ErrorCode;
+import com.google.cloud.spanner.ProtobufResultSet;
+import com.google.cloud.spanner.ResultSet;
 import com.google.cloud.spanner.SpannerException;
+import com.google.cloud.spanner.pgadapter.ProxyServer.DataFormat;
 import com.google.cloud.spanner.pgadapter.parsers.Parser.FormatCode;
+import com.google.cloud.spanner.pgadapter.session.SessionState;
+import java.io.ByteArrayOutputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
 import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
 import java.util.Random;
@@ -52,5 +62,100 @@ public class NumericParserTest {
         "foo",
         new NumericParser("foo".getBytes(StandardCharsets.UTF_8), FormatCode.TEXT).stringParse());
     assertNull(new NumericParser(null).stringParse());
+  }
+
+  @Test
+  public void testConvertToPG() throws IOException {
+    ResultSet resultSet = mock(ResultSet.class);
+    when(resultSet.getString(0)).thenReturn("3.14");
+
+    ByteArrayOutputStream output = new ByteArrayOutputStream();
+    DataOutputStream dataOutputStream = new DataOutputStream(output);
+    SessionState sessionState = mock(SessionState.class);
+
+    // Text format
+    assertNull(
+        NumericParser.convertToPG(
+            sessionState, dataOutputStream, resultSet, 0, DataFormat.POSTGRESQL_TEXT));
+    byte[] textBytes = "3.14".getBytes(StandardCharsets.UTF_8);
+    ByteArrayOutputStream expectedText = new ByteArrayOutputStream();
+    DataOutputStream expectedTextStream = new DataOutputStream(expectedText);
+    expectedTextStream.writeInt(textBytes.length);
+    expectedTextStream.write(textBytes);
+    assertArrayEquals(expectedText.toByteArray(), output.toByteArray());
+    output.reset();
+
+    // Binary format
+    assertNull(
+        NumericParser.convertToPG(
+            sessionState, dataOutputStream, resultSet, 0, DataFormat.POSTGRESQL_BINARY));
+    byte[] binaryBytes = ByteConverter.numeric(new BigDecimal("3.14"));
+    ByteArrayOutputStream expectedBinary = new ByteArrayOutputStream();
+    DataOutputStream expectedBinaryStream = new DataOutputStream(expectedBinary);
+    expectedBinaryStream.writeInt(binaryBytes.length);
+    expectedBinaryStream.write(binaryBytes);
+    assertArrayEquals(expectedBinary.toByteArray(), output.toByteArray());
+    output.reset();
+
+    // Spanner format
+    assertNull(
+        NumericParser.convertToPG(
+            sessionState, dataOutputStream, resultSet, 0, DataFormat.SPANNER));
+    assertArrayEquals(expectedText.toByteArray(), output.toByteArray());
+    output.reset();
+
+    // Verify backward compatibility method
+    assertArrayEquals(
+        textBytes, NumericParser.convertToPG(resultSet, 0, DataFormat.POSTGRESQL_TEXT));
+    assertArrayEquals(
+        binaryBytes, NumericParser.convertToPG(resultSet, 0, DataFormat.POSTGRESQL_BINARY));
+    assertArrayEquals(textBytes, NumericParser.convertToPG(resultSet, 0, DataFormat.SPANNER));
+  }
+
+  @Test
+  public void testConvertToPGNaNAndNegative() throws IOException {
+    SessionState sessionState = mock(SessionState.class);
+
+    // NaN
+    ResultSet nanResultSet = mock(ResultSet.class);
+    when(nanResultSet.getString(0)).thenReturn("NaN");
+    ByteArrayOutputStream output = new ByteArrayOutputStream();
+    DataOutputStream dataOutputStream = new DataOutputStream(output);
+
+    assertNull(
+        NumericParser.convertToPG(
+            sessionState, dataOutputStream, nanResultSet, 0, DataFormat.POSTGRESQL_BINARY));
+    assertArrayEquals(
+        new byte[] {0, 0, 0, 8, 0, 0, 0, 0, (byte) 0xC0, 0, 0, 0}, output.toByteArray());
+    output.reset();
+
+    // Negative numeric
+    ResultSet negResultSet = mock(ResultSet.class);
+    when(negResultSet.getString(0)).thenReturn("-123.456");
+    assertNull(
+        NumericParser.convertToPG(
+            sessionState, dataOutputStream, negResultSet, 0, DataFormat.POSTGRESQL_BINARY));
+    assertArrayEquals(
+        new byte[] {0, 0, 0, 12, 0, 2, 0, 0, (byte) 0x40, 0, 0, 3, 0, 123, 0x11, (byte) 0xd0},
+        output.toByteArray());
+  }
+
+  @Test
+  public void testConvertToPGProtobufResultSet() throws IOException {
+    ProtobufResultSet protobufResultSet = mock(ProtobufResultSet.class);
+    when(protobufResultSet.canGetProtobufValue(0)).thenReturn(true);
+    when(protobufResultSet.getProtobufValue(0))
+        .thenReturn(com.google.protobuf.Value.newBuilder().setStringValue("9876.54321").build());
+
+    ByteArrayOutputStream output = new ByteArrayOutputStream();
+    DataOutputStream dataOutputStream = new DataOutputStream(output);
+    SessionState sessionState = mock(SessionState.class);
+
+    assertNull(
+        NumericParser.convertToPG(
+            sessionState, dataOutputStream, protobufResultSet, 0, DataFormat.POSTGRESQL_TEXT));
+    assertArrayEquals(
+        new byte[] {0, 0, 0, 10, '9', '8', '7', '6', '.', '5', '4', '3', '2', '1'},
+        output.toByteArray());
   }
 }

--- a/src/test/java/com/google/cloud/spanner/pgadapter/parsers/TimestampParserTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/parsers/TimestampParserTest.java
@@ -35,6 +35,9 @@ import com.google.cloud.spanner.pgadapter.error.PGException;
 import com.google.cloud.spanner.pgadapter.parsers.Parser.FormatCode;
 import com.google.cloud.spanner.pgadapter.session.SessionState;
 import com.google.common.collect.ImmutableList;
+import java.io.ByteArrayOutputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.time.ZoneId;
 import java.util.Random;
@@ -92,6 +95,103 @@ public class TimestampParserTest {
     assertArrayEquals(
         "2022-07-08T07:22:59.123456789Z".getBytes(StandardCharsets.UTF_8),
         TimestampParser.convertToPG(resultSet, 0, DataFormat.SPANNER, ZoneId.of("UTC")));
+  }
+
+  @Test
+  public void testConvertToPGStream() throws IOException {
+    ResultSet resultSet =
+        ResultSets.forRows(
+            Type.struct(StructField.of("ts", Type.timestamp())),
+            ImmutableList.of(
+                Struct.newBuilder()
+                    .set("ts")
+                    .to(Timestamp.parseTimestamp("2022-07-08T07:22:59.123456789Z"))
+                    .build()));
+    resultSet.next();
+
+    SessionState sessionState = mock(SessionState.class);
+    when(sessionState.getTimezone()).thenReturn(ZoneId.of("UTC"));
+
+    ByteArrayOutputStream output = new ByteArrayOutputStream();
+    DataOutputStream dataOutputStream = new DataOutputStream(output);
+
+    // Text format
+    assertNull(
+        TimestampParser.convertToPG(
+            sessionState, dataOutputStream, resultSet, 0, DataFormat.POSTGRESQL_TEXT));
+    byte[] textBytes =
+        TimestampParser.convertToPG(resultSet, 0, DataFormat.POSTGRESQL_TEXT, ZoneId.of("UTC"));
+    ByteArrayOutputStream expectedText = new ByteArrayOutputStream();
+    DataOutputStream expectedTextStream = new DataOutputStream(expectedText);
+    expectedTextStream.writeInt(textBytes.length);
+    expectedTextStream.write(textBytes);
+    assertArrayEquals(expectedText.toByteArray(), output.toByteArray());
+    output.reset();
+
+    // Binary format
+    assertNull(
+        TimestampParser.convertToPG(
+            sessionState, dataOutputStream, resultSet, 0, DataFormat.POSTGRESQL_BINARY));
+    byte[] binaryBytes =
+        TimestampParser.convertToPG(resultSet, 0, DataFormat.POSTGRESQL_BINARY, ZoneId.of("UTC"));
+    ByteArrayOutputStream expectedBinary = new ByteArrayOutputStream();
+    DataOutputStream expectedBinaryStream = new DataOutputStream(expectedBinary);
+    expectedBinaryStream.writeInt(binaryBytes.length);
+    expectedBinaryStream.write(binaryBytes);
+    assertArrayEquals(expectedBinary.toByteArray(), output.toByteArray());
+    output.reset();
+
+    // Spanner format
+    assertNull(
+        TimestampParser.convertToPG(
+            sessionState, dataOutputStream, resultSet, 0, DataFormat.SPANNER));
+    byte[] spannerBytes =
+        TimestampParser.convertToPG(resultSet, 0, DataFormat.SPANNER, ZoneId.of("UTC"));
+    ByteArrayOutputStream expectedSpanner = new ByteArrayOutputStream();
+    DataOutputStream expectedSpannerStream = new DataOutputStream(expectedSpanner);
+    expectedSpannerStream.writeInt(spannerBytes.length);
+    expectedSpannerStream.write(spannerBytes);
+    assertArrayEquals(expectedSpanner.toByteArray(), output.toByteArray());
+    output.reset();
+  }
+
+  @Test
+  public void testConvertToPGPre2000EpochAndNonUtcTimezone() throws IOException {
+    Timestamp pre2000 = Timestamp.parseTimestamp("1970-01-01T00:00:00Z");
+    ResultSet resultSet = mock(ResultSet.class);
+    when(resultSet.getTimestamp(0)).thenReturn(pre2000);
+
+    SessionState sessionState = mock(SessionState.class);
+    ZoneId nyZone = ZoneId.of("America/New_York");
+    when(sessionState.getTimezone()).thenReturn(nyZone);
+
+    ByteArrayOutputStream output = new ByteArrayOutputStream();
+    DataOutputStream dataOutputStream = new DataOutputStream(output);
+
+    // Binary format (pre-2000 produces negative microsecond offset relative to PG epoch 2000-01-01)
+    assertNull(
+        TimestampParser.convertToPG(
+            sessionState, dataOutputStream, resultSet, 0, DataFormat.POSTGRESQL_BINARY));
+    byte[] binaryBytes =
+        TimestampParser.convertToPG(resultSet, 0, DataFormat.POSTGRESQL_BINARY, nyZone);
+    ByteArrayOutputStream expectedBinary = new ByteArrayOutputStream();
+    DataOutputStream expectedBinaryStream = new DataOutputStream(expectedBinary);
+    expectedBinaryStream.writeInt(8);
+    expectedBinaryStream.write(binaryBytes);
+    assertArrayEquals(expectedBinary.toByteArray(), output.toByteArray());
+    output.reset();
+
+    // Text format with non-UTC timezone
+    assertNull(
+        TimestampParser.convertToPG(
+            sessionState, dataOutputStream, resultSet, 0, DataFormat.POSTGRESQL_TEXT));
+    byte[] textBytes =
+        TimestampParser.convertToPG(resultSet, 0, DataFormat.POSTGRESQL_TEXT, nyZone);
+    ByteArrayOutputStream expectedText = new ByteArrayOutputStream();
+    DataOutputStream expectedTextStream = new DataOutputStream(expectedText);
+    expectedTextStream.writeInt(textBytes.length);
+    expectedTextStream.write(textBytes);
+    assertArrayEquals(expectedText.toByteArray(), output.toByteArray());
   }
 
   @Test

--- a/src/test/java/com/google/cloud/spanner/pgadapter/parsers/UuidParserTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/parsers/UuidParserTest.java
@@ -20,12 +20,19 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
+import com.google.cloud.spanner.ProtobufResultSet;
+import com.google.cloud.spanner.ResultSet;
+import com.google.cloud.spanner.pgadapter.ProxyServer.DataFormat;
 import com.google.cloud.spanner.pgadapter.error.PGException;
 import com.google.cloud.spanner.pgadapter.error.SQLState;
 import com.google.cloud.spanner.pgadapter.error.Severity;
 import com.google.cloud.spanner.pgadapter.parsers.Parser.FormatCode;
 import com.google.cloud.spanner.pgadapter.session.SessionState;
+import java.io.ByteArrayOutputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.UUID;
 import org.junit.Test;
@@ -145,5 +152,97 @@ public class UuidParserTest {
     assertEquals(SQLState.InternalError, exception.getSQLState());
     assertEquals(Severity.ERROR, exception.getSeverity());
     assertEquals("Unsupported format: TEXT", exception.getMessage());
+  }
+
+  @Test
+  public void testConvertToPG() throws IOException {
+    UUID uuid = UUID.fromString("c852ee2a-7521-4a70-a02f-2b9d0dd9c19a");
+    ResultSet resultSet = mock(ResultSet.class);
+    when(resultSet.getUuid(0)).thenReturn(uuid);
+
+    ByteArrayOutputStream output = new ByteArrayOutputStream();
+    DataOutputStream dataOutputStream = new DataOutputStream(output);
+    SessionState sessionState = mock(SessionState.class);
+
+    // Text format
+    assertNull(
+        UuidParser.convertToPG(
+            sessionState, dataOutputStream, resultSet, 0, DataFormat.POSTGRESQL_TEXT));
+    byte[] textBytes = uuid.toString().getBytes(StandardCharsets.UTF_8);
+    ByteArrayOutputStream expectedText = new ByteArrayOutputStream();
+    DataOutputStream expectedTextStream = new DataOutputStream(expectedText);
+    expectedTextStream.writeInt(textBytes.length);
+    expectedTextStream.write(textBytes);
+    assertArrayEquals(expectedText.toByteArray(), output.toByteArray());
+    output.reset();
+
+    // Binary format
+    assertNull(
+        UuidParser.convertToPG(
+            sessionState, dataOutputStream, resultSet, 0, DataFormat.POSTGRESQL_BINARY));
+    ByteArrayOutputStream expectedBinary = new ByteArrayOutputStream();
+    DataOutputStream expectedBinaryStream = new DataOutputStream(expectedBinary);
+    expectedBinaryStream.writeInt(16);
+    expectedBinaryStream.writeLong(uuid.getMostSignificantBits());
+    expectedBinaryStream.writeLong(uuid.getLeastSignificantBits());
+    assertArrayEquals(expectedBinary.toByteArray(), output.toByteArray());
+    output.reset();
+
+    // Spanner format
+    assertNull(
+        UuidParser.convertToPG(sessionState, dataOutputStream, resultSet, 0, DataFormat.SPANNER));
+    assertArrayEquals(expectedText.toByteArray(), output.toByteArray());
+    output.reset();
+
+    // Verify backward compatibility method
+    assertArrayEquals(textBytes, UuidParser.convertToPG(resultSet, 0, DataFormat.POSTGRESQL_TEXT));
+    byte[] binaryBytes = new byte[16];
+    ByteConverter.int8(binaryBytes, 0, uuid.getMostSignificantBits());
+    ByteConverter.int8(binaryBytes, 8, uuid.getLeastSignificantBits());
+    assertArrayEquals(
+        binaryBytes, UuidParser.convertToPG(resultSet, 0, DataFormat.POSTGRESQL_BINARY));
+    assertArrayEquals(textBytes, UuidParser.convertToPG(resultSet, 0, DataFormat.SPANNER));
+  }
+
+  @Test
+  public void testConvertToPGNilUuid() throws IOException {
+    UUID nilUuid = new UUID(0L, 0L);
+    ResultSet resultSet = mock(ResultSet.class);
+    when(resultSet.getUuid(0)).thenReturn(nilUuid);
+
+    ByteArrayOutputStream output = new ByteArrayOutputStream();
+    DataOutputStream dataOutputStream = new DataOutputStream(output);
+    SessionState sessionState = mock(SessionState.class);
+
+    assertNull(
+        UuidParser.convertToPG(
+            sessionState, dataOutputStream, resultSet, 0, DataFormat.POSTGRESQL_BINARY));
+    assertArrayEquals(
+        new byte[] {0, 0, 0, 16, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+        output.toByteArray());
+  }
+
+  @Test
+  public void testConvertToPGProtobufResultSet() throws IOException {
+    String uuidString = "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11";
+    ProtobufResultSet protobufResultSet = mock(ProtobufResultSet.class);
+    when(protobufResultSet.canGetProtobufValue(0)).thenReturn(true);
+    when(protobufResultSet.getProtobufValue(0))
+        .thenReturn(com.google.protobuf.Value.newBuilder().setStringValue(uuidString).build());
+
+    ByteArrayOutputStream output = new ByteArrayOutputStream();
+    DataOutputStream dataOutputStream = new DataOutputStream(output);
+    SessionState sessionState = mock(SessionState.class);
+
+    assertNull(
+        UuidParser.convertToPG(
+            sessionState, dataOutputStream, protobufResultSet, 0, DataFormat.POSTGRESQL_TEXT));
+    assertArrayEquals(
+        new byte[] {
+          0, 0, 0, 36, 'a', '0', 'e', 'e', 'b', 'c', '9', '9', '-', '9', 'c', '0', 'b', '-', '4',
+          'e', 'f', '8', '-', 'b', 'b', '6', 'd', '-', '6', 'b', 'b', '9', 'b', 'd', '3', '8', '0',
+          'a', '1', '1'
+        },
+        output.toByteArray());
   }
 }

--- a/src/test/java/com/google/cloud/spanner/pgadapter/utils/ConverterTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/utils/ConverterTest.java
@@ -1,0 +1,440 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.cloud.spanner.pgadapter.utils;
+
+import static com.google.cloud.spanner.pgadapter.statements.CopyToStatement.COPY_BINARY_HEADER;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.google.cloud.Date;
+import com.google.cloud.Timestamp;
+import com.google.cloud.spanner.Interval;
+import com.google.cloud.spanner.ResultSet;
+import com.google.cloud.spanner.Type;
+import com.google.cloud.spanner.Value;
+import com.google.cloud.spanner.pgadapter.ConnectionHandler;
+import com.google.cloud.spanner.pgadapter.ConnectionHandler.QueryMode;
+import com.google.cloud.spanner.pgadapter.ProxyServer.DataFormat;
+import com.google.cloud.spanner.pgadapter.metadata.OptionsMetadata;
+import com.google.cloud.spanner.pgadapter.metadata.OptionsMetadata.TextFormat;
+import com.google.cloud.spanner.pgadapter.session.SessionState;
+import com.google.cloud.spanner.pgadapter.statements.BackendConnection;
+import com.google.cloud.spanner.pgadapter.statements.ExtendedQueryProtocolHandler;
+import com.google.cloud.spanner.pgadapter.statements.IntermediateStatement;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
+import java.time.ZoneId;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.UUID;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class ConverterTest {
+
+  @Test
+  public void testConvertToPGScalarTypesStreamDirectly() throws IOException {
+    SessionState sessionState = mock(SessionState.class);
+    when(sessionState.getTimezone()).thenReturn(ZoneId.of("UTC"));
+
+    ByteArrayOutputStream output = new ByteArrayOutputStream();
+    DataOutputStream outputStream = new DataOutputStream(output);
+
+    // BOOL
+    ResultSet boolRs = mock(ResultSet.class);
+    when(boolRs.getColumnType(0)).thenReturn(Type.bool());
+    when(boolRs.getBoolean(0)).thenReturn(true);
+    assertNull(
+        Converter.convertToPG(outputStream, boolRs, 0, DataFormat.POSTGRESQL_TEXT, sessionState));
+    assertTrue(output.size() > 0);
+    output.reset();
+    assertNull(
+        Converter.convertToPG(outputStream, boolRs, 0, DataFormat.POSTGRESQL_BINARY, sessionState));
+    assertTrue(output.size() > 0);
+    output.reset();
+
+    // BYTES
+    ResultSet bytesRs = mock(ResultSet.class);
+    when(bytesRs.getColumnType(0)).thenReturn(Type.bytes());
+    Value bytesVal = mock(Value.class);
+    when(bytesVal.getAsString())
+        .thenReturn(Base64.getEncoder().encodeToString(new byte[] {1, 2, 3}));
+    when(bytesRs.getValue(0)).thenReturn(bytesVal);
+    assertNull(
+        Converter.convertToPG(outputStream, bytesRs, 0, DataFormat.POSTGRESQL_TEXT, sessionState));
+    assertTrue(output.size() > 0);
+    output.reset();
+    assertNull(
+        Converter.convertToPG(
+            outputStream, bytesRs, 0, DataFormat.POSTGRESQL_BINARY, sessionState));
+    assertTrue(output.size() > 0);
+    output.reset();
+
+    // DATE
+    ResultSet dateRs = mock(ResultSet.class);
+    when(dateRs.getColumnType(0)).thenReturn(Type.date());
+    when(dateRs.getDate(0)).thenReturn(Date.fromYearMonthDay(2024, 1, 1));
+    when(dateRs.getString(0)).thenReturn("2024-01-01");
+    assertNull(
+        Converter.convertToPG(outputStream, dateRs, 0, DataFormat.POSTGRESQL_TEXT, sessionState));
+    assertTrue(output.size() > 0);
+    output.reset();
+    assertNull(
+        Converter.convertToPG(outputStream, dateRs, 0, DataFormat.POSTGRESQL_BINARY, sessionState));
+    assertTrue(output.size() > 0);
+    output.reset();
+
+    // FLOAT32
+    ResultSet floatRs = mock(ResultSet.class);
+    when(floatRs.getColumnType(0)).thenReturn(Type.float32());
+    when(floatRs.getFloat(0)).thenReturn(3.14f);
+    assertNull(
+        Converter.convertToPG(outputStream, floatRs, 0, DataFormat.POSTGRESQL_TEXT, sessionState));
+    assertTrue(output.size() > 0);
+    output.reset();
+    assertNull(
+        Converter.convertToPG(
+            outputStream, floatRs, 0, DataFormat.POSTGRESQL_BINARY, sessionState));
+    assertTrue(output.size() > 0);
+    output.reset();
+
+    // FLOAT64
+    ResultSet doubleRs = mock(ResultSet.class);
+    when(doubleRs.getColumnType(0)).thenReturn(Type.float64());
+    when(doubleRs.getDouble(0)).thenReturn(3.14159);
+    assertNull(
+        Converter.convertToPG(outputStream, doubleRs, 0, DataFormat.POSTGRESQL_TEXT, sessionState));
+    assertTrue(output.size() > 0);
+    output.reset();
+    assertNull(
+        Converter.convertToPG(
+            outputStream, doubleRs, 0, DataFormat.POSTGRESQL_BINARY, sessionState));
+    assertTrue(output.size() > 0);
+    output.reset();
+
+    // INT64
+    ResultSet intRs = mock(ResultSet.class);
+    when(intRs.getColumnType(0)).thenReturn(Type.int64());
+    when(intRs.getLong(0)).thenReturn(123456L);
+    assertNull(
+        Converter.convertToPG(outputStream, intRs, 0, DataFormat.POSTGRESQL_TEXT, sessionState));
+    assertTrue(output.size() > 0);
+    output.reset();
+    assertNull(
+        Converter.convertToPG(outputStream, intRs, 0, DataFormat.POSTGRESQL_BINARY, sessionState));
+    assertTrue(output.size() > 0);
+    output.reset();
+
+    // PG_NUMERIC
+    ResultSet numericRs = mock(ResultSet.class);
+    when(numericRs.getColumnType(0)).thenReturn(Type.pgNumeric());
+    when(numericRs.getString(0)).thenReturn("123.456");
+    assertNull(
+        Converter.convertToPG(
+            outputStream, numericRs, 0, DataFormat.POSTGRESQL_TEXT, sessionState));
+    assertTrue(output.size() > 0);
+    output.reset();
+    assertNull(
+        Converter.convertToPG(
+            outputStream, numericRs, 0, DataFormat.POSTGRESQL_BINARY, sessionState));
+    assertTrue(output.size() > 0);
+    output.reset();
+
+    // STRING
+    ResultSet stringRs = mock(ResultSet.class);
+    when(stringRs.getColumnType(0)).thenReturn(Type.string());
+    when(stringRs.getString(0)).thenReturn("test string");
+    assertNull(
+        Converter.convertToPG(outputStream, stringRs, 0, DataFormat.POSTGRESQL_TEXT, sessionState));
+    assertTrue(output.size() > 0);
+    output.reset();
+
+    // UUID
+    ResultSet uuidRs = mock(ResultSet.class);
+    when(uuidRs.getColumnType(0)).thenReturn(Type.uuid());
+    when(uuidRs.getUuid(0)).thenReturn(UUID.randomUUID());
+    assertNull(
+        Converter.convertToPG(outputStream, uuidRs, 0, DataFormat.POSTGRESQL_TEXT, sessionState));
+    assertTrue(output.size() > 0);
+    output.reset();
+    assertNull(
+        Converter.convertToPG(outputStream, uuidRs, 0, DataFormat.POSTGRESQL_BINARY, sessionState));
+    assertTrue(output.size() > 0);
+    output.reset();
+
+    // TIMESTAMP
+    ResultSet tsRs = mock(ResultSet.class);
+    when(tsRs.getColumnType(0)).thenReturn(Type.timestamp());
+    when(tsRs.getTimestamp(0)).thenReturn(Timestamp.now());
+    assertNull(
+        Converter.convertToPG(outputStream, tsRs, 0, DataFormat.POSTGRESQL_TEXT, sessionState));
+    assertTrue(output.size() > 0);
+    output.reset();
+    assertNull(
+        Converter.convertToPG(outputStream, tsRs, 0, DataFormat.POSTGRESQL_BINARY, sessionState));
+    assertTrue(output.size() > 0);
+    output.reset();
+
+    // INTERVAL
+    ResultSet intervalRs = mock(ResultSet.class);
+    when(intervalRs.getColumnType(0)).thenReturn(Type.interval());
+    when(intervalRs.getInterval(0))
+        .thenReturn(Interval.fromMonthsDaysNanos(2, 5, BigInteger.valueOf(1000L)));
+    assertNull(
+        Converter.convertToPG(
+            outputStream, intervalRs, 0, DataFormat.POSTGRESQL_TEXT, sessionState));
+    assertTrue(output.size() > 0);
+    output.reset();
+    assertNull(
+        Converter.convertToPG(
+            outputStream, intervalRs, 0, DataFormat.POSTGRESQL_BINARY, sessionState));
+    assertTrue(output.size() > 0);
+    output.reset();
+
+    // PG_JSONB
+    ResultSet jsonbRs = mock(ResultSet.class);
+    when(jsonbRs.getColumnType(0)).thenReturn(Type.pgJsonb());
+    when(jsonbRs.getPgJsonb(0)).thenReturn("{\"key\": \"value\"}");
+    assertNull(
+        Converter.convertToPG(outputStream, jsonbRs, 0, DataFormat.POSTGRESQL_TEXT, sessionState));
+    assertTrue(output.size() > 0);
+    output.reset();
+    assertNull(
+        Converter.convertToPG(
+            outputStream, jsonbRs, 0, DataFormat.POSTGRESQL_BINARY, sessionState));
+    assertTrue(output.size() > 0);
+  }
+
+  @Test
+  public void testConvertToPGArrayReturnsByteArray() throws IOException {
+    SessionState sessionState = mock(SessionState.class);
+    ByteArrayOutputStream output = new ByteArrayOutputStream();
+    DataOutputStream outputStream = new DataOutputStream(output);
+
+    ResultSet arrayRs = mock(ResultSet.class);
+    when(arrayRs.getColumnType(0)).thenReturn(Type.array(Type.string()));
+    when(arrayRs.getValue(0)).thenReturn(Value.stringArray(Arrays.asList("foo", "bar")));
+
+    byte[] result =
+        Converter.convertToPG(outputStream, arrayRs, 0, DataFormat.POSTGRESQL_TEXT, sessionState);
+    assertNotNull(result);
+    assertTrue(result.length > 0);
+    assertEquals(0, output.size()); // Nothing written directly to stream for ARRAY yet
+  }
+
+  @Test
+  public void testConvertResultSetRowToDataRowResponse() throws Exception {
+    IntermediateStatement statement = mock(IntermediateStatement.class);
+    ConnectionHandler connectionHandler = mock(ConnectionHandler.class);
+    ExtendedQueryProtocolHandler extendedQueryProtocolHandler =
+        mock(ExtendedQueryProtocolHandler.class);
+    BackendConnection backendConnection = mock(BackendConnection.class);
+    SessionState sessionState = mock(SessionState.class);
+    when(sessionState.getTimezone()).thenReturn(ZoneId.of("UTC"));
+    when(statement.getConnectionHandler()).thenReturn(connectionHandler);
+    when(connectionHandler.getExtendedQueryProtocolHandler())
+        .thenReturn(extendedQueryProtocolHandler);
+    when(extendedQueryProtocolHandler.getBackendConnection()).thenReturn(backendConnection);
+    when(backendConnection.getSessionState()).thenReturn(sessionState);
+
+    OptionsMetadata options = mock(OptionsMetadata.class);
+    when(options.isBinaryFormat()).thenReturn(false);
+    when(options.getTextFormat()).thenReturn(TextFormat.POSTGRESQL);
+    when(statement.getResultFormatCode(anyInt())).thenReturn((short) 0);
+
+    ResultSet resultSet = mock(ResultSet.class);
+    when(resultSet.getColumnCount()).thenReturn(4);
+
+    // col 0: NULL string
+    when(resultSet.getColumnType(0)).thenReturn(Type.string());
+    when(resultSet.isNull(0)).thenReturn(true);
+
+    // col 1: INT64 in text mode (42)
+    when(resultSet.getColumnType(1)).thenReturn(Type.int64());
+    when(resultSet.isNull(1)).thenReturn(false);
+    when(resultSet.getLong(1)).thenReturn(42L);
+
+    // col 2: BOOL in text mode (true -> 't')
+    when(resultSet.getColumnType(2)).thenReturn(Type.bool());
+    when(resultSet.isNull(2)).thenReturn(false);
+    when(resultSet.getBoolean(2)).thenReturn(true);
+
+    // col 3: ARRAY in text mode ({"hello","world"})
+    when(resultSet.getColumnType(3)).thenReturn(Type.array(Type.string()));
+    when(resultSet.isNull(3)).thenReturn(false);
+    when(resultSet.getValue(3)).thenReturn(Value.stringArray(Arrays.asList("hello", "world")));
+
+    try (Converter converter =
+        new Converter(statement, QueryMode.EXTENDED, options, resultSet, false)) {
+      int size = converter.convertResultSetRowToDataRowResponse();
+      assertTrue(size > 0);
+
+      ByteArrayOutputStream out = new ByteArrayOutputStream();
+      DataOutputStream dataOut = new DataOutputStream(out);
+      converter.writeBuffer(dataOut);
+
+      DataInputStream in = new DataInputStream(new ByteArrayInputStream(out.toByteArray()));
+      // 4 columns
+      assertEquals(4, in.readShort());
+
+      // col 0: NULL column writes -1 length
+      assertEquals(-1, in.readInt());
+
+      // col 1: INT64 text "42"
+      int len1 = in.readInt();
+      byte[] val1 = new byte[len1];
+      in.readFully(val1);
+      assertEquals("42", new String(val1, StandardCharsets.UTF_8));
+
+      // col 2: BOOL text 't'
+      int len2 = in.readInt();
+      assertEquals(1, len2);
+      assertEquals('t', in.readByte());
+
+      // col 3: ARRAY text '{"hello","world"}'
+      int len3 = in.readInt();
+      byte[] val3 = new byte[len3];
+      in.readFully(val3);
+      assertEquals("{\"hello\",\"world\"}", new String(val3, StandardCharsets.UTF_8));
+      assertEquals(0, in.available());
+    }
+  }
+
+  @Test
+  public void testBinaryCopyHeaderInFirstRowOnly() throws Exception {
+    IntermediateStatement statement = mock(IntermediateStatement.class);
+    ConnectionHandler connectionHandler = mock(ConnectionHandler.class);
+    ExtendedQueryProtocolHandler extendedQueryProtocolHandler =
+        mock(ExtendedQueryProtocolHandler.class);
+    BackendConnection backendConnection = mock(BackendConnection.class);
+    SessionState sessionState = mock(SessionState.class);
+    when(statement.getConnectionHandler()).thenReturn(connectionHandler);
+    when(connectionHandler.getExtendedQueryProtocolHandler())
+        .thenReturn(extendedQueryProtocolHandler);
+    when(extendedQueryProtocolHandler.getBackendConnection()).thenReturn(backendConnection);
+    when(backendConnection.getSessionState()).thenReturn(sessionState);
+
+    OptionsMetadata options = mock(OptionsMetadata.class);
+    when(options.isBinaryFormat()).thenReturn(false);
+    when(options.getTextFormat()).thenReturn(TextFormat.POSTGRESQL);
+    when(statement.getResultFormatCode(anyInt())).thenReturn((short) 0);
+
+    ResultSet resultSet = mock(ResultSet.class);
+    when(resultSet.getColumnCount()).thenReturn(1);
+    when(resultSet.getColumnType(0)).thenReturn(Type.int64());
+    when(resultSet.isNull(0)).thenReturn(false);
+    when(resultSet.getLong(0)).thenReturn(100L);
+
+    try (Converter converter =
+        new Converter(statement, QueryMode.EXTENDED, options, resultSet, true)) {
+      assertTrue(converter.isIncludeBinaryCopyHeaderInFirstRow());
+
+      // Row 1 includes copy binary header
+      converter.convertResultSetRowToDataRowResponse();
+      ByteArrayOutputStream out1 = new ByteArrayOutputStream();
+      converter.writeBuffer(new DataOutputStream(out1));
+      byte[] bytes1 = out1.toByteArray();
+      assertTrue(bytes1.length >= COPY_BINARY_HEADER.length + 8);
+      byte[] header = new byte[COPY_BINARY_HEADER.length];
+      System.arraycopy(bytes1, 0, header, 0, header.length);
+      assertArrayEquals(COPY_BINARY_HEADER, header);
+
+      // Row 2 does NOT include copy binary header
+      converter.convertResultSetRowToDataRowResponse();
+      ByteArrayOutputStream out2 = new ByteArrayOutputStream();
+      converter.writeBuffer(new DataOutputStream(out2));
+      byte[] bytes2 = out2.toByteArray();
+      assertTrue(bytes2.length < bytes1.length);
+      DataInputStream in2 = new DataInputStream(new ByteArrayInputStream(bytes2));
+      assertEquals(1, in2.readShort()); // Starts immediately with column count
+    }
+  }
+
+  @Test
+  public void testConvertResultSetRowToDataRowResponseWithBinaryColumns() throws Exception {
+    IntermediateStatement statement = mock(IntermediateStatement.class);
+    ConnectionHandler connectionHandler = mock(ConnectionHandler.class);
+    ExtendedQueryProtocolHandler extendedQueryProtocolHandler =
+        mock(ExtendedQueryProtocolHandler.class);
+    BackendConnection backendConnection = mock(BackendConnection.class);
+    SessionState sessionState = mock(SessionState.class);
+    when(sessionState.getTimezone()).thenReturn(ZoneId.of("UTC"));
+    when(statement.getConnectionHandler()).thenReturn(connectionHandler);
+    when(connectionHandler.getExtendedQueryProtocolHandler())
+        .thenReturn(extendedQueryProtocolHandler);
+    when(extendedQueryProtocolHandler.getBackendConnection()).thenReturn(backendConnection);
+    when(backendConnection.getSessionState()).thenReturn(sessionState);
+
+    OptionsMetadata options = mock(OptionsMetadata.class);
+    when(options.isBinaryFormat()).thenReturn(false);
+    when(options.getTextFormat()).thenReturn(TextFormat.POSTGRESQL);
+    // Format code 1 = BINARY
+    when(statement.getResultFormatCode(anyInt())).thenReturn((short) 1);
+
+    ResultSet resultSet = mock(ResultSet.class);
+    when(resultSet.getColumnCount()).thenReturn(3);
+
+    // col 0: INT64 in binary mode
+    when(resultSet.getColumnType(0)).thenReturn(Type.int64());
+    when(resultSet.isNull(0)).thenReturn(false);
+    when(resultSet.getLong(0)).thenReturn(100L);
+
+    // col 1: BOOL in binary mode
+    when(resultSet.getColumnType(1)).thenReturn(Type.bool());
+    when(resultSet.isNull(1)).thenReturn(false);
+    when(resultSet.getBoolean(1)).thenReturn(true);
+
+    // col 2: NULL column
+    when(resultSet.getColumnType(2)).thenReturn(Type.float64());
+    when(resultSet.isNull(2)).thenReturn(true);
+
+    try (Converter converter =
+        new Converter(statement, QueryMode.EXTENDED, options, resultSet, false)) {
+      int size = converter.convertResultSetRowToDataRowResponse();
+      assertTrue(size > 0);
+
+      ByteArrayOutputStream out = new ByteArrayOutputStream();
+      converter.writeBuffer(new DataOutputStream(out));
+
+      DataInputStream in = new DataInputStream(new ByteArrayInputStream(out.toByteArray()));
+      assertEquals(3, in.readShort()); // 3 columns
+
+      // col 0: INT64 binary length 8, value 100L
+      assertEquals(8, in.readInt());
+      assertEquals(100L, in.readLong());
+
+      // col 1: BOOL binary length 1, value 1
+      assertEquals(1, in.readInt());
+      assertEquals(1, in.readByte());
+
+      // col 2: NULL column length -1
+      assertEquals(-1, in.readInt());
+      assertEquals(0, in.available());
+    }
+  }
+}


### PR DESCRIPTION
Write all remaining scalar data types (boolean, string/json, bytes, numeric, timestamp, interval, and uuid) directly to the underlying DataOutputStream instead of first allocating intermediate byte arrays.

This eliminates per-column byte array allocations for all scalar column values during query result serialization, reducing heap churn and garbage collection pressure for large result sets.