### PR TITLE
fix: deduplicate integration test failure issues

### DIFF
--- a/.github/integration-test-failed-template.md
+++ b/.github/integration-test-failed-template.md
@@ -1,5 +1,5 @@
 ---
-title: PGAdapter integration tests failed
+title: PGAdapter integration tests failed for {{ env.ENDPOINT }}
 assignees: olavloite, rayudu3745
 labels: integration-test-failure
 ---

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -159,3 +159,6 @@ jobs:
         with:
           filename: .github/integration-test-failed-template.md
           assignees: olavloite, rayudu3745
+          update_existing: true
+          search_existing: open
+


### PR DESCRIPTION
Prevents the daily scheduled integration workflow from opening duplicate GitHub issues when tests fail across consecutive days, and makes failure issues distinct per Spanner endpoint.

Fixes #4821
Fixes #4820

## Why

The scheduled integration test workflow runs twice daily against `staging-wrenchworks.sandbox.googleapis.com` and `preprod-spanner.sandbox.googleapis.com`.

When a failure occurs over consecutive runs (such as the recent `CopyInMockServerTest` failure resolved in #4822), `JasonEtco/create-an-issue` creates a brand new issue on every single failure run because:
1. The issue title in `.github/integration-test-failed-template.md` is generic (`PGAdapter integration tests failed`) and does not identify the endpoint.
2. `integration.yaml` does not enable `update_existing` or `search_existing`, resulting in duplicate issues being filed daily for the same ongoing failure (e.g. #4821, #4820, #4813, #4812).

## What

- **`.github/integration-test-failed-template.md`**: Updated the issue title template to `PGAdapter integration tests failed for {{ env.ENDPOINT }}` so each target endpoint has a distinct, searchable issue title.
- **`.github/workflows/integration.yaml`**: Configured `update_existing: true` and `search_existing: open` in the `create-issue-on-failure` step so that subsequent run failures update the existing open issue instead of filing duplicates.