### PR TITLE
perf: cache the two settings that are read for every statement

### DIFF
--- a/src/main/java/com/google/cloud/spanner/pgadapter/session/SessionState.java
+++ b/src/main/java/com/google/cloud/spanner/pgadapter/session/SessionState.java
@@ -74,6 +74,9 @@ public class SessionState {
           "transaction_isolation",
           "transaction_read_only");
 
+  /** Default for `spanner.log_slow_statement_threshold`, which is not part of pg_settings.txt. */
+  private static final Duration DEFAULT_LOG_SLOW_STATEMENT_THRESHOLD = Duration.ofSeconds(120L);
+
   static final Map<String, PGSetting> SERVER_SETTINGS = new HashMap<>();
 
   static {
@@ -128,6 +131,8 @@ public class SessionState {
   private final AtomicReference<Boolean> cachedReplaceForUpdateClause = new AtomicReference<>();
   private final AtomicReference<Boolean> cachedReplacePgCatalogTables = new AtomicReference<>();
   private final AtomicReference<Boolean> cachedEmulatePgClassTables = new AtomicReference<>();
+  private final AtomicReference<Boolean> cachedForceAutocommit = new AtomicReference<>();
+  private final AtomicReference<Duration> cachedLogSlowStatementThreshold = new AtomicReference<>();
   private final AtomicReference<Integer> cachedBinaryConversionBufferSize = new AtomicReference<>();
   private final AtomicReference<Integer> cachedStringConversionBufferSize = new AtomicReference<>();
 
@@ -138,6 +143,8 @@ public class SessionState {
     cachedReplaceForUpdateClause.set(null);
     cachedReplacePgCatalogTables.set(null);
     cachedEmulatePgClassTables.set(null);
+    cachedForceAutocommit.set(null);
+    cachedLogSlowStatementThreshold.set(null);
     cachedBinaryConversionBufferSize.set(null);
     cachedStringConversionBufferSize.set(null);
   }
@@ -456,7 +463,8 @@ public class SessionState {
    * in autocommit mode.
    */
   public boolean isForceAutocommit() {
-    return getBoolSetting("spanner", "force_autocommit", false);
+    return getCachedValue(
+        () -> getBoolSetting("spanner", "force_autocommit", false), cachedForceAutocommit);
   }
 
   /**
@@ -571,15 +579,19 @@ public class SessionState {
 
   /** Returns the threshold for when a query should be considered slow and should be logged. */
   public Duration getLogSlowStatementThreshold() {
-    PGSetting setting = internalGet(toKey("spanner", "log_slow_statement_threshold"), false);
-    if (setting == null) {
-      return Duration.ofSeconds(120L);
-    }
-    return tryGetFirstNonNull(
-        Duration.ofSeconds(120L),
-        () -> Duration.parse(setting.getSetting()),
-        () -> Duration.parse(setting.getResetVal()),
-        () -> Duration.parse(setting.getBootVal()));
+    return getCachedValue(
+        () -> {
+          PGSetting setting = internalGet(toKey("spanner", "log_slow_statement_threshold"), false);
+          if (setting == null) {
+            return DEFAULT_LOG_SLOW_STATEMENT_THRESHOLD;
+          }
+          return tryGetFirstNonNull(
+              DEFAULT_LOG_SLOW_STATEMENT_THRESHOLD,
+              () -> Duration.parse(setting.getSetting()),
+              () -> Duration.parse(setting.getResetVal()),
+              () -> Duration.parse(setting.getBootVal()));
+        },
+        cachedLogSlowStatementThreshold);
   }
 
   /**

--- a/src/test/java/com/google/cloud/spanner/pgadapter/session/SessionStateTest.java
+++ b/src/test/java/com/google/cloud/spanner/pgadapter/session/SessionStateTest.java
@@ -34,6 +34,7 @@ import com.google.cloud.spanner.pgadapter.metadata.OptionsMetadata.DdlTransactio
 import com.google.cloud.spanner.pgadapter.statements.PgCatalog;
 import com.google.cloud.spanner.pgadapter.utils.ClientAutoDetector.WellKnownClient;
 import com.google.common.collect.ImmutableMap;
+import java.time.Duration;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -48,6 +49,53 @@ public class SessionStateTest {
   public void testShowInitialSetting() {
     SessionState state = new SessionState(mock(OptionsMetadata.class));
     assertEquals("UTF8", state.get(null, "client_encoding").getSetting());
+  }
+
+  @Test
+  public void testForceAutocommit() {
+    SessionState state = new SessionState(mock(OptionsMetadata.class));
+    assertFalse(state.isForceAutocommit());
+
+    state.set("spanner", "force_autocommit", "on");
+    assertTrue(state.isForceAutocommit());
+
+    state.set("spanner", "force_autocommit", "off");
+    assertFalse(state.isForceAutocommit());
+
+    state.setLocal("spanner", "force_autocommit", "on");
+    assertTrue(state.isForceAutocommit());
+  }
+
+  @Test
+  public void testLogSlowStatementThreshold() {
+    SessionState state = new SessionState(mock(OptionsMetadata.class));
+    // The setting is not part of pg_settings.txt, so the hard-coded default is used.
+    assertEquals(Duration.ofSeconds(120L), state.getLogSlowStatementThreshold());
+
+    state.set("spanner", "log_slow_statement_threshold", "PT1S");
+    assertEquals(Duration.ofSeconds(1L), state.getLogSlowStatementThreshold());
+
+    state.set("spanner", "log_slow_statement_threshold", "PT30S");
+    assertEquals(Duration.ofSeconds(30L), state.getLogSlowStatementThreshold());
+
+    state.setLocal("spanner", "log_slow_statement_threshold", "PT2S");
+    assertEquals(Duration.ofSeconds(2L), state.getLogSlowStatementThreshold());
+  }
+
+  @Test
+  public void testHotSettingsAreCached() {
+    SessionState state = new SessionState(mock(OptionsMetadata.class));
+
+    // Duration.ofSeconds allocates a new instance every time, so the same instance can only be
+    // returned twice if the value is cached.
+    Duration threshold = state.getLogSlowStatementThreshold();
+    assertSame(threshold, state.getLogSlowStatementThreshold());
+
+    // Changing any setting invalidates the cache.
+    state.set("spanner", "log_slow_statement_threshold", "PT1S");
+    Duration updatedThreshold = state.getLogSlowStatementThreshold();
+    assertEquals(Duration.ofSeconds(1L), updatedThreshold);
+    assertSame(updatedThreshold, state.getLogSlowStatementThreshold());
   }
 
   @Test


### PR DESCRIPTION
BackendConnection reads spanner.log_slow_statement_threshold once and spanner.force_autocommit twice for every statement. Neither went through the session settings cache. log_slow_statement_threshold is not part of pg_settings.txt, so every read also allocated a new Duration for the default.

Both now use getCachedValue, and the default threshold is a constant instead of two identical literals. In a micro-benchmark the three reads went from 222 nanoseconds and 544 bytes per statement to 7 nanoseconds and 48 bytes.