### PR TITLE
fix: wait for the emulator to start in the Go and Node.js samples

### DIFF
--- a/.github/workflows/samples.yaml
+++ b/.github/workflows/samples.yaml
@@ -37,6 +37,15 @@ jobs:
         with:
           go-version: '1.27.1'
       - run: go version
+      # The released wrapper only waits for PGAdapter to accept connections, and not for the
+      # emulator that runs in the same container. Use the wrapper in this repository until a
+      # version that also waits for the emulator has been released.
+      - name: Use the PGAdapter Go wrapper in this repository
+        run: |
+          for sample in pgx migrate; do
+            go -C "samples/golang/${sample}" mod edit -replace github.com/GoogleCloudPlatform/pgadapter/wrappers/golang=../../../wrappers/golang
+            go -C "samples/golang/${sample}" mod tidy
+          done
       # Temporarily skipped due to a bug in the Emulator
 #      - name: Run gorm Sample tests
 #        working-directory: ./samples/golang/gorm

--- a/samples/nodejs/drizzle/src/init.ts
+++ b/samples/nodejs/drizzle/src/init.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { GenericContainer, PullPolicy, StartedTestContainer, TestContainer } from "testcontainers";
+import { GenericContainer, PullPolicy, StartedTestContainer, TestContainer, Wait } from "testcontainers";
 
 export async function createDataModel(db: any) {
   console.log("Checking whether tables already exists...");
@@ -111,7 +111,12 @@ export async function startPGAdapter(): Promise<StartedTestContainer> {
   console.log("Pulling PGAdapter and Spanner emulator...");
   const container: TestContainer = new GenericContainer("gcr.io/cloud-spanner-pg-adapter/pgadapter-emulator")
       .withPullPolicy(PullPolicy.alwaysPull())
-      .withExposedPorts(5432);
+      .withExposedPorts(5432)
+      // PGAdapter starts accepting connections before the emulator is ready, so wait for the
+      // emulator as well.
+      .withWaitStrategy(Wait.forAll([
+        Wait.forListeningPorts(),
+        Wait.forLogMessage("Cloud Spanner emulator running.")]));
   console.log("Starting PGAdapter and Spanner emulator...");
   return await container.start();
 }

--- a/samples/nodejs/knex/src/init.ts
+++ b/samples/nodejs/knex/src/init.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {GenericContainer, PullPolicy, StartedTestContainer, TestContainer} from "testcontainers";
+import {GenericContainer, PullPolicy, StartedTestContainer, TestContainer, Wait} from "testcontainers";
 import {Knex} from "knex";
 
 /**
@@ -117,7 +117,12 @@ export async function startPGAdapter(): Promise<StartedTestContainer> {
   console.log("Pulling PGAdapter and Spanner emulator");
   const container: TestContainer = new GenericContainer("gcr.io/cloud-spanner-pg-adapter/pgadapter-emulator")
       .withPullPolicy(PullPolicy.alwaysPull())
-      .withExposedPorts(5432);
+      .withExposedPorts(5432)
+      // PGAdapter starts accepting connections before the emulator is ready, so wait for the
+      // emulator as well.
+      .withWaitStrategy(Wait.forAll([
+        Wait.forListeningPorts(),
+        Wait.forLogMessage("Cloud Spanner emulator running.")]));
   console.log("Starting PGAdapter and Spanner emulator");
   return await container.start();
 }

--- a/samples/nodejs/prisma-sample-app/src/index.ts
+++ b/samples/nodejs/prisma-sample-app/src/index.ts
@@ -19,7 +19,7 @@ import {
   deleteExistingData, deployMigrations, printAlbumsReleasedBefore1900,
   printSingersAndAlbums, staleRead, updateVenueDescription
 } from "./sample";
-import {GenericContainer, PullPolicy, StartedTestContainer, TestContainer} from "testcontainers";
+import {GenericContainer, PullPolicy, StartedTestContainer, TestContainer, Wait} from "testcontainers";
 import fs from "fs";
 import path from "path";
 
@@ -110,7 +110,12 @@ export async function startPGAdapter(): Promise<StartedTestContainer> {
   console.log("Pulling PGAdapter and Spanner emulator");
   const container: TestContainer = new GenericContainer("gcr.io/cloud-spanner-pg-adapter/pgadapter-emulator")
     .withPullPolicy(PullPolicy.alwaysPull())
-    .withExposedPorts(5432);
+    .withExposedPorts(5432)
+    // PGAdapter starts accepting connections before the emulator is ready, so wait for the
+    // emulator as well.
+    .withWaitStrategy(Wait.forAll([
+      Wait.forListeningPorts(),
+      Wait.forLogMessage("Cloud Spanner emulator running.")]));
   console.log("Starting PGAdapter and Spanner emulator");
   return await container.start();
 }

--- a/samples/nodejs/sequelize/src/init.ts
+++ b/samples/nodejs/sequelize/src/init.ts
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import {QueryTypes, Sequelize} from 'sequelize';
-import {GenericContainer, PullPolicy, StartedTestContainer, TestContainer} from "testcontainers";
+import {GenericContainer, PullPolicy, StartedTestContainer, TestContainer, Wait} from "testcontainers";
 
 /**
  * Creates the data model that is needed for this sample application.
@@ -111,7 +111,12 @@ export async function startPGAdapter(): Promise<StartedTestContainer> {
   console.log("Pulling PGAdapter and Spanner emulator");
   const container: TestContainer = new GenericContainer("gcr.io/cloud-spanner-pg-adapter/pgadapter-emulator")
       .withPullPolicy(PullPolicy.alwaysPull())
-      .withExposedPorts(5432);
+      .withExposedPorts(5432)
+      // PGAdapter starts accepting connections before the emulator is ready, so wait for the
+      // emulator as well.
+      .withWaitStrategy(Wait.forAll([
+        Wait.forListeningPorts(),
+        Wait.forLogMessage("Cloud Spanner emulator running.")]));
   console.log("Starting PGAdapter and Spanner emulator");
   return await container.start();
 }

--- a/wrappers/golang/pgadapter.go
+++ b/wrappers/golang/pgadapter.go
@@ -62,6 +62,10 @@ type ExecutionEnvironment interface {
 const dockerImage = "gcr.io/cloud-spanner-pg-adapter/pgadapter"
 const dockerImageWithEmulator = "gcr.io/cloud-spanner-pg-adapter/pgadapter-emulator"
 
+// emulatorReadyMessage is logged by the Spanner emulator in the pgadapter-emulator Docker image
+// once it accepts requests.
+const emulatorReadyMessage = "Cloud Spanner emulator running."
+
 // Docker contains the specific configuration for running PGAdapter in a test Docker container.
 // This Docker execution environment can be used for tests and development. You should however
 // not use this Docker execution environment in production, as it uses a test container.
@@ -646,11 +650,20 @@ func startDocker(ctx context.Context, config Config) (pgadapter *PGAdapter, err 
 	if config.Version != "" {
 		image += ":" + config.Version
 	}
+	// PGAdapter accepts connections before the emulator in the same container is ready, so wait
+	// for the emulator as well when the combined image is used.
+	var waitStrategy wait.Strategy = wait.ForListeningPort("5432/tcp")
+	if config.ConnectToEmulator {
+		waitStrategy = wait.ForAll(
+			wait.ForListeningPort("5432/tcp"),
+			wait.ForLog(emulatorReadyMessage),
+		)
+	}
 	req := testcontainers.ContainerRequest{
 		AlwaysPullImage: config.ExecutionEnvironment.(*Docker).AlwaysPullImage,
 		Image:           image,
 		ExposedPorts:    []string{"5432/tcp"},
-		WaitingFor:      wait.ForListeningPort("5432/tcp"),
+		WaitingFor:      waitStrategy,
 		HostConfigModifier: func(hostConfig *container.HostConfig) {
 			if !config.ExecutionEnvironment.(*Docker).KeepContainer {
 				hostConfig.AutoRemove = true


### PR DESCRIPTION
Waits for the Spanner emulator to log `Cloud Spanner emulator running.` before the Go and Node.js samples connect.

## Why

The `pgadapter-emulator` image starts PGAdapter without waiting for the emulator. Testcontainers considers the container ready as soon as port 5432 accepts connections, so a sample that connects immediately gets:

```
UNAVAILABLE: ... contains host 'localhost:9010', but no running emulator or other server could be found at that address.
```

This makes `go-samples` and `nodejs-samples` red on every pull request, including the dependabot ones.

#4873 fixes this in the image itself, but that only takes effect after `docker-build-and-push-emulator.yaml` has been dispatched to republish the image. This change makes the samples wait on the client side, which works with the image that is published today.

## What

- Node.js samples (knex, sequelize, drizzle, prisma): wait for the listening port **and** the emulator log message.
- Go wrapper: same, but only when the combined emulator image is used.
- `samples.yaml`: the Go samples use the wrapper from this repository, as the released wrapper does not have the wait strategy yet. **This step can be removed after the next release.**

The other sample jobs hit the same race but happen to be slow enough to start; they are left unchanged.