### PR TITLE
fix: RowDescription length was wrong for non-ASCII column names

### DIFF
--- a/src/main/java/com/google/cloud/spanner/pgadapter/wireoutput/RowDescriptionResponse.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/wireoutput/RowDescriptionResponse.java
@@ -16,6 +16,7 @@ package com.google.cloud.spanner.pgadapter.wireoutput;
 
 import com.google.api.core.InternalApi;
 import com.google.cloud.spanner.Type;
+import com.google.cloud.spanner.Type.StructField;
 import com.google.cloud.spanner.pgadapter.ConnectionHandler.QueryMode;
 import com.google.cloud.spanner.pgadapter.ProxyServer.DataFormat;
 import com.google.cloud.spanner.pgadapter.metadata.OptionsMetadata;
@@ -23,6 +24,7 @@ import com.google.cloud.spanner.pgadapter.parsers.Parser;
 import com.google.cloud.spanner.pgadapter.statements.IntermediateStatement;
 import java.io.DataOutputStream;
 import java.text.MessageFormat;
+import java.util.List;
 import org.postgresql.core.Oid;
 
 /** Sends back qualifier for a row. */
@@ -47,6 +49,12 @@ public class RowDescriptionResponse extends WireOutput {
   private final OptionsMetadata options;
   private final int columnCount;
 
+  /**
+   * The UTF-8 encoded column names. These are encoded once and used both to determine the length of
+   * the message and to write the payload, as the two must always agree.
+   */
+  private final byte[][] columnNames;
+
   public RowDescriptionResponse(
       DataOutputStream output,
       IntermediateStatement statement,
@@ -54,21 +62,42 @@ public class RowDescriptionResponse extends WireOutput {
       OptionsMetadata options,
       QueryMode mode)
       throws Exception {
-    super(output, calculateLength(columns));
+    this(output, statement, columns, options, mode, encodeColumnNames(columns));
+  }
+
+  private RowDescriptionResponse(
+      DataOutputStream output,
+      IntermediateStatement statement,
+      Type columns,
+      OptionsMetadata options,
+      QueryMode mode,
+      byte[][] columnNames)
+      throws Exception {
+    super(output, calculateLength(columnNames));
     this.statement = statement;
     this.columns = columns;
     this.options = options;
     this.mode = mode;
     this.columnCount = columns.getStructFields().size();
+    this.columnNames = columnNames;
   }
 
-  private static int calculateLength(Type columns) {
+  private static byte[][] encodeColumnNames(Type columns) {
+    List<StructField> fields = columns.getStructFields();
+    byte[][] columnNames = new byte[fields.size()][];
+    for (int columnIndex = 0; /* columns start at 0 */ columnIndex < fields.size(); columnIndex++) {
+      columnNames[columnIndex] = fields.get(columnIndex).getName().getBytes(UTF8);
+    }
+    return columnNames;
+  }
+
+  private static int calculateLength(byte[][] columnNames) {
     int length = HEADER_LENGTH + FIELD_NUMBER_LENGTH;
-    for (int column_index = 0; /* columns start at 0 */
-        column_index < columns.getStructFields().size();
-        column_index++) {
+    for (byte[] columnName : columnNames) {
+      // Note: This must be the number of bytes of the encoded name, and not the number of
+      // characters in the name, as these differ for non-ASCII column names.
       length +=
-          columns.getStructFields().get(column_index).getName().length()
+          columnName.length
               + NULL_TERMINATOR_LENGTH
               + TABLE_OID_LENGTH
               + COLUMN_INDEX_LENGTH
@@ -87,8 +116,7 @@ public class RowDescriptionResponse extends WireOutput {
     for (int columnIndex = 0; /* columns start at 0 */
         columnIndex < this.columnCount;
         columnIndex++) {
-      this.outputStream.write(
-          this.columns.getStructFields().get(columnIndex).getName().getBytes(UTF8));
+      this.outputStream.write(this.columnNames[columnIndex]);
       // If it can be identified as a column of a table, the object ID of the table.
       this.outputStream.writeByte(DEFAULT_FLAG);
       // If it can be identified as a column of a table, the attribute number of the column

--- a/src/test/java/com/google/cloud/spanner/pgadapter/ShutdownModeMockServerTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/ShutdownModeMockServerTest.java
@@ -41,6 +41,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameter;
 import org.junit.runners.Parameterized.Parameters;
+import org.postgresql.util.PSQLState;
 
 @RunWith(Parameterized.class)
 public class ShutdownModeMockServerTest extends AbstractMockServerTest {
@@ -117,11 +118,7 @@ public class ShutdownModeMockServerTest extends AbstractMockServerTest {
       // Verify that we cannot open a new connection.
       SQLException exception =
           assertThrows(SQLException.class, () -> DriverManager.getConnection(createUrl()));
-      assertEquals(
-          String.format(
-              "Connection to localhost:%d refused. Check that the hostname and port are correct and that the postmaster is accepting TCP/IP connections.",
-              proxyServer.getLocalPort()),
-          exception.getMessage());
+      assertConnectionRefused(exception);
       // Verify that the original connection is still valid.
       try (ResultSet resultSet = connection.createStatement().executeQuery(sql)) {
         assertTrue(resultSet.next());
@@ -174,11 +171,7 @@ public class ShutdownModeMockServerTest extends AbstractMockServerTest {
     // Verify that we cannot open a new connection.
     SQLException exception =
         assertThrows(SQLException.class, () -> DriverManager.getConnection(createUrl()));
-    assertEquals(
-        String.format(
-            "Connection to localhost:%d refused. Check that the hostname and port are correct and that the postmaster is accepting TCP/IP connections.",
-            proxyServer.getLocalPort()),
-        exception.getMessage());
+    assertConnectionRefused(exception);
 
     Stopwatch.createStarted();
     while (proxyServer.state() == State.STOPPING
@@ -234,11 +227,7 @@ public class ShutdownModeMockServerTest extends AbstractMockServerTest {
 
       // Verify that we cannot open a new connection.
       exception = assertThrows(SQLException.class, () -> DriverManager.getConnection(createUrl()));
-      assertEquals(
-          String.format(
-              "Connection to localhost:%d refused. Check that the hostname and port are correct and that the postmaster is accepting TCP/IP connections.",
-              proxyServer.getLocalPort()),
-          exception.getMessage());
+      assertConnectionRefused(exception);
     }
   }
 
@@ -280,11 +269,7 @@ public class ShutdownModeMockServerTest extends AbstractMockServerTest {
       // Verify that we cannot open a new connection.
       SQLException exception =
           assertThrows(SQLException.class, () -> DriverManager.getConnection(createUrl()));
-      assertEquals(
-          String.format(
-              "Connection to localhost:%d refused. Check that the hostname and port are correct and that the postmaster is accepting TCP/IP connections.",
-              proxyServer.getLocalPort()),
-          exception.getMessage());
+      assertConnectionRefused(exception);
       // Verify that the server is still stopping, but not yet terminated.
       assertEquals(State.STOPPING, proxyServer.state());
 
@@ -312,6 +297,19 @@ public class ShutdownModeMockServerTest extends AbstractMockServerTest {
           exception.getMessage().equals("An I/O error occurred while sending to the backend.")
               || exception.getMessage().equals("This connection has been closed."));
     }
+  }
+
+  /**
+   * Verifies that a connection attempt failed because the server is no longer accepting
+   * connections. PgJDBC uses "Connection to host:port refused..." if the operating system returns a
+   * ConnectException, and "The connection attempt failed." for any other I/O error. Both can happen
+   * when the server is shutting down, so the SQLState is the only stable part of the exception.
+   */
+  static void assertConnectionRefused(SQLException exception) {
+    assertEquals(
+        exception.getMessage(),
+        PSQLState.CONNECTION_UNABLE_TO_CONNECT.getState(),
+        exception.getSQLState());
   }
 
   ShutdownHandler createShutdownHandler() {

--- a/src/test/java/com/google/cloud/spanner/pgadapter/wireoutput/RowDescriptionTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/wireoutput/RowDescriptionTest.java
@@ -352,4 +352,79 @@ public final class RowDescriptionTest {
 
     assertEquals(Oid.UNSPECIFIED, response.getOidType(0));
   }
+
+  @Test
+  public void testMessageLengthWithAsciiColumnNames() throws Exception {
+    assertMessageLengthMatchesPayload(
+        Type.struct(StructField.of("id", Type.int64()), StructField.of("value", Type.string())));
+  }
+
+  /**
+   * The length that is included in a RowDescription message must be the number of bytes in the
+   * message, and not the number of characters. These differ as soon as a column name contains a
+   * non-ASCII character, as the names are encoded as UTF-8 on the wire.
+   */
+  @Test
+  public void testMessageLengthWithNonAsciiColumnNames() throws Exception {
+    assertMessageLengthMatchesPayload(
+        Type.struct(
+            // 'é' is two bytes in UTF-8, and the emoji is four.
+            StructField.of("café", Type.int64()),
+            StructField.of("naïve_column", Type.string()),
+            StructField.of("日本語", Type.string()),
+            StructField.of("emoji_🍺", Type.bool())));
+  }
+
+  /**
+   * Sends a RowDescription message for the given row type and verifies that the length that is
+   * included in the message header corresponds with the number of bytes that were actually written.
+   * A client uses this length to determine where the next message starts, so a mismatch means that
+   * the client loses track of the message boundaries in the stream.
+   */
+  private void assertMessageLengthMatchesPayload(Type rowType) throws Exception {
+    JSONParser parser = new JSONParser();
+    JSONObject commandMetadata = (JSONObject) parser.parse(EMPTY_COMMAND_JSON);
+    OptionsMetadata options =
+        new OptionsMetadata(
+            "jdbc:cloudspanner:/projects/test-project/instances/test-instance/databases/test-database",
+            8888,
+            TextFormat.POSTGRESQL,
+            false,
+            false,
+            false,
+            false,
+            commandMetadata);
+    RowDescriptionResponse response =
+        new RowDescriptionResponse(output, null, rowType, options, QueryMode.EXTENDED);
+
+    response.send();
+
+    byte[] message = buffer.toByteArray();
+    DataInputStream outputReader = new DataInputStream(new ByteArrayInputStream(message));
+    assertEquals('T', outputReader.readByte());
+    int lengthInMessage = outputReader.readInt();
+    // The length includes the four bytes of the length itself, but not the message identifier.
+    assertEquals(
+        "The length in the message header must match the number of bytes that were written",
+        message.length - 1,
+        lengthInMessage);
+
+    // Verify that reading exactly the number of bytes that the header promises consumes the
+    // complete message, which is what a client does to find the start of the next message.
+    assertEquals(rowType.getStructFields().size(), outputReader.readShort());
+    for (StructField field : rowType.getStructFields()) {
+      byte[] name = new byte[field.getName().getBytes(UTF8).length];
+      outputReader.readFully(name);
+      assertEquals(field.getName(), new String(name, UTF8));
+      assertEquals(DEFAULT_FLAG, outputReader.readByte());
+      // table oid, column index, type oid, type size, type modifier and format code
+      outputReader.readInt();
+      outputReader.readShort();
+      outputReader.readInt();
+      outputReader.readShort();
+      outputReader.readInt();
+      outputReader.readShort();
+    }
+    assertEquals("The message must be fully consumed", 0, outputReader.available());
+  }
 }


### PR DESCRIPTION
The length header counted UTF-16 chars from String.length(), while the payload writes UTF-8 bytes. Any column name outside ASCII made the declared length too small, so clients stopped reading mid-message and lost sync with the wire protocol.

Encode the column names once in the constructor and derive both the length and the payload from those bytes, so the two cannot drift apart.