### PR TITLE
perf: skip trace events when the span does not record them

### DIFF
--- a/src/main/java/com/google/cloud/spanner/pgadapter/statements/ExtendedQueryProtocolHandler.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/statements/ExtendedQueryProtocolHandler.java
@@ -138,7 +138,13 @@ public class ExtendedQueryProtocolHandler {
    * received.
    */
   public void buffer(AbstractQueryProtocolMessage message) {
-    addEvent(message.receivedEventDescription(), Attributes.of(DB_STATEMENT, message.getSql()));
+    // Only build the event if the span actually records it. A null check is not enough: the span is
+    // a no-op span if tracing is disabled, and building an event that is then dropped would
+    // allocate for every message that is received. The span is only null if the message was not
+    // created by the wire protocol.
+    if (isRecordingEvents()) {
+      addEvent(message.receivedEventDescription(), Attributes.of(DB_STATEMENT, message.getSql()));
+    }
     messages.add(message);
   }
 
@@ -229,6 +235,14 @@ public class ExtendedQueryProtocolHandler {
       logger.log(Level.FINER, Logging.format("Flushing messages", Action.Finished));
       endSpan();
     }
+  }
+
+  /**
+   * Returns true if the current span records the events that are added to it. Events that are added
+   * to a span that does not record them are dropped, so building them is a waste of time.
+   */
+  private boolean isRecordingEvents() {
+    return span != null && span.isRecording();
   }
 
   private void addEvent(String event) {

--- a/src/main/java/com/google/cloud/spanner/pgadapter/wireprotocol/AbstractQueryProtocolMessage.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/wireprotocol/AbstractQueryProtocolMessage.java
@@ -20,8 +20,6 @@ import com.google.cloud.spanner.pgadapter.ConnectionHandler.QueryMode;
 import com.google.cloud.spanner.pgadapter.statements.BackendConnection;
 import com.google.cloud.spanner.pgadapter.statements.ExtendedQueryProtocolHandler;
 import java.io.IOException;
-import java.util.HashMap;
-import java.util.Map;
 
 /**
  * Abstract base class for extended query protocol messages. These can be buffered in memory locally
@@ -70,15 +68,10 @@ public abstract class AbstractQueryProtocolMessage extends ControlMessage {
     this.returnedErrorResponse = true;
   }
 
-  private static final Map<Class<? extends AbstractQueryProtocolMessage>, String>
-      RECEIVED_EVENT_DESCRIPTIONS = new HashMap<>();
-
-  public String receivedEventDescription() {
-    String value = RECEIVED_EVENT_DESCRIPTIONS.get(getClass());
-    if (value == null) {
-      value = "Received message: '" + getIdentifier() + "'";
-      RECEIVED_EVENT_DESCRIPTIONS.put(getClass(), value);
-    }
-    return value;
-  }
+  /**
+   * Returns the description that is used for the trace event that is added when this message is
+   * received. This is requested for every message that is received, so implementations must return
+   * a constant instead of creating a new string for each message.
+   */
+  public abstract String receivedEventDescription();
 }

--- a/src/main/java/com/google/cloud/spanner/pgadapter/wireprotocol/BindMessage.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/wireprotocol/BindMessage.java
@@ -34,6 +34,7 @@ import java.util.Arrays;
 @InternalApi
 public class BindMessage extends AbstractQueryProtocolMessage {
   protected static final char IDENTIFIER = 'B';
+  private static final String RECEIVED_EVENT_DESCRIPTION = "Received message: '" + IDENTIFIER + "'";
 
   private final String portalName;
   private final String statementName;
@@ -139,6 +140,11 @@ public class BindMessage extends AbstractQueryProtocolMessage {
   @Override
   public String getIdentifier() {
     return String.valueOf(IDENTIFIER);
+  }
+
+  @Override
+  public String receivedEventDescription() {
+    return RECEIVED_EVENT_DESCRIPTION;
   }
 
   public String getPortalName() {

--- a/src/main/java/com/google/cloud/spanner/pgadapter/wireprotocol/DescribeMessage.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/wireprotocol/DescribeMessage.java
@@ -35,6 +35,7 @@ import java.util.concurrent.Future;
 public class DescribeMessage extends AbstractQueryProtocolMessage {
 
   protected static final char IDENTIFIER = 'D';
+  private static final String RECEIVED_EVENT_DESCRIPTION = "Received message: '" + IDENTIFIER + "'";
 
   private final PreparedType type;
   private final String name;
@@ -110,6 +111,11 @@ public class DescribeMessage extends AbstractQueryProtocolMessage {
   @Override
   public String getIdentifier() {
     return String.valueOf(IDENTIFIER);
+  }
+
+  @Override
+  public String receivedEventDescription() {
+    return RECEIVED_EVENT_DESCRIPTION;
   }
 
   public String getName() {

--- a/src/main/java/com/google/cloud/spanner/pgadapter/wireprotocol/ExecuteMessage.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/wireprotocol/ExecuteMessage.java
@@ -25,6 +25,7 @@ import java.text.MessageFormat;
 @InternalApi
 public class ExecuteMessage extends AbstractQueryProtocolMessage {
   protected static final char IDENTIFIER = 'E';
+  private static final String RECEIVED_EVENT_DESCRIPTION = "Received message: '" + IDENTIFIER + "'";
 
   private final String name;
   private final int maxRows;
@@ -85,6 +86,11 @@ public class ExecuteMessage extends AbstractQueryProtocolMessage {
   @Override
   public String getIdentifier() {
     return String.valueOf(IDENTIFIER);
+  }
+
+  @Override
+  public String receivedEventDescription() {
+    return RECEIVED_EVENT_DESCRIPTION;
   }
 
   public String getName() {

--- a/src/main/java/com/google/cloud/spanner/pgadapter/wireprotocol/ParseMessage.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/wireprotocol/ParseMessage.java
@@ -72,6 +72,7 @@ public class ParseMessage extends AbstractQueryProtocolMessage {
   private static final AbstractStatementParser PARSER =
       AbstractStatementParser.getInstance(Dialect.POSTGRESQL);
   protected static final char IDENTIFIER = 'P';
+  private static final String RECEIVED_EVENT_DESCRIPTION = "Received message: '" + IDENTIFIER + "'";
 
   private final String name;
   private final IntermediatePreparedStatement statement;
@@ -318,6 +319,11 @@ public class ParseMessage extends AbstractQueryProtocolMessage {
   @Override
   public String getIdentifier() {
     return String.valueOf(IDENTIFIER);
+  }
+
+  @Override
+  public String receivedEventDescription() {
+    return RECEIVED_EVENT_DESCRIPTION;
   }
 
   @Override

--- a/src/test/java/com/google/cloud/spanner/pgadapter/statements/ExtendedQueryProtocolHandlerTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/statements/ExtendedQueryProtocolHandlerTest.java
@@ -16,6 +16,8 @@ package com.google.cloud.spanner.pgadapter.statements;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -30,6 +32,10 @@ import com.google.cloud.spanner.pgadapter.wireprotocol.DescribeMessage;
 import com.google.cloud.spanner.pgadapter.wireprotocol.ExecuteMessage;
 import com.google.cloud.spanner.pgadapter.wireprotocol.ParseMessage;
 import com.google.common.collect.ImmutableList;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanBuilder;
+import io.opentelemetry.api.trace.Tracer;
 import java.io.DataOutputStream;
 import java.util.UUID;
 import org.junit.Before;
@@ -148,5 +154,53 @@ public class ExtendedQueryProtocolHandlerTest {
     PGException exception = assertThrows(PGException.class, () -> handler.sync(false));
     assertEquals("Query cancelled", exception.getMessage());
     assertEquals(SQLState.QueryCanceled, exception.getSQLState());
+  }
+
+  @Test
+  public void testBufferDoesNotCreateEventsForNonRecordingSpan() {
+    Span span = startSpan(/* isRecording= */ false);
+    ParseMessage parseMessage = mock(ParseMessage.class);
+
+    ExtendedQueryProtocolHandler handler =
+        new ExtendedQueryProtocolHandler(connectionHandler, backendConnection);
+    handler.maybeStartSpan(true);
+    handler.buffer(parseMessage);
+
+    verify(span, never()).addEvent(anyString(), any(Attributes.class));
+    // The attributes of the event contain the SQL statement. Getting the description and the SQL
+    // statement must be skipped as well, as the event is dropped by the span anyway.
+    verify(parseMessage, never()).receivedEventDescription();
+    verify(parseMessage, never()).getSql();
+  }
+
+  @Test
+  public void testBufferCreatesEventsForRecordingSpan() {
+    Span span = startSpan(/* isRecording= */ true);
+    ParseMessage parseMessage = mock(ParseMessage.class);
+    when(parseMessage.receivedEventDescription()).thenReturn("Received message: 'P'");
+    when(parseMessage.getSql()).thenReturn("select 1");
+
+    ExtendedQueryProtocolHandler handler =
+        new ExtendedQueryProtocolHandler(connectionHandler, backendConnection);
+    handler.maybeStartSpan(true);
+    handler.buffer(parseMessage);
+
+    verify(span)
+        .addEvent(
+            "Received message: 'P'", Attributes.of(BackendConnection.DB_STATEMENT, "select 1"));
+  }
+
+  /** Sets up the mocks that are needed for {@link ExtendedQueryProtocolHandler#maybeStartSpan}. */
+  private Span startSpan(boolean isRecording) {
+    Span span = mock(Span.class);
+    when(span.isRecording()).thenReturn(isRecording);
+    SpanBuilder spanBuilder = mock(SpanBuilder.class);
+    when(spanBuilder.setNoParent()).thenReturn(spanBuilder);
+    when(spanBuilder.setAttribute(anyString(), anyString())).thenReturn(spanBuilder);
+    when(spanBuilder.startSpan()).thenReturn(span);
+    Tracer tracer = mock(Tracer.class);
+    when(tracer.spanBuilder(anyString())).thenReturn(spanBuilder);
+    when(backendConnection.getTracer()).thenReturn(tracer);
+    return span;
   }
 }

--- a/src/test/java/com/google/cloud/spanner/pgadapter/wireprotocol/AbstractQueryProtocolMessageTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/wireprotocol/AbstractQueryProtocolMessageTest.java
@@ -1,0 +1,62 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.cloud.spanner.pgadapter.wireprotocol;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.mock;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class AbstractQueryProtocolMessageTest {
+
+  @Test
+  public void testReceivedEventDescription() {
+    assertEquals("Received message: 'P'", receivedEventDescription(ParseMessage.class));
+    assertEquals("Received message: 'B'", receivedEventDescription(BindMessage.class));
+    assertEquals("Received message: 'D'", receivedEventDescription(DescribeMessage.class));
+    assertEquals("Received message: 'E'", receivedEventDescription(ExecuteMessage.class));
+  }
+
+  @Test
+  public void testReceivedEventDescriptionIsSharedBetweenMessages() {
+    // The description is requested for every message that is received, so it must be a constant per
+    // message type instead of a string that is created for each message.
+    assertSame(
+        receivedEventDescription(ParseMessage.class), receivedEventDescription(ParseMessage.class));
+    assertSame(
+        receivedEventDescription(BindMessage.class), receivedEventDescription(BindMessage.class));
+    assertSame(
+        receivedEventDescription(DescribeMessage.class),
+        receivedEventDescription(DescribeMessage.class));
+    assertSame(
+        receivedEventDescription(ExecuteMessage.class),
+        receivedEventDescription(ExecuteMessage.class));
+  }
+
+  /**
+   * Returns the event description for the given message type. The description does not depend on
+   * any instance state, so the message is mocked to avoid having to set up a connection for each
+   * message type.
+   */
+  private static String receivedEventDescription(
+      Class<? extends AbstractQueryProtocolMessage> messageType) {
+    return mock(messageType, CALLS_REAL_METHODS).receivedEventDescription();
+  }
+}


### PR DESCRIPTION
The extended query protocol handler added an event to the current span for every Parse, Bind, Describe and Execute message. The span is never null, also when tracing is disabled, so the event name and the attributes with the SQL statement were built for every message and then dropped by the no-op span. The events are now only built if the span records them.

The event name was looked up in a static HashMap keyed by message class, and filled in on first use. The map was not synchronized, and it was only safe because there are four message types and the map therefore never resized. Each message type now declares its event name as a constant, and the method that returns it is abstract, so a new message type cannot fall back to building the name per message.