### PR TITLE
refactor: simplify the statement buffering hot path

### DIFF
--- a/src/main/java/com/google/cloud/spanner/pgadapter/statements/BackendConnection.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/statements/BackendConnection.java
@@ -24,7 +24,6 @@ import static com.google.cloud.spanner.pgadapter.wireprotocol.QueryMessage.SHOW;
 import com.google.api.core.InternalApi;
 import com.google.cloud.ByteArray;
 import com.google.cloud.Timestamp;
-import com.google.cloud.Tuple;
 import com.google.cloud.spanner.BatchClient;
 import com.google.cloud.spanner.BatchReadOnlyTransaction;
 import com.google.cloud.spanner.BatchTransactionId;
@@ -99,7 +98,6 @@ import java.util.AbstractMap.SimpleImmutableEntry;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Deque;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
@@ -204,21 +202,12 @@ public class BackendConnection {
     return false;
   }
 
-  boolean shouldReplaceStatement(Statement statement) {
-    if (!localStatements.get().isEmpty() && localStatements.get().containsKey(statement.getSql())) {
-      LocalStatement localStatement = localStatements.get().get(statement.getSql());
-      if (localStatement != null) {
-        return localStatement.hasReplacementStatement();
-      }
-    }
-    return false;
-  }
-
-  Tuple<Statement, ParsedStatement> replaceStatement(Statement statement) {
-    LocalStatement localStatement = localStatements.get().get(statement.getSql());
-    Statement replacement =
-        Objects.requireNonNull(localStatement).getReplacementStatement(statement);
-    return Tuple.of(replacement, Objects.requireNonNull(PARSER.parse(replacement)));
+  /**
+   * Returns the local statement for the given statement, or null if the statement is not a local
+   * statement.
+   */
+  LocalStatement getLocalStatement(Statement statement) {
+    return localStatements.get().get(statement.getSql());
   }
 
   /**
@@ -231,10 +220,10 @@ public class BackendConnection {
     final SettableFuture<T> result;
 
     BufferedStatement(ParsedStatement parsedStatement, Statement statement) {
-      if (shouldReplaceStatement(statement)) {
-        Tuple<Statement, ParsedStatement> replacement = replaceStatement(statement);
-        statement = replacement.x();
-        parsedStatement = replacement.y();
+      LocalStatement localStatement = getLocalStatement(statement);
+      if (localStatement != null && localStatement.hasReplacementStatement()) {
+        statement = localStatement.getReplacementStatement(statement);
+        parsedStatement = Objects.requireNonNull(PARSER.parse(statement));
       }
       this.parsedStatement = parsedStatement;
       this.statement = statement;
@@ -330,13 +319,8 @@ public class BackendConnection {
         //  block.
         SessionStatement sessionStatement =
             getSessionManagementStatement(updatedStatement, parsedStatement);
-        if (!localStatements.get().isEmpty()
-            && localStatements.get().containsKey(statement.getSql())
-            && localStatements.get().get(statement.getSql()) != null
-            && !Objects.requireNonNull(localStatements.get().get(statement.getSql()))
-                .hasReplacementStatement()) {
-          LocalStatement localStatement =
-              Objects.requireNonNull(localStatements.get().get(statement.getSql()));
+        LocalStatement localStatement = getLocalStatement(statement);
+        if (localStatement != null && !localStatement.hasReplacementStatement()) {
           result.set(localStatement.execute(BackendConnection.this, statement));
         } else if (sessionStatement != null) {
           result.set(sessionStatement.execute(sessionState, spannerConnection));
@@ -872,7 +856,7 @@ public class BackendConnection {
   private ConnectionState connectionState = ConnectionState.IDLE;
   private TransactionMode transactionMode = TransactionMode.IMPLICIT;
   private final String currentSchema = "public";
-  private final LinkedList<BufferedStatement<?>> bufferedStatements = new LinkedList<>();
+  private final List<BufferedStatement<?>> bufferedStatements = new ArrayList<>();
   private final Connection spannerConnection;
   private final DatabaseId databaseId;
   private final DdlExecutor ddlExecutor;

--- a/src/main/java/com/google/cloud/spanner/pgadapter/statements/ExtendedQueryProtocolHandler.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/statements/ExtendedQueryProtocolHandler.java
@@ -35,7 +35,6 @@ import io.opentelemetry.api.trace.StatusCode;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.context.Scope;
 import java.util.ArrayList;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -48,7 +47,7 @@ public class ExtendedQueryProtocolHandler {
   private static final Logger logger =
       Logger.getLogger(ExtendedQueryProtocolHandler.class.getName());
 
-  private final LinkedList<AbstractQueryProtocolMessage> messages = new LinkedList<>();
+  private final List<AbstractQueryProtocolMessage> messages = new ArrayList<>();
   private final ConnectionHandler connectionHandler;
   private final BackendConnection backendConnection;
 
@@ -92,6 +91,11 @@ public class ExtendedQueryProtocolHandler {
 
   public Tracer getTracer() {
     return backendConnection.getTracer();
+  }
+
+  /** Returns the connection id that is used as a trace attribute. */
+  public String getConnectionId() {
+    return connectionId;
   }
 
   @VisibleForTesting

--- a/src/main/java/com/google/cloud/spanner/pgadapter/statements/SimpleQueryStatement.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/statements/SimpleQueryStatement.java
@@ -135,12 +135,13 @@ public class SimpleQueryStatement {
   @VisibleForTesting
   static Statement translatePotentialMetadataCommand(
       Statement parsedStatement, ConnectionHandler connectionHandler) {
-    Tracer tracer = connectionHandler.getExtendedQueryProtocolHandler().getTracer();
+    ExtendedQueryProtocolHandler queryProtocolHandler =
+        connectionHandler.getExtendedQueryProtocolHandler();
+    Tracer tracer = queryProtocolHandler.getTracer();
     Span span =
         tracer
             .spanBuilder("translatePotentialMetadataCommand")
-            .setAttribute(
-                "pgadapter.connection_id", connectionHandler.getTraceConnectionId().toString())
+            .setAttribute("pgadapter.connection_id", queryProtocolHandler.getConnectionId())
             .setAttribute(DB_STATEMENT, parsedStatement.getSql())
             .startSpan();
     try (Scope ignore = span.makeCurrent()) {

--- a/src/main/java/com/google/cloud/spanner/pgadapter/wireprotocol/ControlMessage.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/wireprotocol/ControlMessage.java
@@ -36,6 +36,7 @@ import com.google.cloud.spanner.pgadapter.error.PGExceptionFactory;
 import com.google.cloud.spanner.pgadapter.metadata.SendResultSetState;
 import com.google.cloud.spanner.pgadapter.statements.BackendConnection.PartitionQueryResult;
 import com.google.cloud.spanner.pgadapter.statements.CopyToStatement;
+import com.google.cloud.spanner.pgadapter.statements.ExtendedQueryProtocolHandler;
 import com.google.cloud.spanner.pgadapter.statements.IntermediateStatement;
 import com.google.cloud.spanner.pgadapter.utils.Converter;
 import com.google.cloud.spanner.pgadapter.utils.Logging;
@@ -203,11 +204,13 @@ public abstract class ControlMessage extends WireMessage {
    */
   SendResultSetState sendResultSet(
       IntermediateStatement describedResult, QueryMode mode, long maxRows) throws Exception {
-    Tracer tracer = connection.getExtendedQueryProtocolHandler().getTracer();
+    ExtendedQueryProtocolHandler queryProtocolHandler =
+        connection.getExtendedQueryProtocolHandler();
+    Tracer tracer = queryProtocolHandler.getTracer();
     Span span =
         tracer
             .spanBuilder("send_result_set")
-            .setAttribute("pgadapter.connection_id", connection.getTraceConnectionId().toString())
+            .setAttribute("pgadapter.connection_id", queryProtocolHandler.getConnectionId())
             .setAttribute(DB_STATEMENT, describedResult.getSql())
             .startSpan();
     try (Scope ignore = span.makeCurrent()) {

--- a/src/test/java/com/google/cloud/spanner/pgadapter/statements/BackendConnectionTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/statements/BackendConnectionTest.java
@@ -458,6 +458,47 @@ public class BackendConnectionTest {
   }
 
   @Test
+  public void testLocalStatementWithReplacementIsReplaced()
+      throws ExecutionException, InterruptedException {
+    Connection connection = mock(Connection.class);
+    String sql = "start transaction isolation level repeatable read";
+    Statement replacement = Statement.of("select 1");
+    LocalStatement localStatement = mock(LocalStatement.class);
+    when(localStatement.getSql()).thenReturn(new String[] {sql});
+    when(localStatement.hasReplacementStatement()).thenReturn(true);
+    when(localStatement.getReplacementStatement(Statement.of(sql))).thenReturn(replacement);
+    ImmutableList<LocalStatement> localStatements = ImmutableList.of(localStatement);
+
+    StatementResult statementResult = mock(StatementResult.class);
+    when(statementResult.getResultType()).thenReturn(ResultType.RESULT_SET);
+    when(connection.execute(replacement)).thenReturn(statementResult);
+
+    BackendConnection backendConnection =
+        new BackendConnection(
+            NOOP_OTEL,
+            NOOP_OTEL_METER,
+            METRIC_ATTRIBUTES,
+            UUID.randomUUID().toString(),
+            DO_NOTHING,
+            DATABASE_ID,
+            connection,
+            () -> WellKnownClient.UNSPECIFIED,
+            mock(OptionsMetadata.class),
+            () -> localStatements);
+    Future<StatementResult> resultFuture =
+        backendConnection.execute(
+            "SELECT", mock(ParsedStatement.class), Statement.of(sql), Function.identity());
+    backendConnection.flush();
+
+    // The statement is replaced when it is buffered, so Spanner receives the replacement and the
+    // local statement itself is never executed.
+    verify(connection).execute(replacement);
+    verify(localStatement, never()).execute(any(BackendConnection.class), any(Statement.class));
+    assertTrue(resultFuture.isDone());
+    assertEquals(statementResult, resultFuture.get());
+  }
+
+  @Test
   public void testQueryResult() {
     ResultSet resultSet = mock(ResultSet.class);
     QueryResult queryResult = new QueryResult(resultSet);


### PR DESCRIPTION
Three small things in the path that every statement goes through.

The lookup of local statements was spread over five reads of the same map entry, guarded by a containsKey check and two Objects.requireNonNull calls that can never fire, because an ImmutableMap cannot hold a null value. It is now a single get() and a null check. shouldReplaceStatement and replaceStatement were only ever called as a pair, and each looked the same key up again, so they are merged into one method.

The buffers for protocol messages and for buffered statements were LinkedLists. Neither was used as a deque. Buffered statements are read by index throughout the batching logic, which is O(n) per read on a LinkedList, so flushing a batch was quadratic. Both are ArrayLists now.

The connection id was rendered from a UUID for every result set and for every simple query, while ExtendedQueryProtocolHandler already keeps that string in a field. Both call sites already had the handler at hand.

No behaviour changes.