### PR TITLE
perf: stop allocating in the per-statement parsing hot path

### DIFF
--- a/src/main/java/com/google/cloud/spanner/pgadapter/statements/PgCatalog.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/statements/PgCatalog.java
@@ -154,7 +154,7 @@ public class PgCatalog {
               Pattern.compile("obj_description\\s*\\(\\s*.+\\s*,\\s*'pg_class'\\s*\\)"),
               "''::varchar AS obj_description"));
 
-  private final ImmutableSet<String> checkPrefixes;
+  private final ImmutableList<String> checkPrefixes;
 
   private final ImmutableMap<TableOrIndexName, TableOrIndexName> tableReplacements;
   private final ImmutableMap<TableOrIndexName, PgCatalogTable> pgCatalogTables;
@@ -181,7 +181,7 @@ public class PgCatalog {
 
   public PgCatalog(@Nonnull SessionState sessionState, @Nonnull WellKnownClient wellKnownClient) {
     this.sessionState = Preconditions.checkNotNull(sessionState);
-    this.checkPrefixes = wellKnownClient.getPgCatalogCheckPrefixes();
+    this.checkPrefixes = ImmutableList.copyOf(wellKnownClient.getPgCatalogCheckPrefixes());
     ImmutableMap.Builder<TableOrIndexName, TableOrIndexName> builder =
         ImmutableMap.<TableOrIndexName, TableOrIndexName>builder()
             .putAll(DEFAULT_TABLE_REPLACEMENTS);
@@ -229,7 +229,7 @@ public class PgCatalog {
   /** Replace supported pg_catalog tables with Common Table Expressions. */
   public Statement replacePgCatalogTables(Statement statement, String lowerCaseSql) {
     // Only replace tables if the statement contains at least one of the known prefixes.
-    if (checkPrefixes.stream().noneMatch(lowerCaseSql::contains)) {
+    if (!containsAnyCheckPrefix(lowerCaseSql)) {
       return statement;
     }
 
@@ -247,6 +247,19 @@ public class PgCatalog {
     }
 
     return addCommonTableExpressions(replacedTablesStatement.y(), cteBuilder.build());
+  }
+
+  /** Returns true if the given SQL string contains at least one of the check prefixes. */
+  private boolean containsAnyCheckPrefix(String lowerCaseSql) {
+    // This runs for every statement, so use an indexed loop. Both a stream and an iterator would
+    // allocate.
+    int size = checkPrefixes.size();
+    for (int index = 0; index < size; index++) {
+      if (lowerCaseSql.contains(checkPrefixes.get(index))) {
+        return true;
+      }
+    }
+    return false;
   }
 
   Tuple<String, ReplacementStatus> replaceKnownUnsupportedFunctions(Statement statement) {

--- a/src/main/java/com/google/cloud/spanner/pgadapter/statements/SimpleParser.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/statements/SimpleParser.java
@@ -574,8 +574,7 @@ public class SimpleParser {
       } else if (stopAtEndOfExpression && parens == 0 && stopAtComma && sql.charAt(pos) == ',') {
         break;
       }
-      if ((!sameParensLevelAsStart || parens == 0)
-          && keywords.stream().anyMatch(this::peekKeyword)) {
+      if ((!sameParensLevelAsStart || parens == 0) && peekAnyKeyword(keywords)) {
         break;
       }
       pos++;
@@ -584,6 +583,19 @@ public class SimpleParser {
       return null;
     }
     return sql.substring(start, pos).trim();
+  }
+
+  /** Returns true if any of the given keywords is found at the current position. */
+  private boolean peekAnyKeyword(ImmutableList<String> keywords) {
+    // This is called for every character of an expression, so use an indexed loop. Both a stream
+    // and an iterator would allocate.
+    int size = keywords.size();
+    for (int index = 0; index < size; index++) {
+      if (peekKeyword(keywords.get(index))) {
+        return true;
+      }
+    }
+    return false;
   }
 
   List<TableOrIndexName> readTableList() {
@@ -892,7 +904,7 @@ public class SimpleParser {
       }
       return false;
     }
-    if (sql.substring(pos, pos + keyword.length()).equalsIgnoreCase(keyword)
+    if (sql.regionMatches(true, pos, keyword, 0, keyword.length())
         && (!requireWhitespaceAfter || isValidEndOfKeyword(pos + keyword.length()))) {
       if (updatePos) {
         pos = pos + keyword.length();

--- a/src/test/java/com/google/cloud/spanner/pgadapter/statements/PgCatalogTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/statements/PgCatalogTest.java
@@ -16,6 +16,7 @@ package com.google.cloud.spanner.pgadapter.statements;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -34,6 +35,41 @@ import org.junit.runners.JUnit4;
 public class PgCatalogTest {
   @Test
   public void testReplaceCatalogTables() {}
+
+  @Test
+  public void testReplacePgCatalogTablesChecksAllCheckPrefixes() {
+    PgCatalog catalog = new PgCatalog(mock(SessionState.class), WellKnownClient.UNSPECIFIED);
+
+    // Statements that contain none of the check prefixes are returned unchanged.
+    Statement statement = Statement.of("select * from my_table");
+    assertSame(statement, catalog.replacePgCatalogTables(statement, statement.getSql()));
+
+    // 'pg_' is the first check prefix.
+    Statement pgClassStatement = Statement.of("select * from pg_class");
+    assertTrue(
+        catalog
+            .replacePgCatalogTables(pgClassStatement, pgClassStatement.getSql())
+            .getSql()
+            .startsWith("with pg_class as ("));
+
+    // 'information_schema.' is the second check prefix, so the first match may not end the search.
+    Statement sequencesStatement = Statement.of("select * from information_schema.sequences");
+    assertTrue(
+        catalog
+            .replacePgCatalogTables(sequencesStatement, sequencesStatement.getSql())
+            .getSql()
+            .startsWith("with pg_information_schema_sequences as ("));
+
+    // Clients can add prefixes of their own. Prisma adds '_prisma_migrations'.
+    PgCatalog prismaCatalog = new PgCatalog(mock(SessionState.class), WellKnownClient.PRISMA);
+    Statement prismaStatement = Statement.of("select * from _prisma_migrations");
+    assertEquals(
+        Statement.of("select * from prisma_migrations"),
+        prismaCatalog.replacePgCatalogTables(prismaStatement, prismaStatement.getSql()));
+    // Other clients do not have that prefix, so the statement is not touched.
+    assertSame(
+        prismaStatement, catalog.replacePgCatalogTables(prismaStatement, prismaStatement.getSql()));
+  }
 
   @Test
   public void testAddCommonTableExpressions() {

--- a/src/test/java/com/google/cloud/spanner/pgadapter/statements/SimpleParserTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/statements/SimpleParserTest.java
@@ -113,6 +113,41 @@ public class SimpleParserTest {
   }
 
   @Test
+  public void testEatKeywordIgnoresCase() {
+    assertTrue(new SimpleParser("INSERT INTO foo").eatKeyword("insert", "into"));
+    assertTrue(new SimpleParser("InSeRt InTo foo").eatKeyword("insert", "into"));
+    assertTrue(new SimpleParser("insert into foo").eatKeyword("INSERT", "INTO"));
+
+    assertFalse(new SimpleParser("INSET INTO foo").eatKeyword("insert"));
+    assertFalse(new SimpleParser("INSERTINTO foo").eatKeyword("insert", "into"));
+
+    // The keyword is compared with the same case folding as String.equalsIgnoreCase, which maps
+    // U+0130 (LATIN CAPITAL LETTER I WITH DOT ABOVE) to 'i'.
+    assertTrue(new SimpleParser("\u0130NSERT INTO foo").eatKeyword("insert", "into"));
+  }
+
+  @Test
+  public void testEatKeywordAtEndOfInput() {
+    assertTrue(new SimpleParser("insert").eatKeyword("insert"));
+    assertFalse(new SimpleParser("ins").eatKeyword("insert"));
+    assertFalse(new SimpleParser("").eatKeyword("insert"));
+    assertFalse(new SimpleParser("insert into").eatKeyword("insert", "into", "foo"));
+  }
+
+  @Test
+  public void testPeekKeywordKeepsPosition() {
+    SimpleParser parser = new SimpleParser("  insert into foo");
+    assertTrue(parser.peekKeyword("insert"));
+    assertEquals(0, parser.getPos());
+
+    assertFalse(parser.peekKeyword("update"));
+    assertEquals(0, parser.getPos());
+
+    assertTrue(parser.eatKeyword("insert"));
+    assertEquals(8, parser.getPos());
+  }
+
+  @Test
   public void testEatToken() {
     assertTrue(new SimpleParser("(foo").eatToken("("));
     assertTrue(new SimpleParser("(").eatToken("("));
@@ -368,6 +403,40 @@ public class SimpleParserTest {
         "insert into foo (\"\"\"\")",
         new SimpleParser("insert into foo (\"\"\"\") select * from bar")
             .parseExpressionUntilKeyword(ImmutableList.of("select")));
+  }
+
+  @Test
+  public void testParseExpressionUntilOneOfSeveralKeywords() {
+    // The expression stops at whichever keyword occurs first, regardless of its position in the
+    // list.
+    assertEquals(
+        "select * from foo where id=1",
+        new SimpleParser("select * from foo where id=1 order by name")
+            .parseExpressionUntilKeyword(ImmutableList.of("order", "limit", "offset")));
+    assertEquals(
+        "select * from foo where id=1",
+        new SimpleParser("select * from foo where id=1 order by name")
+            .parseExpressionUntilKeyword(ImmutableList.of("limit", "offset", "order")));
+    assertEquals(
+        "select * from foo where id=1 limit 10",
+        new SimpleParser("select * from foo where id=1 limit 10 offset 5")
+            .parseExpressionUntilKeyword(ImmutableList.of("offset", "for")));
+
+    // No keyword matches, so the whole expression is returned.
+    assertEquals(
+        "select * from foo where id=1",
+        new SimpleParser("select * from foo where id=1")
+            .parseExpressionUntilKeyword(ImmutableList.of("limit", "offset")));
+    assertEquals(
+        "select * from foo where id=1",
+        new SimpleParser("select * from foo where id=1")
+            .parseExpressionUntilKeyword(ImmutableList.of()));
+
+    // Keywords are only checked at the start parentheses level if that is requested.
+    assertEquals(
+        "foo(order by)",
+        new SimpleParser("foo(order by) order by x")
+            .parseExpressionUntilKeyword(ImmutableList.of("limit", "order"), true, true));
   }
 
   @Test


### PR DESCRIPTION
Three allocations happened on every statement that PGAdapter parses, none of them necessary.

SimpleParser probes keywords at every character position. internalEat copied the candidate region out of the statement with substring() before comparing it, and parseExpressionUntilKeyword built a Stream and a capturing lambda to test the keyword list against each position. internalEat now uses String.regionMatches; equalsIgnoreCase is defined in terms of regionMatches and the length is already checked before the comparison, so the case folding is unchanged. parseExpressionUntilKeyword now uses an indexed loop.

PgCatalog checked whether a statement mentions pg_catalog by streaming over the prefix set with a method reference that captures the SQL string. That ran for every statement, including SELECT 1. It now uses an indexed loop over a list built once in the constructor.

An iterator was not enough in either case, as ImmutableList.iterator() also allocates.

In micro-benchmarks: a 3 KB statement went from 255 to 67 microseconds and from 1.4 MB to zero allocations for the region comparison, a 1.8 KB expression from 71 to 21 microseconds and from 237 KB to zero for the keyword list, and the pg_catalog check on SELECT 1 from 29 to 5 nanoseconds and from 184 bytes to zero.